### PR TITLE
Remove migrations import in app contracts

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -8,8 +8,6 @@ import "@aragon/os/contracts/lib/zeppelin/math/SafeMath64.sol";
 
 import "@aragon/apps-vault/contracts/IVaultConnector.sol";
 
-import "@aragon/os/contracts/lib/misc/Migrations.sol";
-
 
 contract Finance is AragonApp {
     using SafeMath for uint256;

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -9,8 +9,6 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 import "@aragon/os/contracts/lib/zeppelin/token/ERC20.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath.sol";
 
-import "@aragon/os/contracts/lib/misc/Migrations.sol";
-
 
 contract TokenManager is ITokenController, AragonApp { // ,IForwarder makes coverage crash (removes pure and interface doesnt match)
     using SafeMath for uint256;

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -7,7 +7,6 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 import "@aragon/os/contracts/lib/minime/MiniMeToken.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath64.sol";
-import "@aragon/os/contracts/lib/misc/Migrations.sol";
 
 
 contract Voting is IForwarder, AragonApp {


### PR DESCRIPTION
Is there a reason they're imported?

Vault's is removed in https://github.com/aragon/aragon-apps/pull/304.