### PR TITLE
Finance: fix test

### DIFF
--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -535,7 +535,7 @@ contract('Finance App', accounts => {
         })
 
         it('fails to deposit ETH', async() => {
-            return assertInvalidOpcode(async() => {
+            return assertRevert(async() => {
                 await nonInit.send(10, { gas: 3e5 })
             })
         })


### PR DESCRIPTION
With changes in PR #307 (commit bb6a18d8) sending would revert instead
of failing with invalid opcode, so last test needed to change from
`assertInvalidOpcode` to `assertRevert`. We didn't realize because CI was
broken prior to PR #309.