### PR TITLE
Use truffle dev instead of truffle console

### DIFF
--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -16,7 +16,7 @@
     "test": "TRUFFLE_TEST=true npm run ganache-cli:dev",
     "test:gas": "GAS_REPORTER=true npm test",
     "coverage": "./node_modules/@aragon/test-helpers/run-coverage.sh",
-    "console": "node_modules/.bin/truffle console",
+    "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:dev": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "ganache-cli:coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:dev"
   },

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -16,7 +16,7 @@
     "test": "TRUFFLE_TEST=true npm run ganache-cli:dev",
     "test:gas": "GAS_REPORTER=true npm test",
     "coverage": "./node_modules/@aragon/test-helpers/run-coverage.sh",
-    "console": "node_modules/.bin/truffle console",
+    "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:dev": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "ganache-cli:coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:dev"
   },

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -16,7 +16,7 @@
     "test": "./node_modules/.bin/truffle test",
     "test:gas": "GAS_REPORTER=true npm test",
     "coverage": "./node_modules/@aragon/test-helpers/run-coverage.sh",
-    "console": "node_modules/.bin/truffle console",
+    "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:dev": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "ganache-cli:coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:dev"
   },

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -16,7 +16,7 @@
     "test": "TRUFFLE_TEST=true npm run ganache-cli:dev",
     "test:gas": "GAS_REPORTER=true npm test",
     "coverage": "./node_modules/@aragon/test-helpers/run-coverage.sh",
-    "console": "node_modules/.bin/truffle console",
+    "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:dev": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "ganache-cli:coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:dev"
   },

--- a/templates/beta/package.json
+++ b/templates/beta/package.json
@@ -17,7 +17,7 @@
     "test:local": "TRUFFLE_TEST=true npm run ganache-cli:dev test/TestTemplates.sol test/beta.js",
     "test:gas": "GAS_REPORTER=true npm test:local",
     "coverage": "./node_modules/@aragon/test-helpers/run-coverage.sh",
-    "console": "node_modules/.bin/truffle console",
+    "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:dev": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "ganache-cli:coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:dev"
   },


### PR DESCRIPTION
> truffle console should be truffle dev

I think truffle updated this a while back (probably on version 4) so that `truffle dev` is the standalone console.