### PR TITLE
Bump aragon/os version in templates

### DIFF
--- a/templates/beta/package.json
+++ b/templates/beta/package.json
@@ -16,7 +16,7 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "^3.0.3",
+    "@aragon/os": "^3.0.8",
     "@aragon/apps-voting": "^1.0.0",
     "@aragon/apps-vault": "^1.0.0",
     "@aragon/apps-finance": "^1.0.0",

--- a/templates/demo/package.json
+++ b/templates/demo/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@aragon/apps-vault": "^1.0.0",
     "@aragon/apps-voting": "^1.0.0",
-    "@aragon/os": "^3.0.4",
+    "@aragon/os": "^3.0.8",
     "eth-ens-namehash": "^2.0.8"
   }
 }

--- a/templates/dev/package.json
+++ b/templates/dev/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@aragon/apps-vault": "^1.0.0",
     "@aragon/apps-voting": "^1.0.0",
-    "@aragon/os": "^3.0.4",
+    "@aragon/os": "^3.0.8",
     "eth-ens-namehash": "^2.0.8"
   }
 }

--- a/templates/tokens/package.json
+++ b/templates/tokens/package.json
@@ -16,7 +16,7 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "^3.0.2",
+    "@aragon/os": "^3.0.8",
     "@aragon/apps-voting": "^1.0.0",
     "@aragon/apps-vault": "^1.0.0"
   }


### PR DESCRIPTION
At least 3.0.6 is required for the changes in `Voting` and `Finance` to compile.