### PR TITLE
Pin @aragon/os and other contract packages

### DIFF
--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -40,7 +40,7 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/apps-vault": "^2.0.1",
-    "@aragon/os": "^3.1.2"
+    "@aragon/apps-vault": "2.0.1",
+    "@aragon/os": "3.1.2"
   }
 }

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -43,6 +43,6 @@
     "webpack": "3.10.0"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.4"
+    "@aragon/os": "3.1.4"
   }
 }

--- a/apps/token-manager/package-lock.json
+++ b/apps/token-manager/package-lock.json
@@ -193,9 +193,9 @@
 			}
 		},
 		"@aragon/os": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.4.tgz",
-			"integrity": "sha512-Uvzsrw1+Qc1i7WeyRSBRD9C0gGTnlS4O8nwTieG9pqbuThfevpoCHeR7MqPzhWDo5PLQ4wl6WForRyI/vyvXHw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.2.tgz",
+			"integrity": "sha512-y5MQElBTWdPU7Ul17M8VtMONpNP1VEJc7GHspjXuIvWafwsGnBxocdikj4eK47gUtX4KZZskgMBp4kIL2qkLVg==",
 			"requires": {
 				"homedir": "0.6.0",
 				"truffle-privatekey-provider": "0.0.5"
@@ -10294,11 +10294,6 @@
 						"utf8": "2.1.2",
 						"xhr2": "0.1.4",
 						"xmlhttprequest": "1.8.0"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-						}
 					}
 				}
 			}

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -40,6 +40,6 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.2"
+    "@aragon/os": "3.1.2"
   }
 }

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -40,6 +40,6 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.1"
+    "@aragon/os": "3.1.1"
   }
 }

--- a/apps/voting/package-lock.json
+++ b/apps/voting/package-lock.json
@@ -198,9 +198,9 @@
 			}
 		},
 		"@aragon/os": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.4.tgz",
-			"integrity": "sha512-Uvzsrw1+Qc1i7WeyRSBRD9C0gGTnlS4O8nwTieG9pqbuThfevpoCHeR7MqPzhWDo5PLQ4wl6WForRyI/vyvXHw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.2.tgz",
+			"integrity": "sha512-y5MQElBTWdPU7Ul17M8VtMONpNP1VEJc7GHspjXuIvWafwsGnBxocdikj4eK47gUtX4KZZskgMBp4kIL2qkLVg==",
 			"requires": {
 				"homedir": "0.6.0",
 				"truffle-privatekey-provider": "0.0.5"
@@ -10765,11 +10765,6 @@
 						"utf8": "2.1.2",
 						"xhr2": "0.1.4",
 						"xmlhttprequest": "1.8.0"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-						}
 					}
 				}
 			}

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -41,6 +41,6 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.2"
+    "@aragon/os": "3.1.2"
   }
 }

--- a/templates/beta/package.json
+++ b/templates/beta/package.json
@@ -30,10 +30,10 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.4",
-    "@aragon/apps-voting": "^1.0.0",
-    "@aragon/apps-vault": "^2.0.1",
-    "@aragon/apps-finance": "^1.0.0",
-    "@aragon/apps-token-manager": "^1.0.0"
+    "@aragon/os": "3.1.7",
+    "@aragon/apps-voting": "1.0.0",
+    "@aragon/apps-vault": "2.0.1",
+    "@aragon/apps-finance": "1.0.0",
+    "@aragon/apps-token-manager": "1.0.0"
   }
 }

--- a/templates/beta/package.json
+++ b/templates/beta/package.json
@@ -30,7 +30,7 @@
     "truffle-hdwallet-provider": "0.0.3"
   },
   "dependencies": {
-    "@aragon/os": "3.1.7",
+    "@aragon/os": "3.1.1",
     "@aragon/apps-voting": "1.0.0",
     "@aragon/apps-vault": "2.0.1",
     "@aragon/apps-finance": "1.0.0",


### PR DESCRIPTION
Contract repos should always be pinned for real contracts.

I've left them unpinned in the templates that are meant to be used only for testing (rather than deployed).