### PR TITLE
TokenManager: let Minime token handle transferable-ness

### DIFF
--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -62,10 +62,14 @@ contract TokenManager is ITokenController, AragonApp { // ,IForwarder makes cove
         )
         onlyInit external
     {
-
         initialized();
 
         require(_token.controller() == address(this));
+        if (!_token.transfersEnabled()) {
+            // If the token itself isn't transferable, make sure this app is also initialized to not
+            // be transferable
+            require(!_transferable);
+        }
 
         token = _token;
         transferable = _transferable;

--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -56,6 +56,14 @@ contract('Token Manager', accounts => {
         })
     })
 
+    it('fails when initializing as transferable if token not transferable', async () => {
+      await token.enableTransfers(false)
+      await token.changeController(tokenManager.address)
+      return assertRevert(() => {
+        return tokenManager.initialize(token.address, true, 0, true)
+      })
+    })
+
     it('fails when sending ether to token', async () => {
         return assertRevert(async () => {
             await token.send(1) // transfer 1 wei to token contract

--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -50,18 +50,28 @@ contract('Token Manager', accounts => {
         token = await MiniMeToken.new(n, n, 0, 'n', 0, 'n', true)
     })
 
+    it('initializating as transferable sets the token as transferable', async () => {
+        const transferable = true
+        await token.enableTransfers(!transferable)
+
+        await token.changeController(tokenManager.address)
+        await tokenManager.initialize(token.address, transferable, 0, false)
+        assert.equal(transferable, await token.transfersEnabled())
+    })
+
+    it('initializating as non-transferable sets the token as non-transferable', async () => {
+        const transferable = false
+        await token.enableTransfers(!transferable)
+
+        await token.changeController(tokenManager.address)
+        await tokenManager.initialize(token.address, transferable, 0, false)
+        assert.equal(transferable, await token.transfersEnabled())
+    })
+
     it('fails when initializing without setting controller', async () => {
         return assertRevert(async () => {
             await tokenManager.initialize(token.address, true, 0, false)
         })
-    })
-
-    it('fails when initializing as transferable if token not transferable', async () => {
-      await token.enableTransfers(false)
-      await token.changeController(tokenManager.address)
-      return assertRevert(() => {
-        return tokenManager.initialize(token.address, true, 0, true)
-      })
     })
 
     it('fails when sending ether to token', async () => {
@@ -84,18 +94,20 @@ contract('Token Manager', accounts => {
             })
         })
 
-        it('can transfer to token manager', async () => {
-            await tokenManager.mint(holder, 2000)
-            await token.transfer(tokenManager.address, 10, { from: holder })
-
-            assert.equal(await token.balanceOf(tokenManager.address), 10, 'should have tokens')
-        })
-
         it('token manager can transfer', async () => {
             await tokenManager.issue(100)
             await tokenManager.assign(holder, 10)
 
             assert.equal(await token.balanceOf(holder), 10, 'should have tokens')
+        })
+
+        it('token manager can burn assigned tokens', async () => {
+            const mintAmount = 2000
+            const burnAmount = 10
+            await tokenManager.mint(holder, mintAmount)
+            await tokenManager.burn(holder, burnAmount)
+
+            assert.equal(await token.balanceOf(holder), mintAmount - burnAmount, 'should have burned tokens')
         })
 
         it('forwards actions to holder', async () => {


### PR DESCRIPTION
See https://github.com/aragon/aragon-apps/pull/280#issuecomment-383041298.

~Adds a check to make sure the TokenManager is initialized to be non-transferable if the underlying minime token is also non-transferable.~

~I didn't force equality because the converse is less strict—even if the token was originally transferable, initializing the TokenManager as non-transferable would effectively make the token also non-transferable.~

~Fixes~

> ~check token.transfersEnabled on init~