### PR TITLE
Apps: fix @aragon/client version and lock files

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@aragon/client": "^1.0.0-beta.4",
+    "@aragon/client": "^1.0.0-beta.5",
     "@aragon/ui": "^0.7.0",
     "copy-to-clipboard": "^3.0.8",
     "date-fns": "^2.0.0-alpha.7",

--- a/apps/finance/app/yarn.lock
+++ b/apps/finance/app/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@aragon/client@^1.0.0-beta.4":
-  version "1.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.4.tgz#d4f836f2fc0f36b3597c481842f5aeaaa221ad5a"
+"@aragon/client@^1.0.0-beta.5":
+  version "1.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.5.tgz#63ae6a5384ad8a90f3be543858cf9ff32b723b54"
   dependencies:
-    "@aragon/messenger" "^1.0.0-beta.3"
+    "@aragon/messenger" "^1.0.0-beta.4"
 
-"@aragon/messenger@^1.0.0-beta.3":
+"@aragon/messenger@^1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.4.tgz#e8bff5b969b95ad6da91caa24d480deae9df3aec"
   dependencies:

--- a/apps/token-manager/app/package.json
+++ b/apps/token-manager/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@aragon/client": "^1.0.0-beta.4",
+    "@aragon/client": "^1.0.0-beta.5",
     "@aragon/ui": "^0.7.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/apps/token-manager/app/yarn.lock
+++ b/apps/token-manager/app/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@aragon/client@^1.0.0-beta.4":
-  version "1.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.4.tgz#d4f836f2fc0f36b3597c481842f5aeaaa221ad5a"
+"@aragon/client@^1.0.0-beta.5":
+  version "1.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.5.tgz#63ae6a5384ad8a90f3be543858cf9ff32b723b54"
   dependencies:
-    "@aragon/messenger" "^1.0.0-beta.3"
+    "@aragon/messenger" "^1.0.0-beta.4"
 
-"@aragon/messenger@^1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.3.tgz#da11536df367a5a1d961dacbffe1cb46e950dfad"
+"@aragon/messenger@^1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.4.tgz#e8bff5b969b95ad6da91caa24d480deae9df3aec"
   dependencies:
     rxjs "^5.5.6"
     uuid "^3.2.1"

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/",
   "dependencies": {
-    "@aragon/client": "^1.0.0-beta.4",
+    "@aragon/client": "^1.0.0-beta.5",
     "@aragon/ui": "^0.7.0",
     "date-fns": "^1.29.0",
     "prop-types": "^15.6.0",

--- a/apps/voting/app/yarn.lock
+++ b/apps/voting/app/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@aragon/client@^1.0.0-beta.4":
-  version "1.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.4.tgz#d4f836f2fc0f36b3597c481842f5aeaaa221ad5a"
+"@aragon/client@^1.0.0-beta.5":
+  version "1.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.5.tgz#63ae6a5384ad8a90f3be543858cf9ff32b723b54"
   dependencies:
-    "@aragon/messenger" "^1.0.0-beta.3"
+    "@aragon/messenger" "^1.0.0-beta.4"
 
-"@aragon/messenger@^1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.3.tgz#da11536df367a5a1d961dacbffe1cb46e950dfad"
+"@aragon/messenger@^1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.4.tgz#e8bff5b969b95ad6da91caa24d480deae9df3aec"
   dependencies:
     rxjs "^5.5.6"
     uuid "^3.2.1"


### PR DESCRIPTION
Updates to `@aragon/client@v1.0.0-beta.5` and updates lock files to avoid depending on older version of `@aragon/messenger`.