### PR TITLE
Small adjustments to old Vault with ETH

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -108,7 +108,7 @@ contract Finance is AragonApp {
             this.balance,
             "Ether transfer to Finance app"
         );
-        vault.deposit.value(this.balance)(ETH, this, this.balance, new bytes(0));
+        vault.deposit.value(this.balance)(ETH, this, this.balance);
     }
 
     /**
@@ -152,7 +152,7 @@ contract Finance is AragonApp {
         // and then approve them to vault
         ERC20(_token).approve(address(vault), _amount);
         // finally we can deposit them
-        vault.deposit(_token, this, _amount, new bytes(0));
+        vault.deposit(_token, this, _amount);
     }
 
     /**
@@ -318,7 +318,7 @@ contract Finance is AragonApp {
         // First we approve tokens to vault
         ERC20(_token).approve(address(vault), value);
         // then we can deposit them
-        vault.deposit(_token, this, value, new bytes(0));
+        vault.deposit(_token, this, value);
     }
 
     /**
@@ -510,7 +510,7 @@ contract Finance is AragonApp {
             _reference
         );
 
-        vault.transfer(_token, _receiver, _amount, new bytes(0));
+        vault.transfer(_token, _receiver, _amount);
     }
 
     function _recordIncomingTransaction(

--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -28,9 +28,8 @@ contract Vault is AragonApp {
     * @param token Address of the token being transferred
     * @param from Entity that currently owns the tokens
     * @param value Amount of tokens being transferred
-    * @param data (Currently unused for API comp) Extra data associated with the deposit
     */
