### PR TITLE
Revert "Remove migrations import in app contracts (#305)"

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -8,6 +8,8 @@ import "@aragon/os/contracts/lib/zeppelin/math/SafeMath64.sol";
 
 import "@aragon/apps-vault/contracts/IVaultConnector.sol";
 
+import "@aragon/os/contracts/lib/misc/Migrations.sol";
+
 
 contract Finance is AragonApp {
     using SafeMath for uint256;

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -9,6 +9,8 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 import "@aragon/os/contracts/lib/zeppelin/token/ERC20.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath.sol";
 
+import "@aragon/os/contracts/lib/misc/Migrations.sol";
+
 
 contract TokenManager is ITokenController, AragonApp, IForwarder {
     using SafeMath for uint256;

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -7,6 +7,7 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 import "@aragon/os/contracts/lib/minime/MiniMeToken.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath64.sol";
+import "@aragon/os/contracts/lib/misc/Migrations.sol";
 
 
 contract Voting is IForwarder, AragonApp {


### PR DESCRIPTION
This reverts commit 4135078a2497cc807009b92069b8d5a7046b8b0e.

Missing migration contracts break the tests. Will be done later with https://github.com/aragon/aragon-apps/pull/318.