### PR TITLE
templates: Change geth docker image data path

### DIFF
--- a/templates/beta/docker-compose.yml
+++ b/templates/beta/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   devnet:
     image: aragon/geth-devnet
     volumes:
-      - ${ETHDATA_LOCAL_PATH}:/root/.ethdata
+      - ${ETHDATA_LOCAL_PATH}:/root/.ethereum
     ports:
       - "8545:8545"
       - "8546:8546"


### PR DESCRIPTION
So it's the default and there's no need to add anything to `geth attach`.