### PR TITLE
Voting: fix alignment of description in VoteRow if no question

### DIFF
--- a/apps/voting/app/src/components/VoteRow.js
+++ b/apps/voting/app/src/components/VoteRow.js
@@ -26,9 +26,11 @@ class VoteRow extends React.Component {
         </StatusCell>
         <QuestionCell>
           <div>
-            <QuestionWrapper>
-              {description ? <strong>{question}</strong> : question}
-            </QuestionWrapper>
+            {question && (
+              <QuestionWrapper>
+                {description ? <strong>{question}</strong> : question}
+              </QuestionWrapper>
+            )}
             {description && (
               <DescriptionWrapper>{description}</DescriptionWrapper>
             )}
@@ -91,8 +93,11 @@ const QuestionWrapper = styled.p`
 `
 
 const DescriptionWrapper = styled.p`
-  margin-top: 10px;
   margin-right: 20px;
+
+  ${QuestionWrapper} + & {
+    margin-top: 10px;
+  }
 `
 
 const BarsGroup = styled.div`


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4166642/38019518-0bb657ca-3278-11e8-9b7f-f9e792a7ca84.png)

Fixes the extra padding in the description when no question is available.