### PR TITLE
TokenManager: oly show rest in partition graph if all not owners are present in graph

### DIFF
--- a/apps/token-manager/app/src/components/SideBar.js
+++ b/apps/token-manager/app/src/components/SideBar.js
@@ -43,7 +43,7 @@ const calculateStakes = (accounts, total) => {
   const rest =
     100 - displayedStakes.reduce((total, { stake }) => total + stake, 0)
 
-  return rest > 0
+  return displayedStakes.length < accounts.length
     ? [...displayedStakes, { name: 'Rest', stake: rest }].sort(byStake)
     : displayedStakes
 }


### PR DESCRIPTION
Avoids cases like

![image](https://user-images.githubusercontent.com/4166642/38027383-ba3a82fa-328f-11e8-8edb-6c4ac01d63ca.png)

Where the last 1% is from a rounding issue, but not really representative of the token ownership.