### PR TITLE
Better loading state in the finance app

### DIFF
--- a/apps/finance/app/src/components/Balances.js
+++ b/apps/finance/app/src/components/Balances.js
@@ -32,33 +32,34 @@ class Balances extends React.Component {
   render() {
     const { balances } = this.props
     const { convertRates } = this.state
+    const balanceItems = balances
+      .map(({ amount, decimals, ...token }) => ({
+        ...token,
+        amount: amount / Math.pow(10, decimals),
+      }))
+      .map(({ amount, symbol }) => ({
+        amount,
+        symbol,
+        convertedAmount: convertRates[symbol]
+          ? amount / convertRates[symbol]
+          : -1,
+      }))
+      .map(({ amount, convertedAmount, ...balance }) => ({
+        ...balance,
+        amount: round(amount, 5),
+        convertedAmount: round(convertedAmount, 5),
+      }))
+      .sort(
+        (balanceA, balanceB) =>
+          balanceB.convertedAmount - balanceA.convertedAmount
+      )
     return (
       <section>
         <Title>Token Balances</Title>
         <ScrollView>
           <List>
-            {balances
-              .map(({ amount, decimals, ...token }) => ({
-                ...token,
-                amount: amount / Math.pow(10, decimals),
-              }))
-              .map(({ amount, symbol }) => ({
-                amount,
-                symbol,
-                convertedAmount: convertRates[symbol]
-                  ? amount / convertRates[symbol]
-                  : -1,
-              }))
-              .map(({ amount, convertedAmount, ...balance }) => ({
-                ...balance,
-                amount: round(amount, 5),
-                convertedAmount: round(convertedAmount, 5),
-              }))
-              .sort(
-                (balanceA, balanceB) =>
-                  balanceB.convertedAmount - balanceA.convertedAmount
-              )
-              .map(({ symbol, amount, convertedAmount }) => (
+            {balanceItems.length > 0 ? (
+              balanceItems.map(({ symbol, amount, convertedAmount }) => (
                 <ListItem key={symbol}>
                   <BalanceToken
                     symbol={symbol}
@@ -66,13 +67,22 @@ class Balances extends React.Component {
                     convertedAmount={convertedAmount}
                   />
                 </ListItem>
-              ))}
+              ))
+            ) : (
+              <EmptyListItem />
+            )}
           </List>
         </ScrollView>
       </section>
     )
   }
 }
+
+const EmptyListItem = () => (
+  <ListItem style={{ opacity: '0' }}>
+    <BalanceToken symbol=" " amount={0} convertedAmount={0} />
+  </ListItem>
+)
 
 const ScrollView = styled.div`
   overflow-x: auto;


### PR DESCRIPTION
Add an empty, transparent item to make sure the balances box is already at the right height:

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/36158/37710715-5be43b58-2d06-11e8-993c-a89e3416d588.png">
