### PR TITLE
Finance: correctly identity outgoing transfers

### DIFF
--- a/apps/finance/app/src/components/TransferRow.js
+++ b/apps/finance/app/src/components/TransferRow.js
@@ -48,14 +48,19 @@ class TransferRow extends React.Component {
       date,
       decimals,
       entity,
+      isIncoming,
       network: { etherscanBaseUrl },
       reference,
       symbol,
     } = this.props
     const { showCopyTransferMessage } = this.state
-    const formattedAmount = formatTokenAmount(amount, decimals, true, {
-      rounding: 5,
-    })
+    const formattedAmount = formatTokenAmount(
+      amount,
+      isIncoming,
+      decimals,
+      true,
+      { rounding: 5 }
+    )
     const formattedDate = formatHtmlDatetime(date)
     return (
       <TableRow>
@@ -80,7 +85,7 @@ class TransferRow extends React.Component {
           </TextOverflow>
         </NoWrapCell>
         <NoWrapCell align="right">
-          <Amount positive={amount > 0}>
+          <Amount positive={isIncoming}>
             {formattedAmount} {symbol}
           </Amount>
         </NoWrapCell>

--- a/apps/finance/app/src/lib/utils.js
+++ b/apps/finance/app/src/lib/utils.js
@@ -2,11 +2,12 @@ import { round } from './math-utils'
 
 export const formatTokenAmount = (
   amount,
+  isIncoming,
   decimals = 0,
   displaySign = false,
   { rounding = 2 } = {}
 ) =>
-  (displaySign && amount > 0 ? '+' : '') +
+  (displaySign && isIncoming ? '+' : '') +
   Number(round(amount / Math.pow(10, decimals), rounding)).toLocaleString(
     'latn',
     {


### PR DESCRIPTION
Use `isIncoming` to identify when it's an incoming or outgoing payment.