### PR TITLE
Finance: fix fiat conversion for tokens

### DIFF
--- a/apps/finance/app/src/components/Balances.js
+++ b/apps/finance/app/src/components/Balances.js
@@ -14,20 +14,22 @@ class Balances extends React.Component {
     convertRates: {},
   }
   componentDidMount() {
-    this.updateConvertedRates()
+    this.updateConvertedRates(this.props)
   }
-  componentWillReceiveProps() {
-    this.updateConvertedRates()
+  componentWillReceiveProps(nextProps) {
+    this.updateConvertedRates(nextProps)
   }
-  async updateConvertedRates() {
-    const symbols = this.props.balances.map(({ symbol }) => symbol)
+  async updateConvertedRates({ balances }) {
+    const symbols = balances.map(({ symbol }) => symbol)
 
-    // Uncomment the next line to simulate a delay
-    // await new Promise(r => setTimeout(r, 2000))
+    if (symbols.length) {
+      // Uncomment the next line to simulate a delay
+      // await new Promise(r => setTimeout(r, 2000))
 
-    const res = await fetch(convertApiUrl(symbols))
-    const convertRates = await res.json()
-    this.setState({ convertRates })
+      const res = await fetch(convertApiUrl(symbols))
+      const convertRates = await res.json()
+      this.setState({ convertRates })
+    }
   }
   render() {
     const { balances } = this.props


### PR DESCRIPTION
Fixes #190.

Fixes a race condition with getting the right tokens to convert fiat amounts for.

@Smokyish this should work a lot more reliably now. We can still hide it, if you'd like.