### PR TITLE
Multiple voting app small changes

### DIFF
--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -50,9 +50,9 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     /**
     * @notice Initializes Voting app (some parameters won't be modifiable after being set)
     * @param _token MiniMeToken address that will be used as governance token
-    * @param _supportRequiredPct Percentage of voters that must support a voting for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
-    * @param _minAcceptQuorumPct Percetage of total voting power that must support a voting  for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
-    * @param _voteTime Seconds that a voting will be open for token holders to vote (unless it is impossible for the fate of the vote to change)
+    * @param _supportRequiredPct Percentage of voters that must support a vote for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
+    * @param _minAcceptQuorumPct Percetage of total voting power that must support a vote for it to succeed (expressed as a 10^18 percetage, (eg 10^16 = 1%, 10^18 = 100%)
+    * @param _voteTime Seconds that a vote will be open for token holders to vote (unless it is impossible for the fate of the vote to change)
     */
     function initialize(
         MiniMeToken _token,
@@ -98,7 +98,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     /**
     * @notice Vote `_supports` in vote with id `_voteId`
     * @param _voteId Id for vote
-    * @param _supports Whether voter supports the voting
+    * @param _supports Whether voter supports the vote
     */
     function vote(uint256 _voteId, bool _supports) external {
         require(canVote(_voteId, msg.sender));

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -99,10 +99,11 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     * @notice Vote `_supports` in vote with id `_voteId`
     * @param _voteId Id for vote
     * @param _supports Whether voter supports the vote
+    * @param _executesIfDecided Whether it should execute the vote if it becomes decided
     */
-    function vote(uint256 _voteId, bool _supports) external {
+    function vote(uint256 _voteId, bool _supports, bool _executesIfDecided) external {
         require(canVote(_voteId, msg.sender));
-        _vote(_voteId, _supports, msg.sender);
+        _vote(_voteId, _supports, msg.sender, _executesIfDecided);
     }
 
     /**
@@ -191,10 +192,10 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
         StartVote(voteId);
 
         if (canVote(voteId, msg.sender))
-            _vote(voteId, true, msg.sender);
+            _vote(voteId, true, msg.sender, true);
     }
 
-    function _vote(uint256 _voteId, bool _supports, address _voter) internal {
+    function _vote(uint256 _voteId, bool _supports, address _voter, bool _executesIfDecided) internal {
         Vote storage vote = votes[_voteId];
 
         // this could re-enter, though we can asume the governance token is not maliciuous
@@ -216,7 +217,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
 
         CastVote(_voteId, _voter, _supports, voterStake);
 
-        if (canExecute(_voteId))
+        if (_executesIfDecided && canExecute(_voteId))
             _executeVote(_voteId);
     }
 

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -43,7 +43,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
     Vote[] votes;
 
     event StartVote(uint256 indexed voteId);
-    event CastVote(uint256 indexed voteId, address indexed voter, bool supports);
+    event CastVote(uint256 indexed voteId, address indexed voter, bool supports, uint256 stake);
     event ExecuteVote(uint256 indexed voteId);
     event ChangeMinQuorum(uint256 minAcceptQuorumPct);
 
@@ -214,7 +214,7 @@ contract Voting is App, Initializable, EVMCallScriptRunner, EVMCallScriptDecoder
 
         vote.voters[_voter] = _supports ? VoterState.Yea : VoterState.Nay;
 
-        CastVote(_voteId, _voter, _supports);
+        CastVote(_voteId, _voter, _supports, voterStake);
 
         if (canExecute(_voteId))
             _executeVote(_voteId);

--- a/apps/voting/test/voting.js
+++ b/apps/voting/test/voting.js
@@ -128,7 +128,7 @@ contract('Voting App', accounts => {
                 // with new quorum at 50% it shouldn't have, but since min quorum is snapshotted
                 // it will succeed
 
-                await app.vote(voteId, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
                 await timeTravel(votingTime + 1)
 
                 const state = await app.getVote(voteId)
@@ -137,16 +137,16 @@ contract('Voting App', accounts => {
             })
 
             it('holder can vote', async () => {
-                await app.vote(voteId, false, { from: holder31 })
+                await app.vote(voteId, false, true, { from: holder31 })
                 const state = await app.getVote(voteId)
 
                 assert.equal(state[7], 31, 'nay vote should have been counted')
             })
 
             it('holder can modify vote', async () => {
-                await app.vote(voteId, true, { from: holder31 })
-                await app.vote(voteId, false, { from: holder31 })
-                await app.vote(voteId, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
+                await app.vote(voteId, false, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
                 const state = await app.getVote(voteId)
 
                 assert.equal(state[6], 31, 'yea vote should have been counted')
@@ -156,7 +156,7 @@ contract('Voting App', accounts => {
             it('token transfers dont affect voting', async () => {
                 await token.transfer(nonHolder, 31, { from: holder31 })
 
-                await app.vote(voteId, true, { from: holder31 })
+                await app.vote(voteId, true, true, { from: holder31 })
                 const state = await app.getVote(voteId)
 
                 assert.equal(state[6], 31, 'yea vote should have been counted')
@@ -165,49 +165,55 @@ contract('Voting App', accounts => {
 
             it('throws when non-holder votes', async () => {
                 return assertInvalidOpcode(async () => {
-                    await app.vote(voteId, true, { from: nonHolder })
+                    await app.vote(voteId, true, true, { from: nonHolder })
                 })
             })
 
             it('throws when voting after voting closes', async () => {
                 await timeTravel(votingTime + 1)
                 return assertInvalidOpcode(async () => {
-                    await app.vote(voteId, true, { from: holder31 })
+                    await app.vote(voteId, true, true, { from: holder31 })
                 })
             })
 
             it('can execute if vote is approved with support and quorum', async () => {
-                await app.vote(voteId, true, { from: holder31 })
-                await app.vote(voteId, false, { from: holder19 })
+                await app.vote(voteId, true, true, { from: holder31 })
+                await app.vote(voteId, false, true, { from: holder19 })
                 await timeTravel(votingTime + 1)
                 await app.executeVote(voteId)
                 assert.equal(await executionTarget.counter(), 2, 'should have executed result')
             })
 
             it('cannot execute vote if not enough quorum met', async () => {
-                await app.vote(voteId, true, { from: holder19 })
+                await app.vote(voteId, true, true, { from: holder19 })
                 await timeTravel(votingTime + 1)
                 return assertInvalidOpcode(async () => {
                     await app.executeVote(voteId)
                 })
             })
 
-            it('vote is executed automatically if decided', async () => {
-                await app.vote(voteId, true, { from: holder50 }) // causes execution
+            it('vote can be executed automatically if decided', async () => {
+                await app.vote(voteId, true, true, { from: holder50 }) // causes execution
+                assert.equal(await executionTarget.counter(), 2, 'should have executed result')
+            })
+
+            it('vote can be not executed automatically if decided', async () => {
+                await app.vote(voteId, true, false, { from: holder50 }) // doesnt cause execution
+                await app.executeVote(voteId)
                 assert.equal(await executionTarget.counter(), 2, 'should have executed result')
             })
 
             it('cannot re-execute vote', async () => {
-                await app.vote(voteId, true, { from: holder50 }) // causes execution
+                await app.vote(voteId, true, true, { from: holder50 }) // causes execution
                 return assertInvalidOpcode(async () => {
                     await app.executeVote(voteId)
                 })
             })
 
             it('cannot vote on executed vote', async () => {
-                await app.vote(voteId, true, { from: holder50 }) // causes execution
+                await app.vote(voteId, true, true, { from: holder50 }) // causes execution
                 return assertInvalidOpcode(async () => {
-                    await app.vote(voteId, true, { from: holder19 })
+                    await app.vote(voteId, true, true, { from: holder19 })
                 })
             })
         })
@@ -234,7 +240,7 @@ contract('Voting App', accounts => {
 
             assert.isFalse(await app.canExecute(voteId), 'vote cannot be executed')
 
-            await app.vote(voteId, true, { from: holder })
+            await app.vote(voteId, true, true, { from: holder })
 
             const [isOpen, isExecuted] = await app.getVote(voteId)
 
@@ -275,8 +281,8 @@ contract('Voting App', accounts => {
 
             assert.isFalse(await app.canExecute(voteId), 'vote cannot be executed')
 
-            await app.vote(voteId, true, { from: holder1 })
-            await app.vote(voteId, true, { from: holder2 })
+            await app.vote(voteId, true, true, { from: holder1 })
+            await app.vote(voteId, true, true, { from: holder2 })
 
             const [isOpen, isExecuted] = await app.getVote(voteId)
 


### PR DESCRIPTION
- Change all instances where 'voting' was being used instead of 'vote'. Closes https://github.com/aragon/aragon/issues/53 after wiki documentation update.
- Logs voter stake in cast vote event. Closes #18 
- Add boolean parameter when casting a vote on whether it should be automatically executed . Closes #19