### PR TITLE
TokenManager: allow clients to get more vesting details

### DIFF
--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -45,7 +45,7 @@ contract TokenManager is ITokenController, AragonApp { // ,IForwarder makes cove
 
     // Other token specific events can be watched on the token address directly (avoid duplication)
     event NewVesting(address indexed receiver, uint256 vestingId, uint256 amount);
-    event RevokeVesting(address indexed receiver, uint256 vestingId);
+    event RevokeVesting(address indexed receiver, uint256 vestingId, uint256 nonVestedAmount);
 
     /**
     * @notice Initializes Token Manager for `_token.symbol(): string`, `transerable ? 'T' : 'Not t'`ransferable`_maxAccountTokens > 0 ? ', with a maximum of ' _maxAccountTokens ' per account' : ''` and with`_logHolders ? '' : 'out'` storage of token holders.
@@ -157,7 +157,7 @@ contract TokenManager is ITokenController, AragonApp { // ,IForwarder makes cove
         TokenVesting storage v = vestings[_holder][_vestingId];
         require(v.revokable);
 
-        uint nonVested = calculateNonVestedTokens(
+        uint256 nonVested = calculateNonVestedTokens(
             v.amount,
             uint64(now),
             v.start,
@@ -172,7 +172,7 @@ contract TokenManager is ITokenController, AragonApp { // ,IForwarder makes cove
         // onTransfer hook always allows if transfering to token controller
         require(token.transferFrom(_holder, address(this), nonVested));
 
-        RevokeVesting(_holder, _vestingId);
+        RevokeVesting(_holder, _vestingId, nonVested);
     }
 
     /**

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -198,6 +198,15 @@ contract TokenManager is ITokenController, AragonApp { // ,IForwarder makes cove
 
     function allHolders() public view returns (address[]) { return holders; }
 
+    function getVesting(address _recipient, uint256 _vestingId) public view returns (uint256 amount, uint64 start, uint64 cliff, uint64 vesting, bool revokable) {
+        TokenVesting storage tokenVesting = vestings[_recipient][_vestingId];
+        amount = tokenVesting.amount;
+        start = tokenVesting.start;
+        cliff = tokenVesting.cliff;
+        vesting = tokenVesting.vesting;
+        revokable = tokenVesting.revokable;
+    }
+
     /*
     * @dev Notifies the controller about a token transfer allowing the
     *      controller to decide whether to allow it or react if desired

--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -237,19 +237,33 @@ contract('Token Manager', accounts => {
 
         context('assigning vested tokens', () => {
             let now = 0
+            let startDate, cliffDate, vestingDate
 
             const start = 1000
             const cliff = 2000
             const vesting = 5000
 
             const totalTokens = 40
+            const revokable = true
 
             beforeEach(async () => {
                 await tokenManager.issue(totalTokens)
                 const block = await getBlock(await getBlockNumber())
                 now = block.timestamp
+                startDate = now + start
+                cliffDate = now + cliff
+                vestingDate = now + vesting
 
-                await tokenManager.assignVested(holder, totalTokens, now + start, now + cliff, now + vesting, true)
+                await tokenManager.assignVested(holder, totalTokens, startDate, cliffDate, vestingDate, revokable)
+            })
+
+            it('can get vesting details before being revoked', async () => {
+                const [vAmount, vStartDate, vCliffDate, vVestingDate, vRevokable] = await tokenManager.getVesting(holder, 0)
+                assert.equal(vAmount, totalTokens)
+                assert.equal(vStartDate, startDate)
+                assert.equal(vCliffDate, cliffDate)
+                assert.equal(vVestingDate, vestingDate)
+                assert.equal(vRevokable, revokable)
             })
 
             it('can start transfering on cliff', async () => {


### PR DESCRIPTION
@izqui not sure if this was an oversight or if there was a reason this wasn't originally included?

Fixes:

> when revoking a vesting, there is no way to see historical data. adding _cliff, _start, etc to NewVesting. Also adding amount to RevokeVesting