-    function deposit(address token, address from, uint256 value, bytes data) payable public {
+    function deposit(address token, address from, uint256 value) payable public {
         if (token == ETH) {
             require(msg.value > 0 && msg.value == value);
             require(msg.sender == from);
@@ -42,17 +41,40 @@ contract Vault is AragonApp {
     }
 
     /**
+    * @notice Deposit `value` `token` to the vault
+    * @param token Address of the token being transferred
+    * @param from Entity that currently owns the tokens
+    * @param value Amount of tokens being transferred
+    * @param data Extra data associated with the deposit (currently unused)
+    */
+    function deposit(address token, address from, uint256 value, bytes data) payable public {
+        deposit(token, from, value);
+    }
+
+    /**
     * @notice Transfer `value` `token` from the Vault to `to`
     * @param token Address of the token being transferred
     * @param to Address of the recipient of tokens
     * @param value Amount of tokens being transferred
-    * @param data Extra data associated with the transfer (only allowed for ETH)
     */
-    function transfer(address token, address to, uint256 value, bytes data)
+    function transfer(address token, address to, uint256 value)
         authP(TRANSFER_ROLE, arr(address(token), to, value))
         external
     {
+        transfer(token, to, value, new bytes(0));
+    }
 
+    /**
+    * @notice Transfer `value` `token` from the Vault to `to`
+    * @param token Address of the token being transferred
+    * @param to Address of the recipient of tokens
+    * @param value Amount of tokens being transferred
+    * @param data Extra data associated with the transfer (only used for ETH)
+    */
+    function transfer(address token, address to, uint256 value, bytes data)
+        authP(TRANSFER_ROLE, arr(address(token), to, value))
+        public
+    {
         require(value > 0);
 
         if (token == ETH) {

--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -30,9 +30,11 @@ contract Vault is AragonApp {
     * @param value Amount of tokens being transferred
     */
     function deposit(address token, address from, uint256 value) payable public {
+        require(value > 0);
+
         if (token == ETH) {
-            require(msg.value > 0 && msg.value == value);
-            require(msg.sender == from);
+            // Deposit is implicit in this case
+            require(msg.value == value && msg.sender == from);
         } else {
             require(ERC20(token).transferFrom(from, this, value));
         }

--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -17,7 +17,7 @@ contract Vault is AragonApp {
     /**
     * @dev When used behind an AppProxy, this fallback is never executed
     *      as it will be intercepted by the Proxy (see aragonOS#281)
-    */ 
+    */
     function () payable external {
         require(msg.data.length == 0);
         deposit(ETH, msg.sender, msg.value, msg.data);

--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -3,7 +3,6 @@ pragma solidity 0.4.18;
 import "@aragon/os/contracts/apps/AragonApp.sol";
 
 import "@aragon/os/contracts/lib/zeppelin/token/ERC20.sol";
-import "@aragon/os/contracts/lib/misc/Migrations.sol";
 
 
 contract Vault is AragonApp {

--- a/apps/vault/test/vault.js
+++ b/apps/vault/test/vault.js
@@ -34,7 +34,7 @@ contract('Vault app', (accounts) => {
     })
 
     it('transfers ETH', async () => {
-      await vault.sendTransaction( { value: 100 }) 
+      await vault.sendTransaction( { value: 100 })
       const testAccount = '0xbeef000000000000000000000000000000000000'
       const initialBalance = await getBalance(testAccount)
 

--- a/apps/vault/test/vault.js
+++ b/apps/vault/test/vault.js
@@ -23,9 +23,19 @@ contract('Vault app', (accounts) => {
 
   context('ETH:', async () => {
     it('deposits ETH', async () => {
-      await vault.deposit(ETH, accounts[0], 1, [0], { value: 1 })
-      assert.equal((await getBalance(vault.address)).toString(), 1, "should hold 1 wei")
-      assert.equal((await vault.balance(ETH)).toString(), 1, "should return 1 wei balance")
+      const value = 1
+
+      // Deposit without data param
+      await vault.deposit(ETH, accounts[0], value, { value })
+      assert.equal((await getBalance(vault.address)).toString(), value, `should hold ${value} wei`)
+      assert.equal((await vault.balance(ETH)).toString(), value, `should return ${value} wei balance`)
+
+      // Deposit with data param
+      /* Waiting for truffle to get overloading...
+      await vault.deposit(ETH, accounts[0], value, [0], { value })
+      assert.equal((await getBalance(vault.address)).toString(), value * 2, `should hold ${value * 2} wei`)
+      assert.equal((await vault.balance(ETH)).toString(), value * 2, `should return ${value * 2} wei balance`)
+      */
     })
 
     it('deposits ETH through callback', async () => {
@@ -34,19 +44,33 @@ contract('Vault app', (accounts) => {
     })
 
     it('transfers ETH', async () => {
-      await vault.sendTransaction( { value: 100 })
+      const depositValue = 100
+      const transferValue = 10
+
+      await vault.sendTransaction( { value: depositValue })
       const testAccount = '0xbeef000000000000000000000000000000000000'
       const initialBalance = await getBalance(testAccount)
 
-      await vault.transfer(ETH, testAccount, 10, NO_DATA)
+      // Transfer with data param
+      await vault.transfer(ETH, testAccount, transferValue, NO_DATA)
 
-      assert.equal((await getBalance(testAccount)).toString(), initialBalance.add(10).toString(), "should have sent eth")
-      assert.equal((await getBalance(vault.address)).toString(), 90, "should have remaining balance")
+      assert.equal((await getBalance(testAccount)).toString(), initialBalance.add(transferValue).toString(), "should have sent eth")
+      assert.equal((await getBalance(vault.address)).toString(), depositValue - transferValue, "should have remaining balance")
+
+      // Transfer without data param
+      /* Waiting for truffle to get overloading...
+      await vault.transfer(ETH, testAccount, transferValue)
+
+      assert.equal((await getBalance(testAccount)).toString(), initialBalance.add(transferValue * 2).toString(), "should have sent eth")
+      assert.equal((await getBalance(vault.address)).toString(), depositValue - transferValue * 2, "should have remaining balance")
+      */
     })
 
     it('fails if depositing a different amount of ETH than sent', async () => {
+      const value = 1
+
       return assertRevert(async () => {
-        await vault.deposit(ETH, accounts[0], 1, [0], { value: 2 })
+        await vault.deposit(ETH, accounts[0], value, { value: value * 2 })
       })
     })
   })
@@ -60,25 +84,45 @@ contract('Vault app', (accounts) => {
 
     it('deposits ERC20s', async () => {
       await token.approve(vault.address, 10)
-      await vault.deposit(token.address, accounts[0], 5, '')
+
+      // Deposit half without data param
+      await vault.deposit(token.address, accounts[0], 5)
 
       assert.equal(await token.balanceOf(vault.address), 5, "token accounting should be correct")
       assert.equal(await vault.balance(token.address), 5, "vault should know its balance")
+
+      // Deposit half with data param
+      /* Waiting for truffle to get overloading...
+      await vault.deposit(token.address, accounts[0], 5, '')
+
+      assert.equal(await token.balanceOf(vault.address), 10, "token accounting should be correct")
+      assert.equal(await vault.balance(token.address), 10, "vault should know its balance")
+      */
     })
 
     it('transfers tokens', async () => {
       const tokenReceiver = accounts[2]
       await token.transfer(vault.address, 10)
+
+      // Transfer half with data param
       await vault.transfer(token.address, tokenReceiver, 5, '')
 
       assert.equal(await token.balanceOf(tokenReceiver), 5, "receiver should have correct token balance")
+
+      // Transfer half without data param
+      /* Waiting for truffle to get overloading...
+      await vault.transfer(token.address, tokenReceiver, 5)
+
+      assert.equal(await token.balanceOf(tokenReceiver), 10, "receiver should have correct token balance")
+      */
     })
 
     it('fails if not sufficient token balance available', async () => {
-      await token.approve(vault.address, 10)
+      const approvedAmount = 10
+      await token.approve(vault.address, approvedAmount)
 
       return assertRevert(async () => {
-          await vault.deposit(token.address, accounts[0], 15, '')
+          await vault.deposit(token.address, accounts[0], approvedAmount * 2)
       })
     })
   })


### PR DESCRIPTION
Adds some overloads for `deposit()` and `transfer()` to avoid the `bytes data` parameter (note that testing these is difficult ATM due to truffle).

Also requires all deposits to have positive value, rather than just ETH deposits.