### PR TITLE
Voting: add signaling multi-option vote support, and some general refactor

### DIFF
--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -210,7 +210,7 @@ contract Voting is IForwarder, AragonApp {
         return true;
     }
 
-    function getVote(uint256 _voteId) public view returns (bool open, bool executed, address creator, uint64 startDate, uint256 snapshotBlock, uint256 minAcceptQuorum, uint256 yea, uint256 nay, uint256 votingPower, uint256 quorum, bytes script) {
+    function getVote(uint256 _voteId) public view returns (bool open, bool executed, address creator, uint64 startDate, uint256 snapshotBlock, uint256 minAcceptQuorum, uint256 yea, uint256 nay, uint256 votingPower, uint256 quorum, uint256 options, bytes script) {
         Vote vote = votes[_voteId];
 
         open = _isVoteOpen(vote);
@@ -219,11 +219,16 @@ contract Voting is IForwarder, AragonApp {
         startDate = vote.startDate;
         snapshotBlock = vote.snapshotBlock;
         minAcceptQuorum = vote.minAcceptQuorumPct;
-        yea = vote.votes[YEA_VOTE_OPTION];
-        nay = vote.votes[NAY_VOTE_OPTION];
         votingPower = vote.votingPower;
         quorum = vote.quorum;
+        options = vote.options;
         script = vote.executionScript;
+
+        // yea and nay are only returned in case of binary votes, otherwise getOptionSupport(..) should be used
+        if (options == 2) {
+            yea = vote.votes[YEA_VOTE_OPTION];
+            nay = vote.votes[NAY_VOTE_OPTION]; 
+        }
     }
 
     function getVoteMetadata(uint256 _voteId) public view returns (string) {

--- a/apps/voting/package-lock.json
+++ b/apps/voting/package-lock.json
@@ -193,9 +193,9 @@
 			}
 		},
 		"@aragon/os": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.1.tgz",
-			"integrity": "sha512-6Q4SSc6YuLOGjXiH2SbN586KpJgszOtjYtfXNmf+HXtTCEn4iNPQrZ5gPoA2tcjBIz8pof79nXfTBM3ZSw5z6w==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.3.tgz",
+			"integrity": "sha512-DehFB6Tytw+NACTULXJ1rndJhYvMtF3EMJ8+M8UDP1s8Nw/hD1O3DDJNYum6bSnUBJ7OKLdoNFZbIUsl5uo0Kg==",
 			"requires": {
 				"homedir": "0.6.0",
 				"truffle-privatekey-provider": "0.0.5"
@@ -2778,7 +2778,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.2.tgz",
 			"integrity": "sha512-UpHVysD6Wzx3tjH5SaPJVnGsU92LMlyOMwfuWifgPjaNqBj+D1Lr/phZY1fh28V7Jd7Wkh1RVl0iLsuT/XlEUQ==",
 			"requires": {
-				"webpack": "3.8.1"
+				"webpack": "3.10.0"
 			}
 		},
 		"ethereumjs-testrpc-sc": {
@@ -2786,7 +2786,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
 			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
-				"webpack": "3.8.1"
+				"webpack": "3.10.0"
 			}
 		},
 		"ethereumjs-tx": {
@@ -4026,7 +4026,7 @@
 			"resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.0.3.tgz",
 			"integrity": "sha512-C7a8su4Zwtootvcy9HtroshTsyUtLC51+aOGUREpy/G4CXbAuLa3nNQri2NyFdqGyOrm/D+jxYP/PWnnrGLyXg==",
 			"requires": {
-				"webpack": "3.8.1"
+				"webpack": "3.10.0"
 			}
 		},
 		"ganache-core": {
@@ -9974,9 +9974,9 @@
 			"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
 		},
 		"webpack": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+			"integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
 			"requires": {
 				"acorn": "5.2.1",
 				"acorn-dynamic-import": "2.0.2",

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -50,6 +50,6 @@
     "webpack": "3.10.0"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.2"
+    "@aragon/os": "^3.1.3"
   }
 }


### PR DESCRIPTION
This PR adds multi-option votes for non-binding votes (no script execution) (closes #231)

It also no longer votes on vote creation when a vote is created directly (that is not through the forwarding interface, which still votes on creation) (closes #189)

It is also a general refactor in terms of style mainly. Tests have been minimally modified (apart from adding tests for the new logic).

