### PR TITLE
finance: Restrict receiveApproval to be called only by token

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -152,7 +152,7 @@ contract Finance is AragonApp, ERC677Receiver {
         transitionsPeriod
         external
     {
-        ERC20 token = ERC20(_token);
+        ERC20 token = ERC20(msg.sender);
         _recordIncomingTransaction(
             token,
             _from,


### PR DESCRIPTION
Otherwise, `receiveApproval` can move anyone's money that has given a 0xFFF approval to the org.
Fixes issue #83 