### PR TITLE
Add permissions field to module.json

### DIFF
--- a/apps/finance/module.json
+++ b/apps/finance/module.json
@@ -7,5 +7,12 @@
         { "name": "Execute payments", "id": "EXECUTE_PAYMENTS_ROLE" },
         { "name": "Disable payments", "id": "DISABLE_PAYMENTS_ROLE" }
     ],
+    "permissions": [
+        {
+            "appName": "vault.aragonpm.test",
+            "role": "TRANSFER_ROLE",
+            "entity": { "type": "INIT_VALUE", "value": "_vault" }
+        }
+    ],
     "path": "contracts/Finance.sol"
 }

--- a/apps/fundraising/module.json
+++ b/apps/fundraising/module.json
@@ -5,5 +5,12 @@
         { "name": "Create fundraising", "id": "CREATOR_ROLE" },
         { "name": "Close fundraising", "id": "CLOSER_ROLE" }
     ],
+    "permissions": [
+        {
+            "appName": "token-manager.aragonpm.test",
+            "role": "MINT_ROLE",
+            "entity": { "type": "INIT_VALUE", "value": "_tokenManager" }
+        }
+    ],
     "path": "contracts/FundraisingApp.sol"
 }


### PR DESCRIPTION
Added a new permissions field to the metadata of apps, so when creating an instance of an app that needs permissions over another app, it can be displayed to the user in the client.

We should probably extend this and document all other initialization values so the client can show options to initialize apps.