### PR TITLE
Voting: use break-word in vote rows

### DIFF
--- a/apps/voting/app/src/components/VoteRow.js
+++ b/apps/voting/app/src/components/VoteRow.js
@@ -88,7 +88,7 @@ const ActionsCell = styled(Cell)`
 
 const QuestionWrapper = styled.p`
   margin-right: 20px;
-  word-break: break-all;
+  word-break: break-word;
   hyphens: auto;
 `
 


### PR DESCRIPTION
`break-word` gives much saner line breaks :).