### PR TITLE
finance: Add function to send tokens to Vault

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -272,6 +272,30 @@ contract Finance is App, Initializable, ERC677Receiver {
     }
 
     /**
+     * @dev Allows make a simple payment from this contract to Vault,
+            to avoid locked tokens in contract forever.
+            This contract should never receive tokens with a simple transfer call,
+            but in case it happens, this function allows to recover them.
+     * @notice Send tokens to Vault
+     * @param _token Token whose balance is going to be transferred.
+     * @return success boolean indicating whether transaction suceeded
+     */
+    function depositToVault(address _token) public returns (bool success) {
+        ERC20 token = ERC20(_token);
+        uint256 value = token.balanceOf(this);
+        require(value >= 0);
+
+        _recordIncomingTransaction(
+            token,
+            this,
+            value,
+            "Transfer from Finance"
+        );
+        require(token.transfer(address(vault), value));
+        return true;
+    }
+
+    /**
     * @dev Transitions accounting periods if needed. For preventing OOG attacks,
            a TTL param is provided. If more that TTL periods need to be transitioned,
            it will return false.

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -278,21 +278,19 @@ contract Finance is App, Initializable, ERC677Receiver {
             but in case it happens, this function allows to recover them.
      * @notice Send tokens to Vault
      * @param _token Token whose balance is going to be transferred.
-     * @return success boolean indicating whether transaction suceeded
      */
-    function depositToVault(address _token) public returns (bool success) {
+    function depositToVault(address _token) public {
         ERC20 token = ERC20(_token);
         uint256 value = token.balanceOf(this);
-        require(value >= 0);
+        require(value > 0);
 
         _recordIncomingTransaction(
             token,
             this,
             value,
-            "Transfer from Finance"
+            "Deposit to Vault"
         );
         require(token.transfer(address(vault), value));
-        return true;
     }
 
     /**

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -106,6 +106,28 @@ contract('Finance App', accounts => {
         assert.equal(ref, 'reference', 'ref should be correct')
     })
 
+    it('sends locked tokens to Vault', async () => {
+        let initialBalance = await token1.balanceOf(vault.address)
+        // 'lock' tokens
+        await token1.transfer(app.address, 5)
+
+        await app.depositToVault(token1.address)
+
+        const [periodId, amount, paymentId, token, entity, incoming, date, ref] = await app.getTransaction(1)
+
+        let finalBalance = await token1.balanceOf(vault.address)
+        assert.equal(finalBalance.toString(), initialBalance.plus(5).toString(), 'deposited tokens must be in vault')
+        assert.equal(await token1.balanceOf(app.address), 0, 'finance shouldn\'t have tokens')
+        assert.equal(periodId, 0, 'period id should be correct')
+        assert.equal(amount, 5, 'amount should be correct')
+        assert.equal(paymentId, 0, 'payment id should be 0')
+        assert.equal(token, token1.address, 'token should be correct')
+        assert.equal(entity, app.address, 'entity should be correct')
+        assert.isTrue(incoming, 'tx should be incoming')
+        assert.equal(date, 1, 'date should be correct')
+        assert.equal(ref, 'Transfer from Finance', 'ref should be correct')
+    })
+
     it('before setting budget allows unlimited spending', async () => {
         const recipient = accounts[1]
         const time = 22

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -125,7 +125,15 @@ contract('Finance App', accounts => {
         assert.equal(entity, app.address, 'entity should be correct')
         assert.isTrue(incoming, 'tx should be incoming')
         assert.equal(date, 1, 'date should be correct')
-        assert.equal(ref, 'Transfer from Finance', 'ref should be correct')
+        assert.equal(ref, 'Deposit to Vault', 'ref should be correct')
+
+    })
+
+    it('try to send locked tokens to Vault, but balance is 0', async () => {
+        // if current balance is zero, it just fails
+        return assertRevert(async () => {
+            await app.depositToVault(token1.address)
+        })
     })
 
     it('before setting budget allows unlimited spending', async () => {


### PR DESCRIPTION
If accidentally somebody sends tokens to Finance contract address
directly through transfer, tokens could be locked. This function
allows to send them to Vault.

Closes #57.