### PR TITLE
ethereumjs-abi is needed to test token-manager

### DIFF
--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -40,6 +40,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
     "eth-gas-reporter": "^0.1.1",
+    "ethereumjs-abi": "^0.6.4",
     "ethereumjs-testrpc": "^6.0.2",
     "ganache-cli": "^6.0.3",
     "solidity-coverage": "0.3.5",


### PR DESCRIPTION
Issue:

Can't run `truffle test` successfully because of `ethereumjs-abi` module is missing.

Solution:

Add the missing module via run the command in `apps/token-manager/`:

```sh
yarn add ethereumjs-abi
```

The `truffle test` is passed now.

FYI, `apps/finance` also has `ethereumjs-abi` dev-dependency
https://github.com/aragon/aragon-apps/blob/master/apps/finance/package.json#L43