### PR TITLE
UIs: fix parcel bundling of script.js

### DIFF
--- a/apps/finance/app/.gitignore
+++ b/apps/finance/app/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 # built assets
 /public/aragon-ui
 /public/script.js
+/public/script.map

--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -44,7 +44,7 @@
     "sync-assets": "rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" public/aragon-ui",
     "start": "npm run sync-assets && npm run build:script -- --no-minify && PORT=3002 react-scripts start",
     "build": "npm run sync-assets && npm run build:script && react-scripts build",
-    "build:script": "parcel build src/script.js -d public/ -o script.js",
+    "build:script": "parcel build src/script.js -d public/",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/apps/token-manager/app/.gitignore
+++ b/apps/token-manager/app/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 # built assets
 /public/aragon-ui
 /public/script.js
+/public/script.map

--- a/apps/token-manager/app/package.json
+++ b/apps/token-manager/app/package.json
@@ -38,7 +38,7 @@
     "sync-assets": "rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" public/aragon-ui",
     "start": "npm run sync-assets && npm run build:script -- --no-minify && PORT=3003 react-scripts start",
     "build": "npm run sync-assets && npm run build:script && react-scripts build",
-    "build:script": "parcel build src/script.js -d public/ -o script.js",
+    "build:script": "parcel build src/script.js -d public/",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/apps/voting/app/.gitignore
+++ b/apps/voting/app/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 # built assets
 /public/aragon-ui
 /public/script.js
+/public/script.map

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -42,7 +42,7 @@
     "sync-assets": "rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" public/aragon-ui",
     "start": "npm run sync-assets && npm run build:script -- --no-minify && PORT=3001 react-scripts start",
     "build": "npm run sync-assets && npm run build:script && react-scripts build",
-    "build:script": "parcel build src/script.js -d public/ -o script.js",
+    "build:script": "parcel build src/script.js -d public/",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Fixes #239.

So it looks like parcel 1.7.0 (originally those commands were for 1.6.2) either removed or changed the behaviour of `-o` (and the bundler's default behaviour without that flag set).

Specifying `-o script.js` actually produces `public/script.js.js` now, but the default just works<sup>TM</sup> :D.