### PR TITLE
Vault: update to ERC897 proxies

### DIFF
--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -4,11 +4,13 @@ import "./VaultBase.sol"; // split made to avoid circular import
 
 import "./connectors/ERC20Connector.sol";
 import "./connectors/ETHConnector.sol";
+import "./detectors/ERC165Detector.sol";
 
+import "@aragon/os/contracts/common/DelegateProxy.sol";
 import "@aragon/os/contracts/lib/misc/Migrations.sol";
 
 
-contract Vault is VaultBase {
+contract Vault is VaultBase, DelegateProxy, ERC165Detector {
     struct TokenStandard {
         uint32 erc;
         uint32 interfaceDetectionERC;
@@ -102,6 +104,17 @@ contract Vault is VaultBase {
 
     function isInterfaceDetectionERCSupported(uint32 interfaceDetectionERC) public view returns (bool) {
         return supportedInterfaceDetectionERCs[interfaceDetectionERC];
+    }
+
+    // Proxy implementation
+    function proxyType() public pure returns (uint256 proxyTypeId) {
+        return FORWARDING;
+    }
+
+    function implementation() public view returns (address codeAddr) {
+        // No input given to differentiate connectors, so we just give the ETH connector as the
+        // default implementation
+        return connectors[ETH];
     }
 
     function _registerStandard(uint32 erc, uint32 interfaceDetectionERC, bytes4 interfaceID, address connector) internal {

--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -108,7 +108,7 @@ contract Vault is VaultBase, DelegateProxy, ERC165Detector {
 
     // Proxy implementation
     function proxyType() public pure returns (uint256 proxyTypeId) {
-        return FORWARDING;
+        return UPGRADEABLE;
     }
 
     function implementation() public view returns (address codeAddr) {

--- a/apps/vault/contracts/VaultBase.sol
+++ b/apps/vault/contracts/VaultBase.sol
@@ -1,13 +1,11 @@
 pragma solidity 0.4.18;
 
-import "./detectors/ERC165Detector.sol";
 import "./IVaultConnector.sol";
 
-import "@aragon/os/contracts/common/DelegateProxy.sol";
 import "@aragon/os/contracts/apps/AragonApp.sol";
 
 
-contract VaultBase is AragonApp, DelegateProxy, ERC165Detector {
+contract VaultBase is AragonApp {
     address constant ETH = address(0);
     uint32 constant ERC165 = 165;
     uint32 constant NO_DETECTION = uint32(-1);

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -47,6 +47,6 @@
     "webpack": "^3.7.1"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.1"
+    "@aragon/os": "^3.1.4"
   }
 }


### PR DESCRIPTION
The current 897 spec for `proxyType()` and `implementation()` are a bit of a problem... our Vault doesn't conform to their requirements (might need a new type?).

@izqui