### PR TITLE
finance: Restrict receiveApproval to be called only by token

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -152,6 +152,7 @@ contract Finance is AragonApp, ERC677Receiver {
         transitionsPeriod
         external
     {
+        require(msg.sender == _token);
         ERC20 token = ERC20(msg.sender);
         _recordIncomingTransaction(
             token,

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -90,6 +90,14 @@ contract('Finance App', accounts => {
         assert.equal(ref, 'ref', 'ref should be correct')
     })
 
+    it('fails calling receiveApproval from other than token', async () => {
+        let amount = 5
+        await token1.approve(app.address, amount)
+        return assertRevert(async () => {
+            await app.receiveApproval(accounts[0], amount, token1.address, '', {from: accounts[1]})
+        })
+    })
+
     it('records ERC677 deposits', async () => {
         await etherToken.transferAndCall(app.address, 50, 'reference')
 


### PR DESCRIPTION
Otherwise, `receiveApproval` can move anyone's money that has given a 0xFFF approval to the org.
Fixes issue #83 
Compare to PR #84 