### PR TITLE
Radspec voting

### DIFF
--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/",
   "dependencies": {
-    "@aragon/client": "^1.0.0-beta.5",
+    "@aragon/client": "^1.0.0-beta.7",
     "@aragon/ui": "^0.7.0",
     "date-fns": "^1.29.0",
     "prop-types": "^15.6.0",

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -11,9 +11,8 @@ import AppLayout from './components/AppLayout'
 import { networkContextType } from './utils/provideNetwork'
 import { hasLoadedVoteSettings } from './vote-settings'
 import { VOTE_YEA } from './vote-types'
-import { getQuorumProgress } from './vote-utils'
+import { EMPTY_CALLSCRIPT, getQuorumProgress } from './vote-utils'
 
-const EMPTY_CALLSCRIPT = '0x00000001'
 const tokenAbi = [].concat(tokenBalanceOfAbi, tokenDecimalsAbi)
 
 class App extends React.Component {

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -73,6 +73,15 @@ class VotePanelContent extends React.Component {
         })
     }
   }
+  renderDescription = (description = '') => {
+    // Make '\n's real breaks
+    return description.split('\n').map((line, i) => (
+      <React.Fragment key={i}>
+        {line}
+        <br />
+      </React.Fragment>
+    ))
+  }
   render() {
     const { network: { etherscanBaseUrl }, vote, ready } = this.props
     const { userBalance, userCanVote } = this.state
@@ -127,7 +136,7 @@ class VotePanelContent extends React.Component {
               <h2>
                 <Label>Description:</Label>
               </h2>
-              <p>{description}</p>
+              <p>{this.renderDescription(description)}</p>
             </React.Fragment>
           )}
         </Part>

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -112,19 +112,24 @@ class VotePanelContent extends React.Component {
           </div>
         </SidePanelSplit>
         <Part>
-          {metadata && (<h2>
-            <Label>Question:</Label>
-          </h2>
-          <p>
-            <strong>{metadata}</strong>
-          </p>)}
-          {description && (<h2>
-            <Label>Description:</Label>
-          </h2>
-          <p>
-            Fusce vehicula dolor arcu, sit amet blandit dolor mollis nec. Sed
-            sollicitudin ipsum quis nunc sollicitudin ultrices?
-          </p>)}
+          {metadata && (
+            <React.Fragment>
+              <h2>
+                <Label>Question:</Label>
+              </h2>
+              <p>
+                <strong>{metadata}</strong>
+              </p>
+            </React.Fragment>
+          )}
+          {description && (
+            <React.Fragment>
+              <h2>
+                <Label>Description:</Label>
+              </h2>
+              <p>{description}</p>
+            </React.Fragment>
+          )}
         </Part>
         <SidePanelSeparator />
         <Part>

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -81,7 +81,7 @@ class VotePanelContent extends React.Component {
     }
 
     const { quorum, support, endDate, quorumProgress } = vote
-    const { creator, metadata, nay, totalVoters, yea } = vote.data
+    const { creator, metadata, nay, totalVoters, yea, description } = vote.data
 
     // const creatorName = 'Robert Johnson' // TODO: get creator name
 
@@ -112,21 +112,19 @@ class VotePanelContent extends React.Component {
           </div>
         </SidePanelSplit>
         <Part>
-          <h2>
+          {metadata && (<h2>
             <Label>Question:</Label>
           </h2>
           <p>
             <strong>{metadata}</strong>
-          </p>
-          {/*
-          <h2>
+          </p>)}
+          {description && (<h2>
             <Label>Description:</Label>
           </h2>
           <p>
             Fusce vehicula dolor arcu, sit amet blandit dolor mollis nec. Sed
             sollicitudin ipsum quis nunc sollicitudin ultrices?
-          </p>
-          */}
+          </p>)}
         </Part>
         <SidePanelSeparator />
         <Part>

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -1,6 +1,7 @@
 import Aragon from '@aragon/client'
 import { combineLatest } from './rxjs'
 import voteSettings, { hasLoadedVoteSettings } from './vote-settings'
+import { EMPTY_CALLSCRIPT } from './vote-utils'
 
 const app = new Aragon()
 
@@ -60,7 +61,6 @@ async function startVote(state, { voteId }) {
  *                     *
  ***********************/
 
-const EMPTY_CALLSCRIPT = '0x00000001'
 async function loadVoteDescription(vote) {
   if (!vote.script || vote.script === EMPTY_CALLSCRIPT) {
     return vote

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -68,14 +68,13 @@ async function loadVoteDescription(vote) {
 
   const path = await app.describeScript(vote.script).toPromise()
 
-  vote.description = path.map((step) => {
-    let app = `${step.to}`
-    if (step.name) {
-      app = `${step.name} (${step.to})`
-    }
+  vote.description = path
+    .map(step => {
+      const app = step.name ? `${step.name} (${step.to})` : `${step.to}`
 
-    return `${app}: ${step.description || 'No description'}`
-  }).join('\n')
+      return `${app}: ${step.description || 'No description'}`
+    })
+    .join('\n')
 
   return vote
 }
@@ -88,13 +87,12 @@ function loadVoteData(voteId) {
     )
       .first()
       .subscribe(([vote, metadata]) => {
-        loadVoteDescription(vote)
-          .then((vote) => {
-            resolve({
-              ...marshallVote(vote),
-              metadata,
-            })
+        loadVoteDescription(vote).then(vote => {
+          resolve({
+            ...marshallVote(vote),
+            metadata,
           })
+        })
       })
   })
 }

--- a/apps/voting/app/src/vote-utils.js
+++ b/apps/voting/app/src/vote-utils.js
@@ -6,6 +6,8 @@ import {
   VOTE_STATUS_ACCEPTED,
 } from './vote-types'
 
+export const EMPTY_CALLSCRIPT = '0x00000001'
+
 export const getAccountVote = (account, voters) =>
   voters[account] || VOTE_ABSENT
 

--- a/apps/voting/app/yarn.lock
+++ b/apps/voting/app/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@aragon/client@^1.0.0-beta.4":
-  version "1.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.4.tgz#d4f836f2fc0f36b3597c481842f5aeaaa221ad5a"
+"@aragon/client@^1.0.0-beta.7":
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@aragon/client/-/client-1.0.0-beta.7.tgz#552a06f683d2431ad4cc4ee022eb759507ce2ba3"
   dependencies:
-    "@aragon/messenger" "^1.0.0-beta.3"
+    "@aragon/messenger" "^1.0.0-beta.4"
 
-"@aragon/messenger@^1.0.0-beta.3":
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.3.tgz#da11536df367a5a1d961dacbffe1cb46e950dfad"
+"@aragon/messenger@^1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0-beta.4.tgz#e8bff5b969b95ad6da91caa24d480deae9df3aec"
   dependencies:
     rxjs "^5.5.6"
     uuid "^3.2.1"


### PR DESCRIPTION
Generates a description from the vote callscript if specified.

We might want to change the description format. Currently each step in the transaction path contains:

```js
{
  to: string,
  data: string,
  ?description: string,
  ?name: string,
  ?identifier: string
}
```

And we render each step on a new line in chronological order, where each like is ``<name> (<address>): <description>``, for example:

>Token Manager (0xbabe): Execute action as token holder
>Token Manager (0xdeadbeef): Mint 1 tokens for 0xebefbbabbe

Note that the above example is super hypothetical