### PR TITLE
Pin truffle to 4.0.5

### DIFF
--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -36,7 +36,7 @@
     "solidity-coverage": "0.3.5",
     "solidity-sha3": "^0.4.1",
     "solium": "^1.0.4",
-    "truffle": "^4.0.4",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3",
     "webpack": "^3.7.1"
   },

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -34,7 +34,7 @@
     "ganache-cli": "^6.0.3",
     "solidity-coverage": "0.3.5",
     "solium": "^1.0.4",
-    "truffle": "^4.0.4",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3",
     "webpack": "^3.7.1"
   },

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -34,7 +34,7 @@
     "ganache-cli": "^6.0.3",
     "solidity-coverage": "0.3.5",
     "solium": "^1.0.4",
-    "truffle": "^4.0.4",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3",
     "webpack": "^3.7.1"
   },

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -35,7 +35,7 @@
     "solidity-coverage": "0.3.5",
     "solidity-sha3": "^0.4.1",
     "solium": "^1.0.4",
-    "truffle": "^4.0.4",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3",
     "webpack": "^3.7.1"
   },

--- a/future-apps/fundraising/package.json
+++ b/future-apps/fundraising/package.json
@@ -30,7 +30,7 @@
     "ethereumjs-testrpc": "^6.0.1",
     "solidity-coverage": "0.3.5",
     "solium": "^1.0.4",
-    "truffle": "^4.0.4",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3",
     "webpack": "^3.7.1"
   },

--- a/future-apps/payroll/package.json
+++ b/future-apps/payroll/package.json
@@ -30,7 +30,7 @@
     "solidity-coverage": "0.3.5",
     "solidity-sha3": "^0.4.1",
     "solium": "^1.1.3",
-    "truffle": "4.0.4",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3",
     "webpack": "^3.7.1"
   },

--- a/templates/dev/package.json
+++ b/templates/dev/package.json
@@ -12,7 +12,7 @@
   "author": "Aragon Institution MTU <contact@aragon.one>",
   "license": "GPL-3.0",
   "devDependencies": {
-    "truffle": "^4.0.5",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {

--- a/templates/tokens/package.json
+++ b/templates/tokens/package.json
@@ -12,7 +12,7 @@
   "author": "Aragon Institution MTU <contact@aragon.one>",
   "license": "GPL-3.0",
   "devDependencies": {
-    "truffle": "^4.0.5",
+    "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {


### PR DESCRIPTION
Truffle@4.0.6 upgrades solidity to 0.4.19, which breaks our fixed contracts.