### PR TITLE
Voting: calculate if votes are open client-side

### DIFF
--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aragon/client": "^1.0.0-beta.7",
     "@aragon/ui": "^0.7.0",
-    "date-fns": "^1.29.0",
+    "date-fns": "^2.0.0-alpha.7",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-blockies": "^1.2.2",

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -89,7 +89,7 @@ class VotePanelContent extends React.Component {
       return null
     }
 
-    const { quorum, support, endDate, quorumProgress } = vote
+    const { endDate, open, quorum, quorumProgress, support } = vote
     const { creator, metadata, nay, totalVoters, yea, description } = vote.data
 
     // const creatorName = 'Robert Johnson' // TODO: get creator name
@@ -99,10 +99,10 @@ class VotePanelContent extends React.Component {
         <SidePanelSplit>
           <div>
             <h2>
-              <Label>{vote.open ? 'Time Remaining:' : 'Status'}</Label>
+              <Label>{open ? 'Time Remaining:' : 'Status'}</Label>
             </h2>
             <div>
-              {vote.open ? (
+              {open ? (
                 <Countdown end={endDate} />
               ) : (
                 <VoteStatus

--- a/apps/voting/app/src/components/VoteRow.js
+++ b/apps/voting/app/src/components/VoteRow.js
@@ -15,8 +15,8 @@ class VoteRow extends React.Component {
   }
   render() {
     const { vote } = this.props
-    const { endDate } = vote
-    const { metadata, nay, open, totalVoters, yea } = vote.data
+    const { endDate, open } = vote
+    const { metadata, nay, totalVoters, yea } = vote.data
     const totalVotes = safeDiv(yea + nay, totalVoters)
 
     return (

--- a/apps/voting/app/src/screens/Votes.js
+++ b/apps/voting/app/src/screens/Votes.js
@@ -10,7 +10,7 @@ import VotesTable from '../components/VotesTable'
 class Votes extends React.Component {
   render() {
     const { votes, onSelectVote } = this.props
-    const openedVotes = votes.filter(({ data: { open } }) => open)
+    const openedVotes = votes.filter(({ open }) => open)
     const closedVotes = votes.filter(vote => !openedVotes.includes(vote))
     return (
       <Main>

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -132,7 +132,16 @@ function loadVoteSettings() {
           app
             .call(name)
             .first()
-            .map(val => (type === 'number' ? parseInt(val, 10) : val))
+            .map(val => {
+              if (type === 'number') {
+                return parseInt(val, 10)
+              }
+              if (type === 'time') {
+                // Adjust for js time (in ms vs s)
+                return parseInt(val, 10) * 1000
+              }
+              return val
+            })
             .subscribe(value => {
               resolve({ [key]: value })
             }, reject)
@@ -169,7 +178,7 @@ function marshallVote({
     minAcceptQuorum: parseInt(minAcceptQuorum, 10),
     nay: parseInt(nay, 10),
     snapshotBlock: parseInt(snapshotBlock, 10),
-    startDate: parseInt(startDate, 10),
+    startDate: parseInt(startDate, 10) * 1000, // adjust for js time (in ms vs s)
     totalVoters: parseInt(totalVoters, 10),
     yea: parseInt(yea, 10),
     script,

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -150,12 +150,12 @@ function loadVoteSettings() {
 }
 
 // Apply transmations to a vote received from web3
+// Note: ignores the 'open' field as we calculate that locally
 function marshallVote({
   creator,
   executed,
   minAcceptQuorum,
   nay,
-  open,
   snapshotBlock,
   startDate,
   totalVoters,
@@ -166,7 +166,6 @@ function marshallVote({
   return {
     creator,
     executed,
-    open,
     minAcceptQuorum: parseInt(minAcceptQuorum, 10),
     nay: parseInt(nay, 10),
     snapshotBlock: parseInt(snapshotBlock, 10),

--- a/apps/voting/app/src/vote-settings.js
+++ b/apps/voting/app/src/vote-settings.js
@@ -1,6 +1,6 @@
 const voteSettings = [
   ['token', 'tokenAddress'],
-  ['voteTime', 'voteTime', 'number'],
+  ['voteTime', 'voteTime', 'time'],
   ['PCT_BASE', 'pctBase', 'number'],
   ['supportRequiredPct', 'supportRequiredPct', 'number'],
 ]

--- a/apps/voting/app/yarn.lock
+++ b/apps/voting/app/yarn.lock
@@ -2878,10 +2878,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
-
 date-fns@^2.0.0-alpha.7:
   version "2.0.0-alpha.7"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.7.tgz#245ad16f95764eababfb2c0a41fd5d033c20e57a"


### PR DESCRIPTION
The scripts shouldn't do this, as they'd have to check all the time. Instead, we replicate the logic client-side based on the current time and whether or not the vote's been executed.