### PR TITLE
Use relative paths for frontend assets

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -54,5 +54,6 @@
     "last 1 edge versions",
     "not ie > 0",
     "not op_mini all"
-  ]
+  ],
+  "homepage": "."
 }

--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -62,7 +62,7 @@ class App extends React.Component {
     }))
     const paymentPossibleTokens = balances.filter(({ amount }) => amount)
     return (
-      <AragonApp publicUrl="/aragon-ui/">
+      <AragonApp publicUrl="./aragon-ui/">
         <Layout>
           <Layout.FixedHeader>
             <AppBar

--- a/apps/token-manager/app/package.json
+++ b/apps/token-manager/app/package.json
@@ -48,5 +48,6 @@
     "last 1 edge versions",
     "not ie > 0",
     "not op_mini all"
-  ]
+  ],
+  "homepage": "."
 }

--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -69,7 +69,7 @@ class App extends React.Component {
       tokenSettingsLoaded,
     } = this.state
     return (
-      <AragonApp publicUrl="/aragon-ui/">
+      <AragonApp publicUrl="./aragon-ui/">
         <AppLayout>
           <AppLayout.Header>
             <AppBar

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -52,5 +52,6 @@
     "last 1 edge versions",
     "not ie > 0",
     "not op_mini all"
-  ]
+  ],
+  "homepage": "."
 }

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -141,7 +141,7 @@ class App extends React.Component {
         : preparedVotes.find(vote => vote.voteId === currentVoteId)
 
     return (
-      <AragonApp publicUrl="/aragon-ui/">
+      <AragonApp publicUrl="./aragon-ui/">
         <AppLayout>
           <AppLayout.Header>
             <AppBar


### PR DESCRIPTION
Just found this for creating relative paths for assets: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#serving-the-same-build-from-different-paths

Some brief testing convinces me this will probably solve a lot of our asset loading problems with IPFS, but would like another set of eyes :).