### PR TITLE
Finance: handle endTime overflow for transitioning periods

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -430,8 +430,14 @@ contract Finance is AragonApp {
 
         Period storage period = periods[newPeriodId];
         period.startTime = _startTime;
-        // endTime = startTime + periodDuration - 1
-        period.endTime = _startTime.add(settings.periodDuration).sub(1);
+
+        // Be careful here to not overflow; if startTime + periodDuration overflows, we set endTime
+        // to MAX_UINT64 (let's assume that's the end of time for now).
+        uint64 endTime = _startTime + settings.periodDuration - 1;
+        if (endTime < _startTime) { // overflowed
+            endTime = MAX_UINT64;
+        }
+        period.endTime = endTime;
 
         NewPeriod(newPeriodId, period.startTime, period.endTime);
 

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -43,6 +43,17 @@ contract('Finance App', accounts => {
         assert.equal(await app.currentPeriodId(), 0, 'current period should be 0')
     })
 
+    it('sets the end of time correctly', async () => {
+        const maxUint64 = await app.MAX_UINT64()
+
+        app = await Finance.new()
+        // initialize with MAX_UINT64 as period duration
+        await app.initialize(vault.address, maxUint64)
+        const [isCurrent, start, end, firstTx, lastTx] = await app.getPeriod(await app.currentPeriodId())
+
+        assert.equal(end.toNumber(), maxUint64.toNumber(), "should have set the period's end date to MAX_UINT64")
+    })
+
     it('fails on reinitialization', async () => {
         return assertRevert(async () => {
             await app.initialize(vault.address, periodDuration)


### PR DESCRIPTION
We can get into cases where `startTime + periodDuration` causes initialization to fail (e.g. if someone's lazy and uses `MAX_UINT64` as `periodDuration`).

This just sets `endTime = max(startTime + periodDuration, MAX_UINT64)`.