### PR TITLE
Save payment reference as transaction reference in one time payments

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -204,7 +204,8 @@ contract Finance is AragonApp {
                 _token,
                 _receiver,
                 _amount,
-                0   // unrelated to any payment id, it isn't created
+                0,   // unrelated to any payment id, it isn't created
+                _reference
             );
             return;
         }
@@ -423,7 +424,6 @@ contract Finance is AragonApp {
     }
 
     // internal fns
-
     function _newPeriod(uint64 _startTime) internal returns (Period storage) {
         uint256 newPeriodId = periods.length++;
 
@@ -455,7 +455,8 @@ contract Finance is AragonApp {
                 payment.token,
                 payment.receiver,
                 payment.amount,
-                _paymentId
+                _paymentId,
+                "" // reference can be fetched from paymentId, save gas
             );
         }
     }
@@ -464,7 +465,8 @@ contract Finance is AragonApp {
         address _token,
         address _receiver,
         uint256 _amount,
-        uint256 _paymentId
+        uint256 _paymentId,
+        string _reference
         ) internal
     {
         require(_getRemainingBudget(_token) >= _amount);
@@ -474,7 +476,7 @@ contract Finance is AragonApp {
             _receiver,
             _amount,
             _paymentId,
-            ""
+            _reference
         );
 
         vault.transfer(_token, _receiver, _amount, new bytes(0));

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -188,11 +188,14 @@ contract('Finance App', accounts => {
 
         it('can create single payment', async () => {
             const amount = 10
-
+            const ref = 'one time ref'
             // interval 0, repeat 1 (single payment)
-            await app.newPayment(token1.address, recipient, amount, time, 0, 1, '')
+            await app.newPayment(token1.address, recipient, amount, time, 0, 1, ref)
+
+            const txData = await app.getTransaction(1)
 
             assert.equal(await token1.balanceOf(recipient), amount, 'recipient should have received tokens')
+            assert.equal(txData[7], ref, 'ref should be saved in one time payments')
         })
 
         it('can decrease budget after spending', async () => {


### PR DESCRIPTION
We only save the payment reference in the tx reference in one time payments (that the payment data structure is not stored). When a saved payment is executed many times, the reference can be fetched from the `paymentId`.

Requires APM redeploy. 
