### PR TITLE
Templates: Expose IPFS 8080 port

### DIFF
--- a/templates/beta/docker-compose.yml
+++ b/templates/beta/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     ports:
       - "5001:5001"
       - "4001:4001"
+      - "8080:8080"
     expose:
       - 5001
     networks:


### PR DESCRIPTION
This way we can access it from outside and use it with the local apps
generated with aragon-dev-cli.