### PR TITLE
Finance: check vault on initialization

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -123,6 +123,7 @@ contract Finance is AragonApp {
         initialized();
 
         require(_periodDuration >= 1 days);
+        require(_vault != address(0));
 
         vault = _vault;
 

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -6,6 +6,7 @@ pragma solidity 0.4.18;
 
 import "@aragon/os/contracts/apps/AragonApp.sol";
 
+import "@aragon/os/contracts/common/IsContract.sol";
 import "@aragon/os/contracts/lib/zeppelin/token/ERC20.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath64.sol";
@@ -15,7 +16,7 @@ import "@aragon/apps-vault/contracts/IVaultConnector.sol";
 import "@aragon/os/contracts/lib/misc/Migrations.sol";
 
 
-contract Finance is AragonApp {
+contract Finance is IsContract, AragonApp {
     using SafeMath for uint256;
     using SafeMath64 for uint64;
 
@@ -123,7 +124,7 @@ contract Finance is AragonApp {
         initialized();
 
         require(_periodDuration >= 1 days);
-        require(_vault != address(0));
+        require(isContract(_vault));
 
         vault = _vault;
 

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -63,7 +63,8 @@ contract('Finance App', accounts => {
     it('fails on initializing with no vault', async () => {
         app = await Finance.new()
 
-        return assertRevert(() => app.initialize(0, periodDuration))
+        await assertRevert(() => app.initialize(0, periodDuration))
+        await assertRevert(() => app.initialize(withdrawAddr, periodDuration))
     })
 
     it('fails on initializing with less than one day period', async () => {

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -60,6 +60,12 @@ contract('Finance App', accounts => {
         })
     })
 
+    it('fails on initializing with no vault', async () => {
+        app = await Finance.new()
+
+        return assertRevert(() => app.initialize(0, periodDuration))
+    })
+
     it('fails on initializing with less than one day period', async () => {
         const badPeriod = 60 * 60 * 24 - 1
 


### PR DESCRIPTION
> initialize check vault & etherToken != 0. Why not use kernel for vault & etherToken.

In the future, we could also use the kernel's default vault, if no vault is given.

TODO:

* [x] Wait until aragonOS is upgraded, and then rebase ontop of master
* [x] Use `IsContract` to check if the vault is a contract

Note that this is untestable due to the breaking Vault depedency :(.