### PR TITLE
Updating coveralls in root project, removing hoek dependency (#323)

### DIFF
--- a/apps/finance/package-lock.json
+++ b/apps/finance/package-lock.json
@@ -3,13 +3,13 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@aragon/cli": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.0.6.tgz",
-			"integrity": "sha512-MvmLlN2o2+ixax/xPpp4ZRY5XAOyhIDXaqax/lqRQq3nIQBxWV4KxAWQS2sM0B6ZncFRDvKsWAU+4mqmk606Dg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.2.0.tgz",
+			"integrity": "sha512-CkbgxET1xRHqxCnAWD3zEzeNiVeIlA+0FFbP3n32dGu21vxQZk5bHUxjhpSU5Uc28Fa7CNv9pK3niFwMrqexDA==",
 			"requires": {
 				"chalk": "^2.1.0",
 				"eth-ens-namehash": "^2.0.0",
-				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
+				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#48f3e968d781f44f8bf8c32476948651d4d14ef4",
 				"find-up": "^2.1.0",
 				"fs-extra": "^4.0.2",
 				"ganache-core": "~2.0.2",
@@ -24,146 +24,62 @@
 				"tmp-promise": "^1.0.4",
 				"web3": "1.0.0-beta.26",
 				"yargs": "^10.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"js-sha3": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-					"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"web3": {
-					"version": "1.0.0-beta.26",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
-					"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
-					"requires": {
-						"web3-bzz": "^1.0.0-beta.26",
-						"web3-core": "^1.0.0-beta.26",
-						"web3-eth": "^1.0.0-beta.26",
-						"web3-eth-personal": "^1.0.0-beta.26",
-						"web3-net": "^1.0.0-beta.26",
-						"web3-shh": "^1.0.0-beta.26",
-						"web3-utils": "^1.0.0-beta.26"
-					}
-				},
-				"yargs": {
-					"version": "10.1.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
 			}
 		},
 		"@aragon/os": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.1.tgz",
-			"integrity": "sha512-6Q4SSc6YuLOGjXiH2SbN586KpJgszOtjYtfXNmf+HXtTCEn4iNPQrZ5gPoA2tcjBIz8pof79nXfTBM3ZSw5z6w==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.7.tgz",
+			"integrity": "sha512-NSEi9uUooxWTjwBzogabP8KO0idBGmFoUc+5IHaWaVelTwS11vqjJ83jc9cUo1s08ei/qNjEiFqDi7ieS0719w==",
 			"requires": {
 				"homedir": "^0.6.0",
-				"truffle-privatekey-provider": "0.0.5"
+				"truffle-hdwallet-provider": "0.0.3",
+				"truffle-privatekey-provider": "0.0.6"
 			}
+		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
+			"integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
 		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+		},
+		"@types/concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/form-data": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "9.6.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
+			"integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig=="
+		},
+		"@types/qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q=="
 		},
 		"abbrev": {
 			"version": "1.0.9",
@@ -171,224 +87,43 @@
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
 		},
 		"abi-decoder": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.0.9.tgz",
-			"integrity": "sha1-a8/Yb39j++yFc9l3izpPkruS4B8=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.1.0.tgz",
+			"integrity": "sha512-nvLArBx0XOJufWyaghMKtIofZDBwEMdVZoqcetQOIe1qYeKZk4+kRYGPEJ5lt7dD3MLulw//amUzOJLM8eW5RA==",
 			"requires": {
 				"babel-core": "^6.23.1",
 				"babel-loader": "^6.3.2",
 				"babel-plugin-add-module-exports": "^0.2.1",
 				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+				"babel-plugin-transform-runtime": "^6.23.0",
 				"babel-preset-es2015": "^6.22.0",
 				"chai": "^3.5.0",
 				"web3": "^0.18.4",
-				"webpack": "^2.2.1"
+				"webpack": "^2.7.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
-				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				},
-				"webpack": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
-					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
-					"requires": {
-						"acorn": "^5.0.0",
-						"acorn-dynamic-import": "^2.0.0",
-						"ajv": "^4.7.0",
-						"ajv-keywords": "^1.1.1",
-						"async": "^2.1.2",
-						"enhanced-resolve": "^3.3.0",
-						"interpret": "^1.0.0",
-						"json-loader": "^0.5.4",
-						"json5": "^0.5.1",
-						"loader-runner": "^2.3.0",
-						"loader-utils": "^0.2.16",
-						"memory-fs": "~0.4.1",
-						"mkdirp": "~0.5.0",
-						"node-libs-browser": "^2.0.0",
-						"source-map": "^0.5.3",
-						"supports-color": "^3.1.0",
-						"tapable": "~0.2.5",
-						"uglify-js": "^2.8.27",
-						"watchpack": "^1.3.1",
-						"webpack-sources": "^1.0.1",
-						"yargs": "^6.0.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "^3.0.0"
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
 					}
 				}
 			}
 		},
 		"abstract-leveldown": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+			"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
 			"requires": {
 				"xtend": "~4.0.0"
 			}
@@ -400,27 +135,12 @@
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-				},
-				"mime-types": {
-					"version": "2.1.18",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"requires": {
-						"mime-db": "~1.33.0"
-					}
-				}
 			}
 		},
 		"acorn": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -443,9 +163,9 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -454,9 +174,9 @@
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -484,9 +204,12 @@
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"any-observable": {
 			"version": "0.2.0",
@@ -499,32 +222,18 @@
 			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
-			}
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -535,17 +244,19 @@
 			"integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
@@ -571,14 +282,19 @@
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
@@ -586,9 +302,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -613,18 +329,20 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
 		"ast-types": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
 			"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA=="
 		},
 		"async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-			"requires": {
-				"lodash": "^4.14.0"
-			}
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"async-each": {
 			"version": "1.0.1",
@@ -637,6 +355,16 @@
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
 				"async": "^2.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				}
 			}
 		},
 		"async-limiter": {
@@ -649,15 +377,20 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"atob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -667,12 +400,36 @@
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
 				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -684,21 +441,36 @@
 				"babel-traverse": "^6.26.0",
 				"babel-types": "^6.26.0",
 				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.0",
-				"debug": "^2.6.8",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
 				"json5": "^0.5.1",
 				"lodash": "^4.17.4",
 				"minimatch": "^3.0.4",
 				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.7",
+				"private": "^0.1.8",
 				"slash": "^1.0.0",
-				"source-map": "^0.5.6"
+				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-generator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -706,15 +478,8 @@
 				"detect-indent": "^4.0.0",
 				"jsesc": "^1.3.0",
 				"lodash": "^4.17.4",
-				"source-map": "^0.5.6",
+				"source-map": "^0.5.7",
 				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-				}
 			}
 		},
 		"babel-helper-bindify-decorators": {
@@ -872,19 +637,6 @@
 				"loader-utils": "^0.2.16",
 				"mkdirp": "^0.5.1",
 				"object-assign": "^4.0.1"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				}
 			}
 		},
 		"babel-messages": {
@@ -1123,9 +875,9 @@
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"version": "6.26.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -1273,6 +1025,14 @@
 				"regenerator-transform": "^0.10.0"
 			}
 		},
+		"babel-plugin-transform-runtime": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -1395,6 +1155,21 @@
 				"globals": "^9.18.0",
 				"invariant": "^2.2.2",
 				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-types": {
@@ -1408,15 +1183,6 @@
 				"to-fast-properties": "^1.0.3"
 			}
 		},
-		"babelify": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-			"integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-			"requires": {
-				"babel-core": "^6.0.14",
-				"object-assign": "^4.0.0"
-			}
-		},
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
@@ -1427,15 +1193,70 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
 		"base-x": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
 			"integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
 		},
 		"base64-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
@@ -1452,13 +1273,14 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bignumber.js": {
-			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-			"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
 		},
 		"binary-extensions": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"binaryextensions": {
 			"version": "2.1.1",
@@ -1491,11 +1313,24 @@
 			}
 		},
 		"bl": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+			"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
 			"requires": {
-				"readable-stream": "^2.0.5"
+				"readable-stream": "~1.0.26"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				}
 			}
 		},
 		"blakejs": {
@@ -1522,47 +1357,71 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
-				"iconv-lite": "0.4.19",
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
-			}
-		},
-		"boom": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"requires": {
-				"hoek": "4.x.x"
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"brorand": {
@@ -1576,9 +1435,9 @@
 			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
 		},
 		"browserify-aes": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -1589,9 +1448,9 @@
 			}
 		},
 		"browserify-cipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -1599,9 +1458,9 @@
 			}
 		},
 		"browserify-des": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -1623,6 +1482,13 @@
 			"integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
 			"requires": {
 				"js-sha3": "^0.3.1"
+			},
+			"dependencies": {
+				"js-sha3": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+					"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+				}
 			}
 		},
 		"browserify-sign": {
@@ -1640,11 +1506,11 @@
 			}
 		},
 		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
-				"pako": "~0.2.0"
+				"pako": "~1.0.5"
 			}
 		},
 		"bs58": {
@@ -1672,12 +1538,38 @@
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
 			}
+		},
+		"buffer-alloc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+			"integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+			"requires": {
+				"buffer-alloc-unsafe": "^0.1.0",
+				"buffer-fill": "^0.1.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+			"integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-fill": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+			"integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
 		},
 		"buffer-from": {
 			"version": "0.1.2",
@@ -1731,6 +1623,22 @@
 				"typewise-core": "^1.2"
 			}
 		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
 		"cacheable-request": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
@@ -1743,6 +1651,13 @@
 				"lowercase-keys": "1.0.0",
 				"normalize-url": "2.0.1",
 				"responselike": "1.0.2"
+			},
+			"dependencies": {
+				"lowercase-keys": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+				}
 			}
 		},
 		"cachedown": {
@@ -1752,22 +1667,17 @@
 			"requires": {
 				"abstract-leveldown": "^2.4.1",
 				"lru-cache": "^3.2.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-					"requires": {
-						"pseudomap": "^1.0.1"
-					}
-				}
 			}
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1794,15 +1704,13 @@
 			}
 		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
@@ -1819,25 +1727,23 @@
 			}
 		},
 		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 			"requires": {
-				"anymatch": "^1.3.0",
+				"anymatch": "^2.0.0",
 				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.1.2",
+				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.1",
 				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^2.1.1",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.0"
 			}
-		},
-		"chownr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 		},
 		"cids": {
 			"version": "0.5.3",
@@ -1856,6 +1762,27 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
 			}
 		},
 		"cli-cursor": {
@@ -1900,16 +1827,6 @@
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -1920,18 +1837,6 @@
 			"requires": {
 				"slice-ansi": "0.0.4",
 				"string-width": "^1.0.1"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
 			}
 		},
 		"cli-width": {
@@ -1940,13 +1845,13 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
-				"wordwrap": "0.0.2"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"clone": {
@@ -1980,35 +1885,6 @@
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
 				"readable-stream": "^2.3.5"
-			},
-			"dependencies": {
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"co": {
@@ -2037,6 +1913,15 @@
 				}
 			}
 		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -2051,27 +1936,35 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+			"integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": ">= 1.0.0"
+			}
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2079,13 +1972,21 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
+				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
+			},
+			"dependencies": {
+				"buffer-from": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+				}
 			}
 		},
 		"console-browserify": {
@@ -2095,11 +1996,6 @@
 			"requires": {
 				"date-now": "^0.1.4"
 			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -2117,9 +2013,9 @@
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-source-map": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -2131,10 +2027,15 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
 		"core-js": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-			"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+			"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -2151,29 +2052,30 @@
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
 				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -2191,22 +2093,15 @@
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			}
-		},
-		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"requires": {
-				"boom": "5.x.x"
 			},
 			"dependencies": {
-				"boom": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"hoek": "4.x.x"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -2281,11 +2176,11 @@
 			"integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+			"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "0.7.2"
 			}
 		},
 		"decamelize": {
@@ -2408,9 +2303,9 @@
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -2423,6 +2318,16 @@
 			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
 			"requires": {
 				"abstract-leveldown": "~2.6.0"
+			},
+			"dependencies": {
+				"abstract-leveldown": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+					"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+					"requires": {
+						"xtend": "~4.0.0"
+					}
+				}
 			}
 		},
 		"define-properties": {
@@ -2441,6 +2346,48 @@
 				}
 			}
 		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
 		"defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -2450,11 +2397,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -2494,18 +2436,42 @@
 			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
 		},
 		"diff": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
 		},
 		"diffie-hellman": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			}
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"dom-walk": {
@@ -2514,9 +2480,9 @@
 			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
 		},
 		"domain-browser": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"drbg.js": {
 			"version": "1.0.1",
@@ -2553,9 +2519,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
-			"version": "2.5.9",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-			"integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -2595,9 +2561,9 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2619,11 +2585,11 @@
 			"integrity": "sha512-5rfRs+m+6pwoKRCFqpsA5+qsLngFms1aWPrxfKbrObCzQaPc3M3yPloZx+BL9UE3dK58cxw36XVQbFRSCCfGSQ=="
 		},
 		"errno": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
-				"prr": "~0.0.0"
+				"prr": "~1.0.1"
 			}
 		},
 		"error": {
@@ -2644,9 +2610,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-			"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"requires": {
 				"es-to-primitive": "^1.1.1",
 				"function-bind": "^1.1.1",
@@ -2666,12 +2632,13 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.35",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+			"version": "0.10.42",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
 			"requires": {
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "~3.1.1"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "1"
 			}
 		},
 		"es6-iterator": {
@@ -2751,6 +2718,11 @@
 				"source-map": "~0.2.0"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -2779,17 +2751,16 @@
 			}
 		},
 		"esprima": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esrecurse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"requires": {
-				"estraverse": "^4.1.0",
-				"object-assign": "^4.0.1"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -2824,40 +2795,67 @@
 			}
 		},
 		"eth-gas-reporter": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.1.tgz",
-			"integrity": "sha512-ky5P27RRaDxD5EAzRL+xEBTq6uyfFj1Dyan2Epq5rfV66wEDtDkGTCYBefRaQpuXJ5C/U6Jsv5TR12qn7Mb83g==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.5.tgz",
+			"integrity": "sha512-SO3XePkWnl3d5HuIE+0jv6as03RJKRVeZ4/IQc+ukLeo6Vm5aez2/d1yfnxd2zE+MmoFGwvYuN6erk3CUxiHWg==",
 			"requires": {
 				"abi-decoder": "^1.0.8",
 				"cli-table2": "^0.2.0",
 				"colors": "^1.1.2",
 				"lodash": "^4.17.4",
+				"mocha": "^3.5.3",
 				"req-cwd": "^2.0.0",
 				"request": "^2.83.0",
 				"request-promise-native": "^1.0.5",
-				"shelljs": "^0.7.8"
+				"shelljs": "^0.7.8",
+				"solidity-parser-antlr": "^0.2.10",
+				"sync-request": "^6.0.0"
 			},
 			"dependencies": {
-				"req-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
-					"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"requires": {
-						"req-from": "^2.0.0"
+						"ms": "2.0.0"
 					}
 				},
-				"req-from": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
-					"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"mocha": {
+					"version": "3.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+					"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
 					"requires": {
-						"resolve-from": "^3.0.0"
+						"browser-stdout": "1.3.0",
+						"commander": "2.9.0",
+						"debug": "2.6.8",
+						"diff": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.1",
+						"growl": "1.9.2",
+						"he": "1.1.1",
+						"json3": "3.3.2",
+						"lodash.create": "3.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "3.1.2"
 					}
 				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
@@ -2876,13 +2874,13 @@
 			}
 		},
 		"ethereum-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-			"integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
+			"integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
 		},
 		"ethereum-ens": {
-			"version": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
-			"from": "ethereum-ens@git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
+			"version": "git+https://github.com/Arachnid/ensjs.git#48f3e968d781f44f8bf8c32476948651d4d14ef4",
+			"from": "git+https://github.com/Arachnid/ensjs.git",
 			"requires": {
 				"bluebird": "^3.4.7",
 				"eth-ens-namehash": "^2.0.0",
@@ -2893,20 +2891,10 @@
 				"web3": "^0.19.1"
 			},
 			"dependencies": {
-				"bignumber.js": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-					"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-				},
 				"js-sha3": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
 					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-				},
-				"pako": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-					"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 				},
 				"web3": {
 					"version": "0.19.1",
@@ -2923,37 +2911,35 @@
 			}
 		},
 		"ethereumjs-account": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
-			"integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+			"integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
 			"requires": {
-				"ethereumjs-util": "^4.0.1",
-				"rlp": "^2.0.0"
+				"ethereumjs-util": "^5.0.0",
+				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"ethereumjs-block": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
-			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
+			"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
 			"requires": {
-				"async": "^2.0.1",
-				"ethereum-common": "0.2.0",
-				"ethereumjs-tx": "^1.2.2",
-				"ethereumjs-util": "^5.0.0",
+				"async": "^1.5.2",
+				"ethereum-common": "0.0.16",
+				"ethereumjs-tx": "^1.0.0",
+				"ethereumjs-util": "^4.0.1",
 				"merkle-patricia-tree": "^2.1.2"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 					"requires": {
-						"babel-preset-es2015": "^6.24.0",
-						"babelify": "^7.3.0",
 						"bn.js": "^4.8.0",
 						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
+						"keccakjs": "^0.2.0",
 						"rlp": "^2.0.0",
 						"secp256k1": "^3.0.1"
 					}
@@ -2966,12 +2952,213 @@
 			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
 				"webpack": "^3.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+					"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0",
+						"uri-js": "^4.2.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "^2.0.0"
+					}
+				},
+				"webpack": {
+					"version": "3.12.0",
+					"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
+					"integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+					"requires": {
+						"acorn": "^5.0.0",
+						"acorn-dynamic-import": "^2.0.0",
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0",
+						"async": "^2.1.2",
+						"enhanced-resolve": "^3.4.0",
+						"escope": "^3.6.0",
+						"interpret": "^1.0.0",
+						"json-loader": "^0.5.4",
+						"json5": "^0.5.1",
+						"loader-runner": "^2.3.0",
+						"loader-utils": "^1.1.0",
+						"memory-fs": "~0.4.1",
+						"mkdirp": "~0.5.0",
+						"node-libs-browser": "^2.0.0",
+						"source-map": "^0.5.3",
+						"supports-color": "^4.2.1",
+						"tapable": "^0.2.7",
+						"uglifyjs-webpack-plugin": "^0.4.6",
+						"watchpack": "^1.4.0",
+						"webpack-sources": "^1.0.1",
+						"yargs": "^8.0.2"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"requires": {
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
 			}
 		},
 		"ethereumjs-tx": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
-			"integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz",
+			"integrity": "sha512-kOgUd5jC+0tgV7t52UDECMMz9Uf+Lro+6fSpCvzWemtXfMEcwI3EOxf5mVPMRbTFkMMhuERokNNVF3jItAjidg==",
 			"requires": {
 				"ethereum-common": "^0.0.18",
 				"ethereumjs-util": "^5.0.0"
@@ -2981,33 +3168,20 @@
 					"version": "0.0.18",
 					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 					"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-				},
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "^6.24.0",
-						"babelify": "^7.3.0",
-						"bn.js": "^4.8.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"secp256k1": "^3.0.1"
-					}
 				}
 			}
 		},
 		"ethereumjs-util": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-			"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
+			"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
 			"requires": {
-				"bn.js": "^4.8.0",
+				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
-				"keccakjs": "^0.2.0",
+				"ethjs-util": "^0.1.3",
+				"keccak": "^1.0.2",
 				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1",
 				"secp256k1": "^3.0.1"
 			}
 		},
@@ -3027,6 +3201,61 @@
 				"merkle-patricia-tree": "^2.1.2",
 				"rustbn.js": "~0.1.1",
 				"safe-buffer": "^5.1.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"ethereum-common": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+					"integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+				},
+				"ethereumjs-block": {
+					"version": "1.7.1",
+					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+					"integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+					"requires": {
+						"async": "^2.0.1",
+						"ethereum-common": "0.2.0",
+						"ethereumjs-tx": "^1.2.2",
+						"ethereumjs-util": "^5.0.0",
+						"merkle-patricia-tree": "^2.1.2"
+					},
+					"dependencies": {
+						"ethereumjs-util": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"requires": {
+								"bn.js": "^4.11.0",
+								"create-hash": "^1.1.2",
+								"ethjs-util": "^0.1.3",
+								"keccak": "^1.0.2",
+								"rlp": "^2.0.0",
+								"safe-buffer": "^5.1.1",
+								"secp256k1": "^3.0.1"
+							}
+						}
+					}
+				},
+				"ethereumjs-util": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+					"requires": {
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
+					}
+				}
 			}
 		},
 		"ethereumjs-wallet": {
@@ -3041,6 +3270,20 @@
 				"scrypt.js": "^0.2.0",
 				"utf8": "^2.1.1",
 				"uuid": "^2.0.1"
+			},
+			"dependencies": {
+				"ethereumjs-util": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+					"requires": {
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
+					}
+				}
 			}
 		},
 		"ethjs-unit": {
@@ -3116,11 +3359,35 @@
 			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"expand-range": {
@@ -3129,12 +3396,42 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
 				"fill-range": "^2.1.0"
+			},
+			"dependencies": {
+				"fill-range": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"requires": {
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^3.0.0",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				}
 			}
-		},
-		"expand-template": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-			"integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
@@ -3181,10 +3478,89 @@
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "~2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "~1.6.15"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": ">= 1.3.1 < 2"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 				}
 			}
 		},
@@ -3192,6 +3568,25 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
 		},
 		"external-editor": {
 			"version": "2.2.0",
@@ -3214,11 +3609,67 @@
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"extsprintf": {
@@ -3235,9 +3686,22 @@
 			}
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-glob": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.0.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.10"
+			}
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -3276,15 +3740,24 @@
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fill-range": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^1.1.3",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"finalhandler": {
@@ -3299,6 +3772,26 @@
 				"parseurl": "~1.3.2",
 				"statuses": "~1.4.0",
 				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
 			}
 		},
 		"find-cache-dir": {
@@ -3333,9 +3826,9 @@
 			"integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
 		},
 		"flow-parser": {
-			"version": "0.70.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
-			"integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg=="
+			"version": "0.72.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.72.0.tgz",
+			"integrity": "sha512-kFaDtviKlD/rHi6NRp42KTbnPgz/nKcWUJQhqDnLDeKA8uGcRVSy0YlQjaf9M3pFo5PgC3SNFnCPpQGLtHjH2w=="
 		},
 		"for-each": {
 			"version": "0.3.2",
@@ -3369,12 +3862,12 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.5",
+				"combined-stream": "1.0.6",
 				"mime-types": "^2.1.12"
 			}
 		},
@@ -3382,6 +3875,14 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
 		},
 		"fresh": {
 			"version": "0.5.2",
@@ -3397,16 +3898,19 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs-extra": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-			"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"jsonfile": "^2.1.0",
-				"klaw": "^1.0.0",
-				"path-is-absolute": "^1.0.0",
-				"rimraf": "^2.2.8"
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs-promise": {
@@ -3428,6 +3932,14 @@
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^2.1.0"
 					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
 				}
 			}
 		},
@@ -3437,291 +3949,111 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"optional": true,
 			"requires": {
-				"nan": "^2.3.0",
-				"node-pre-gyp": "^0.6.39"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+					"version": "1.1.1",
+					"bundled": true,
 					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"optional": true,
-					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true
 				},
 				"aproba": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+					"version": "1.2.0",
+					"bundled": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
 					}
 				},
-				"asn1": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-					"optional": true
-				},
 				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-					"optional": true,
-					"requires": {
-						"tweetnacl": "^0.14.3"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-					"requires": {
-						"inherits": "~2.0.0"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-					"requires": {
-						"hoek": "2.x.x"
-					}
+					"version": "1.0.0",
+					"bundled": true
 				},
 				"brace-expansion": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"version": "1.1.11",
+					"bundled": true,
 					"requires": {
-						"balanced-match": "^0.4.1",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-					"requires": {
-						"delayed-stream": "~1.0.0"
-					}
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-					"requires": {
-						"boom": "2.x.x"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
+					"bundled": true,
+					"optional": true
 				},
 				"debug": {
-					"version": "2.6.8",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"version": "2.6.9",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"deep-extend": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"version": "0.5.1",
+					"bundled": true,
 					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
 					"optional": true
 				},
 				"detect-libc": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+					"version": "1.0.3",
+					"bundled": true,
 					"optional": true
 				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-					"optional": true,
-					"requires": {
-						"fstream": "^1.0.0",
-						"inherits": "2",
-						"minimatch": "^3.0.0"
-					}
+					"bundled": true,
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -3734,27 +4066,10 @@
 						"wide-align": "^1.1.0"
 					}
 				},
-				"getpass": {
-					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
-				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
+					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -3764,64 +4079,31 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"optional": true,
-					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
-					}
-				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"optional": true
 				},
-				"hawk": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
+					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -3829,175 +4111,117 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true
 				},
 				"ini": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+					"version": "1.3.5",
+					"bundled": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-					"optional": true
-				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"bundled": true,
 					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-					"optional": true,
-					"requires": {
-						"jsbn": "~0.1.0"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-					"optional": true,
-					"requires": {
-						"jsonify": "~0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-					"requires": {
-						"mime-db": "~1.27.0"
-					}
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"optional": true
 				},
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
 				"node-pre-gyp": {
-					"version": "0.6.39",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+					"version": "0.10.0",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
-						"hawk": "3.1.3",
 						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
 						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
 						"rc": "^1.1.7",
-						"request": "2.81.0",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
-						"tar": "^2.2.1",
-						"tar-pack": "^3.4.0"
+						"tar": "^4"
 					}
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
 						"osenv": "^0.1.4"
 					}
 				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
 				"npmlog": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+					"version": "4.1.2",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -4008,45 +4232,33 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"osenv": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+					"version": "0.1.5",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -4055,39 +4267,20 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+					"bundled": true,
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"version": "2.0.0",
+					"bundled": true,
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+					"version": "1.2.7",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
+						"deep-extend": "^0.5.1",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -4095,124 +4288,65 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
-					"version": "2.2.9",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+					"version": "2.3.6",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
+						"inherits": "~2.0.3",
 						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
 						"util-deprecate": "~1.0.1"
 					}
 				},
-				"request": {
-					"version": "2.81.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"optional": true,
-					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
-					}
-				},
 				"rimraf": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"version": "2.6.2",
+					"bundled": true,
+					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"optional": true
 				},
 				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"version": "5.5.0",
+					"bundled": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-					"requires": {
-						"hoek": "2.x.x"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-					"optional": true,
-					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jodid25519": "^1.0.0",
-						"jsbn": "~0.1.0",
-						"tweetnacl": "~0.14.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4220,113 +4354,47 @@
 					}
 				},
 				"string_decoder": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "~5.1.0"
 					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"optional": true
 				},
 				"tar": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+					"version": "4.4.1",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.2.0",
-						"fstream": "^1.0.10",
-						"fstream-ignore": "^1.0.5",
-						"once": "^1.3.3",
-						"readable-stream": "^2.1.4",
-						"rimraf": "^2.5.1",
-						"tar": "^2.2.1",
-						"uid-number": "^0.0.6"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-					"optional": true,
-					"requires": {
-						"punycode": "^1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+					"bundled": true,
 					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -4334,8 +4402,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true
 				}
 			}
 		},
@@ -4380,9 +4451,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-					"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -4427,255 +4498,6 @@
 				"yargs": "^7.0.2"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
-				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-					"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
-				},
-				"debug": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-					"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-					"requires": {
-						"ms": "0.7.2"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"ethereum-common": {
-					"version": "0.0.16",
-					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
-					"integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
-				},
-				"ethereumjs-block": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
-					"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
-					"requires": {
-						"async": "^1.5.2",
-						"ethereum-common": "0.0.16",
-						"ethereumjs-tx": "^1.0.0",
-						"ethereumjs-util": "^4.0.1",
-						"merkle-patricia-tree": "^2.1.2"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "4.5.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-							"requires": {
-								"bn.js": "^4.8.0",
-								"create-hash": "^1.1.2",
-								"keccakjs": "^0.2.0",
-								"rlp": "^2.0.0",
-								"secp256k1": "^3.0.1"
-							}
-						}
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.1.5",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
-					"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.2",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				},
-				"mocha": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
-					"integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
-					"requires": {
-						"browser-stdout": "1.3.0",
-						"commander": "2.9.0",
-						"debug": "2.6.0",
-						"diff": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"glob": "7.1.1",
-						"growl": "1.9.2",
-						"json3": "3.3.2",
-						"lodash.create": "3.1.1",
-						"mkdirp": "0.5.1",
-						"supports-color": "3.1.2"
-					}
-				},
-				"ms": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				},
 				"web3": {
 					"version": "0.19.1",
 					"resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
@@ -4687,121 +4509,6 @@
 						"xhr2": "*",
 						"xmlhttprequest": "*"
 					}
-				},
-				"web3-provider-engine": {
-					"version": "8.1.19",
-					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
-					"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
-					"requires": {
-						"async": "^2.1.2",
-						"clone": "^2.0.0",
-						"ethereumjs-block": "^1.2.2",
-						"ethereumjs-tx": "^1.2.0",
-						"ethereumjs-util": "^5.0.1",
-						"ethereumjs-vm": "^2.0.2",
-						"isomorphic-fetch": "^2.2.0",
-						"request": "^2.67.0",
-						"semaphore": "^1.0.3",
-						"solc": "^0.4.2",
-						"tape": "^4.4.0",
-						"web3": "^0.16.0",
-						"xhr": "^2.2.0",
-						"xtend": "^4.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "2.6.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-							"requires": {
-								"lodash": "^4.14.0"
-							}
-						},
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-						},
-						"web3": {
-							"version": "0.16.0",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-							"requires": {
-								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-								"crypto-js": "^3.1.4",
-								"utf8": "^2.1.1",
-								"xmlhttprequest": "*"
-							},
-							"dependencies": {
-								"bignumber.js": {
-									"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-									"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-								}
-							}
-						}
-					}
-				},
-				"webpack": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
-					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
-					"requires": {
-						"acorn": "^5.0.0",
-						"acorn-dynamic-import": "^2.0.0",
-						"ajv": "^4.7.0",
-						"ajv-keywords": "^1.1.1",
-						"async": "^2.1.2",
-						"enhanced-resolve": "^3.3.0",
-						"interpret": "^1.0.0",
-						"json-loader": "^0.5.4",
-						"json5": "^0.5.1",
-						"loader-runner": "^2.3.0",
-						"loader-utils": "^0.2.16",
-						"memory-fs": "~0.4.1",
-						"mkdirp": "~0.5.0",
-						"node-libs-browser": "^2.0.0",
-						"source-map": "^0.5.3",
-						"supports-color": "^3.1.0",
-						"tapable": "~0.2.5",
-						"uglify-js": "^2.8.27",
-						"watchpack": "^1.3.1",
-						"webpack-sources": "^1.0.1",
-						"yargs": "^6.0.0"
-					},
-					"dependencies": {
-						"async": {
-							"version": "2.6.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-							"requires": {
-								"lodash": "^4.14.0"
-							}
-						},
-						"yargs": {
-							"version": "6.6.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-							"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-							"requires": {
-								"camelcase": "^3.0.0",
-								"cliui": "^3.2.0",
-								"decamelize": "^1.1.1",
-								"get-caller-file": "^1.0.1",
-								"os-locale": "^1.4.0",
-								"read-pkg-up": "^1.0.1",
-								"require-directory": "^2.1.1",
-								"require-main-filename": "^1.0.1",
-								"set-blocking": "^2.0.0",
-								"string-width": "^1.0.2",
-								"which-module": "^1.0.0",
-								"y18n": "^3.2.1",
-								"yargs-parser": "^4.2.0"
-							}
-						}
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"yargs": {
 					"version": "7.1.0",
@@ -4821,51 +4528,14 @@
 						"which-module": "^1.0.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^5.0.0"
-					},
-					"dependencies": {
-						"yargs-parser": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-							"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-							"requires": {
-								"camelcase": "^3.0.0"
-							}
-						}
 					}
 				},
 				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 					"requires": {
 						"camelcase": "^3.0.0"
-					}
-				}
-			}
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -4880,10 +4550,20 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -4907,11 +4587,6 @@
 			"resolved": "https://registry.npmjs.org/git-clone/-/git-clone-0.1.0.tgz",
 			"integrity": "sha1-DXYWN3gJOu9/HDAjjyqe8/B6Lrk="
 		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-		},
 		"github-username": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
@@ -4921,13 +4596,14 @@
 			}
 		},
 		"glob": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 			"requires": {
+				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "2 || 3",
+				"minimatch": "^3.0.2",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
@@ -4941,19 +4617,6 @@
 				"yargs": "~1.2.6"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
@@ -4976,6 +4639,29 @@
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
 			}
 		},
 		"glob-escape": {
@@ -4984,12 +4670,28 @@
 			"integrity": "sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0="
 		},
 		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
+		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global": {
 			"version": "4.3.2",
@@ -4998,13 +4700,6 @@
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
-			},
-			"dependencies": {
-				"process": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-				}
 			}
 		},
 		"global-modules": {
@@ -5035,15 +4730,17 @@
 			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"requires": {
 				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -5058,6 +4755,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -5116,10 +4818,14 @@
 				"uglify-js": "^2.6"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
 				},
 				"source-map": {
 					"version": "0.4.4",
@@ -5167,9 +4873,9 @@
 			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-localstorage": {
 			"version": "1.0.1",
@@ -5189,17 +4895,42 @@
 				"has-symbol-support-x": "^1.4.1"
 			}
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"hash-base": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"requires": {
-				"inherits": "^2.0.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"hash.js": {
@@ -5209,17 +4940,6 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"hawk": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"requires": {
-				"boom": "4.x.x",
-				"cryptiles": "3.x.x",
-				"hoek": "4.x.x",
-				"sntp": "2.x.x"
 			}
 		},
 		"hdkey": {
@@ -5251,11 +4971,6 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
-		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -5279,9 +4994,22 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"http-basic": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/http-basic/-/http-basic-7.0.0.tgz",
+			"integrity": "sha1-gvClBr6UJzLsje6+6A50bvVzbbo=",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/node": "^9.4.1",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.4.6",
+				"http-response-object": "^3.0.1",
+				"parse-cache-control": "^1.0.1"
+			}
 		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
@@ -5289,27 +5017,28 @@
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
-				"depd": "1.1.1",
+				"depd": "~1.1.2",
 				"inherits": "2.0.3",
-				"setprototypeof": "1.0.3",
-				"statuses": ">= 1.3.1 < 2"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-				}
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
 			}
 		},
 		"http-https": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
 			"integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
+		},
+		"http-response-object": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.1.tgz",
+			"integrity": "sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==",
+			"requires": {
+				"@types/node": "^9.3.0"
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -5322,9 +5051,9 @@
 			}
 		},
 		"https-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"humble-localstorage": {
 			"version": "1.4.2",
@@ -5336,9 +5065,12 @@
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"idna-uts46-hx": {
 			"version": "2.3.1",
@@ -5346,19 +5078,17 @@
 			"integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
 			"requires": {
 				"punycode": "2.1.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-				}
 			}
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+		},
+		"ignore": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
 		},
 		"immediate": {
 			"version": "3.2.3",
@@ -5417,9 +5147,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "5.2.0",
@@ -5446,28 +5176,19 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -5476,21 +5197,13 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"interpret": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-			"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"into-stream": {
 			"version": "3.1.0",
@@ -5502,9 +5215,9 @@
 			}
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -5559,6 +5272,14 @@
 				"tar-stream": "^1.5.4"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -5586,6 +5307,15 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -5625,6 +5355,14 @@
 				"stable": "^0.1.6"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -5641,6 +5379,14 @@
 						"base-x": "^3.0.2"
 					}
 				}
+			}
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"requires": {
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -5674,10 +5420,35 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
 			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -5698,9 +5469,9 @@
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -5724,11 +5495,11 @@
 			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-hex-prefixed": {
@@ -5770,9 +5541,9 @@
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -5797,10 +5568,33 @@
 				}
 			}
 		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"requires": {
+				"is-number": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
+		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
@@ -5864,9 +5658,14 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isbinaryfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+			"integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -5874,12 +5673,9 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
@@ -5916,15 +5712,32 @@
 				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -5990,9 +5803,9 @@
 			}
 		},
 		"js-sha3": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
-			"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
+			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -6005,19 +5818,12 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				}
 			}
 		},
 		"jsbn": {
@@ -6048,17 +5854,89 @@
 				"write-file-atomic": "^1.2.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
 				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+					"version": "7.0.0-beta.47",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
 				}
 			}
 		},
 		"jsesc": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-buffer": {
 			"version": "3.0.0",
@@ -6109,9 +5987,9 @@
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -6133,14 +6011,13 @@
 			}
 		},
 		"keccak": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
-			"integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+			"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
 			"requires": {
 				"bindings": "^1.2.1",
 				"inherits": "^2.0.3",
 				"nan": "^2.2.1",
-				"prebuild-install": "^2.0.0",
 				"safe-buffer": "^5.1.0"
 			}
 		},
@@ -6219,11 +6096,6 @@
 				"xtend": "^4.0.0"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -6234,11 +6106,6 @@
 						"isarray": "0.0.1",
 						"string_decoder": "~0.10.x"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -6251,15 +6118,16 @@
 			}
 		},
 		"level-sublevel": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
-			"integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
+			"integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
 			"requires": {
 				"bytewise": "~1.1.0",
 				"levelup": "~0.19.0",
 				"ltgt": "~2.1.1",
+				"pull-defer": "^0.2.2",
 				"pull-level": "^2.0.3",
-				"pull-stream": "^3.4.5",
+				"pull-stream": "^3.6.8",
 				"typewiselite": "~1.0.0",
 				"xtend": "~4.0.0"
 			},
@@ -6279,14 +6147,6 @@
 						}
 					}
 				},
-				"bl": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-					"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-					"requires": {
-						"readable-stream": "~1.0.26"
-					}
-				},
 				"deferred-leveldown": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
@@ -6294,11 +6154,6 @@
 					"requires": {
 						"abstract-leveldown": "~0.12.1"
 					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"levelup": {
 					"version": "0.19.1",
@@ -6326,6 +6181,11 @@
 					"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
 					"integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
 				},
+				"prr": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -6341,11 +6201,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
 					"integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -6358,11 +6213,6 @@
 				"xtend": "~2.1.1"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -6373,11 +6223,6 @@
 						"isarray": "0.0.1",
 						"string_decoder": "~0.10.x"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xtend": {
 					"version": "2.1.2",
@@ -6403,10 +6248,10 @@
 				"xtend": "~4.0.0"
 			},
 			"dependencies": {
-				"prr": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+				"semver": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
 				}
 			}
 		},
@@ -6449,6 +6294,14 @@
 						"minimalistic-assert": "^1.0.0"
 					}
 				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -6482,6 +6335,16 @@
 				"nodeify": "^1.0.1",
 				"safe-buffer": "^5.1.1",
 				"secp256k1": "^3.3.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				}
 			}
 		},
 		"listr": {
@@ -6508,6 +6371,23 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"figures": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -6529,6 +6409,11 @@
 					"requires": {
 						"chalk": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -6552,6 +6437,23 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"figures": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -6573,6 +6475,11 @@
 					"requires": {
 						"chalk": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -6587,6 +6494,23 @@
 				"figures": "^1.7.0"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -6617,18 +6541,24 @@
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
 				"pify": "^2.0.0",
-				"strip-bom": "^3.0.0"
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"loader-runner": {
@@ -6637,13 +6567,14 @@
 			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
 		},
 		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 			"requires": {
 				"big.js": "^3.1.3",
 				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"json5": "^0.5.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"localstorage-down": {
@@ -6690,9 +6621,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",
@@ -6779,39 +6710,6 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"requires": {
 				"chalk": "^2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"log-update": {
@@ -6871,28 +6769,27 @@
 			}
 		},
 		"lowercase-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "^1.0.1"
 			}
 		},
 		"ltgt": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-			"integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
 		},
 		"make-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
 				"pify": "^3.0.0"
 			},
@@ -6904,6 +6801,24 @@
 				}
 			}
 		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"math-random": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+		},
 		"md5.js": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -6911,17 +6826,6 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
-			},
-			"dependencies": {
-				"hash-base": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
-				}
 			}
 		},
 		"media-typer": {
@@ -6948,15 +6852,16 @@
 			}
 		},
 		"mem-fs-editor": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+			"integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
 			"requires": {
 				"commondir": "^1.0.1",
-				"deep-extend": "^0.4.0",
-				"ejs": "^2.3.1",
+				"deep-extend": "^0.5.1",
+				"ejs": "^2.5.9",
 				"glob": "^7.0.3",
-				"globby": "^6.1.0",
+				"globby": "^8.0.0",
+				"isbinaryfile": "^3.0.2",
 				"mkdirp": "^0.5.0",
 				"multimatch": "^2.0.0",
 				"rimraf": "^2.2.8",
@@ -6968,19 +6873,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
 					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
 				},
 				"replace-ext": {
 					"version": "1.0.0",
@@ -7013,16 +6905,6 @@
 				"inherits": "~2.0.1",
 				"ltgt": "~2.2.0",
 				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				}
 			}
 		},
 		"memory-fs": {
@@ -7044,26 +6926,24 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
+		"merge2": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
+		},
 		"merkle-patricia-tree": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.2.0.tgz",
-			"integrity": "sha1-ekeHsSYqsA/psgSrRxsAUzIwbvo=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+			"integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
 			"requires": {
 				"async": "^1.4.2",
-				"ethereumjs-util": "^4.0.0",
+				"ethereumjs-util": "^5.0.0",
 				"level-ws": "0.0.0",
 				"levelup": "^1.2.1",
 				"memdown": "^1.0.0",
 				"readable-stream": "^2.0.0",
 				"rlp": "^2.0.0",
 				"semaphore": ">=1.0.1"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				}
 			}
 		},
 		"methods": {
@@ -7072,23 +6952,30 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"miller-rabin": {
@@ -7106,22 +6993,22 @@
 			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "~1.30.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.0",
@@ -7137,9 +7024,9 @@
 			}
 		},
 		"minimalistic-assert": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
@@ -7159,6 +7046,25 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -7176,74 +7082,42 @@
 			}
 		},
 		"mocha": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-			"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
+			"integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
 			"requires": {
-				"commander": "2.3.0",
-				"debug": "2.2.0",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.2",
-				"glob": "3.2.11",
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.0",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
 				"growl": "1.9.2",
-				"jade": "0.26.3",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
 				"mkdirp": "0.5.1",
-				"supports-color": "1.2.0",
-				"to-iso-string": "0.0.2"
+				"supports-color": "3.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
-				},
-				"glob": {
-					"version": "3.2.11",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-					"requires": {
-						"inherits": "2",
-						"minimatch": "0.3"
-					}
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
 		"mock-fs": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.2.tgz",
-			"integrity": "sha512-dF+yxZSojSiI8AXGoxj5qdFWpucndc54Ug+TwlpHFaV7j22MGG+OML2+FVa6xAZtjb/OFFQhOC37Jegx2GbEwA=="
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
+			"integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w=="
 		},
 		"mout": {
 			"version": "0.11.1",
@@ -7251,14 +7125,14 @@
 			"integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+			"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
 		},
 		"multiaddr": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.0.2.tgz",
-			"integrity": "sha512-TLEujk9VD1SR8HgV00rr1I3MWOk4t0GSDvxzzOO1m1hfxdv4DkFHmKKUHngUCiWHDeClHKSSV23Ig5/Mav3MQw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
+			"integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
 			"requires": {
 				"bs58": "^4.0.1",
 				"ip": "^1.1.5",
@@ -7352,10 +7226,13 @@
 				"nodeify": "^1.0.1"
 			},
 			"dependencies": {
-				"js-sha3": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-					"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				}
 			}
 		},
@@ -7401,14 +7278,40 @@
 			}
 		},
 		"nan": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
 		},
 		"nano-json-stream-parser": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
 			"integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
 		},
 		"ndjson": {
 			"version": "1.5.0",
@@ -7438,18 +7341,15 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
 			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
 		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		},
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
 			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
-		},
-		"node-abi": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
-			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
-			"requires": {
-				"semver": "^5.4.1"
-			}
 		},
 		"node-dir": {
 			"version": "0.1.8",
@@ -7466,44 +7366,57 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-			"integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
 		},
 		"node-libs-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"requires": {
 				"assert": "^1.1.1",
-				"browserify-zlib": "^0.1.4",
+				"browserify-zlib": "^0.2.0",
 				"buffer": "^4.3.0",
 				"console-browserify": "^1.1.0",
 				"constants-browserify": "^1.0.0",
 				"crypto-browserify": "^3.11.0",
 				"domain-browser": "^1.1.1",
 				"events": "^1.0.0",
-				"https-browserify": "0.0.1",
-				"os-browserify": "^0.2.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "^0.11.0",
+				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.0.5",
+				"readable-stream": "^2.3.3",
 				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.3.1",
-				"string_decoder": "^0.10.25",
-				"timers-browserify": "^2.0.2",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
 				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
+				"process": {
+					"version": "0.11.10",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
 				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
 				}
 			}
 		},
@@ -7551,11 +7464,6 @@
 					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
 			}
-		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -7609,17 +7517,6 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -7651,15 +7548,43 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
 		"object-inspect": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-			"integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+			"integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
 		},
 		"object-keys": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
 			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "^3.0.0"
+			}
 		},
 		"object.omit": {
 			"version": "2.0.1",
@@ -7668,6 +7593,14 @@
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "^3.0.1"
 			}
 		},
 		"oboe": {
@@ -7708,11 +7641,10 @@
 			}
 		},
 		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+			"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
 			"requires": {
-				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
 			}
 		},
@@ -7747,6 +7679,23 @@
 				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -7768,6 +7717,11 @@
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -7777,9 +7731,9 @@
 			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
 		},
 		"os-browserify": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
@@ -7787,13 +7741,11 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -7830,9 +7782,12 @@
 			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
 		},
 		"p-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "^1.0.0"
+			}
 		},
 		"p-locate": {
 			"version": "2.0.0",
@@ -7860,15 +7815,20 @@
 				"p-finally": "^1.0.0"
 			}
 		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
 		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 		},
 		"parse-asn1": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -7876,6 +7836,11 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3"
 			}
+		},
+		"parse-cache-control": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+			"integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -7886,6 +7851,21 @@
 				"is-dotfile": "^1.0.0",
 				"is-extglob": "^1.0.0",
 				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
 			}
 		},
 		"parse-headers": {
@@ -7915,10 +7895,20 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
 			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -7946,17 +7936,19 @@
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"pify": "^2.0.0"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -7966,9 +7958,9 @@
 			}
 		},
 		"peer-id": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.6.tgz",
-			"integrity": "sha512-NyJgPRy108amQClcuBI/VZtyFJLDaTsPC3nVhZ87mpY5JVFmI2Er4atMap6/ToRJxm/RBX1Nh8CMxzlXCpfKKw==",
+			"version": "0.10.7",
+			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+			"integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
 			"requires": {
 				"async": "^2.6.0",
 				"libp2p-crypto": "~0.12.1",
@@ -7976,10 +7968,13 @@
 				"multihashes": "~0.4.13"
 			},
 			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				}
 			}
 		},
@@ -8079,33 +8074,10 @@
 				}
 			}
 		},
-		"prebuild-install": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-			"integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
-			"requires": {
-				"expand-template": "^1.0.2",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"node-abi": "^2.1.1",
-				"noop-logger": "^0.1.1",
-				"npmlog": "^4.0.1",
-				"os-homedir": "^1.0.1",
-				"pump": "^1.0.1",
-				"rc": "^1.1.6",
-				"simple-get": "^1.4.2",
-				"tar-fs": "^1.13.0",
-				"tunnel-agent": "^0.6.0",
-				"xtend": "4.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -8146,14 +8118,14 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise": {
 			"version": "1.3.0",
@@ -8199,9 +8171,9 @@
 			}
 		},
 		"prr": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -8209,9 +8181,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -8224,6 +8196,11 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
 			"integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+		},
+		"pull-defer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
+			"integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
 		},
 		"pull-level": {
 			"version": "2.0.4",
@@ -8254,9 +8231,9 @@
 			"integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
 		},
 		"pull-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz",
-			"integrity": "sha1-HqFMbxMXTmrE3vDCpOdlZ7fLDFw="
+			"version": "3.6.8",
+			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.8.tgz",
+			"integrity": "sha512-wQUIptQBcM0rFsUhZoEpOT3vUn73DtTGVq3NQ86c4T7iMOSprDzeKWYq2ksXnbwiuExTKvt+8G9fzNLFQuiO+A=="
 		},
 		"pull-traverse": {
 			"version": "1.0.3",
@@ -8272,23 +8249,23 @@
 			}
 		},
 		"pump": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-			"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
 			}
 		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 		},
 		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "5.1.1",
@@ -8311,54 +8288,39 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"randomatic": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				},
 				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"randombytes": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -8375,32 +8337,14 @@
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
 			"requires": {
 				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
 				"unpipe": "1.0.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-			"requires": {
-				"deep-extend": "~0.4.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
 			}
 		},
 		"read-chunk": {
@@ -8420,36 +8364,70 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				}
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
 				"isarray": "~1.0.0",
-				"process-nextick-args": "~1.0.6",
+				"process-nextick-args": "~2.0.0",
 				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.0.3",
+				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
 			}
 		},
 		"readdirp": {
@@ -8474,11 +8452,6 @@
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8495,14 +8468,14 @@
 			}
 		},
 		"regenerate": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerator-runtime": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
@@ -8520,6 +8493,15 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -8543,6 +8525,13 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
 				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
 			}
 		},
 		"remove-trailing-separator": {
@@ -8574,25 +8563,25 @@
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"req-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
-			"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
+			"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
 			"requires": {
-				"req-from": "^1.0.1"
+				"req-from": "^2.0.0"
 			}
 		},
 		"req-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
-			"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
+			"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
 			"requires": {
-				"resolve-from": "^2.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.6.0",
@@ -8602,7 +8591,6 @@
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.1",
 				"har-validator": "~5.0.3",
-				"hawk": "~6.0.2",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -8612,16 +8600,15 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.1",
 				"safe-buffer": "^5.1.1",
-				"stringstream": "~0.0.5",
 				"tough-cookie": "~2.3.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"uuid": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 				}
 			}
 		},
@@ -8659,9 +8646,12 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"requires": {
+				"path-parse": "^1.0.5"
+			}
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
@@ -8669,13 +8659,6 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
 				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				}
 			}
 		},
 		"resolve-dir": {
@@ -8688,9 +8671,14 @@
 			}
 		},
 		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"responselike": {
 			"version": "1.0.2",
@@ -8717,6 +8705,11 @@
 				"through": "~2.3.4"
 			}
 		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -8731,29 +8724,14 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
 				"glob": "^7.0.5"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"ripemd160": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"requires": {
-				"hash-base": "^2.0.0",
+				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
 			}
 		},
@@ -8784,16 +8762,6 @@
 			"integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
 			"requires": {
 				"optimist": "~0.3.5"
-			},
-			"dependencies": {
-				"optimist": {
-					"version": "0.3.7",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-					"requires": {
-						"wordwrap": "~0.0.2"
-					}
-				}
 			}
 		},
 		"run-async": {
@@ -8812,22 +8780,9 @@
 			}
 		},
 		"rustbn.js": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
-			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"requires": {
-				"rx-lite": "*"
-			}
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+			"integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
 		},
 		"rxjs": {
 			"version": "5.5.10",
@@ -8838,9 +8793,22 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sandwich-stream": {
 			"version": "1.0.0",
@@ -8878,9 +8846,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
-			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+			"integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
 			"requires": {
 				"bindings": "^1.2.1",
 				"bip66": "^1.1.3",
@@ -8889,7 +8857,6 @@
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.2.3",
 				"nan": "^2.2.1",
-				"prebuild-install": "^2.0.0",
 				"safe-buffer": "^5.1.0"
 			}
 		},
@@ -8922,9 +8889,9 @@
 			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
 		},
 		"semver": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"send": {
 			"version": "0.16.2",
@@ -8944,6 +8911,26 @@
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.0",
 				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
 			}
 		},
 		"serve-static": {
@@ -8979,31 +8966,52 @@
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-			"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"sha.js": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
 		},
 		"sha3": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
-			"integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+			"integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
 			"requires": {
-				"nan": "^2.0.5"
+				"nan": "2.10.0"
 			}
 		},
 		"shebang-command": {
@@ -9032,21 +9040,6 @@
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
 				"rechoir": "^0.6.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"sigmund": {
@@ -9073,13 +9066,13 @@
 			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
 		},
 		"simple-get": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-			"integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
 			"requires": {
+				"decompress-response": "^3.3.0",
 				"once": "^1.3.1",
-				"unzip-response": "^1.0.0",
-				"xtend": "^4.0.0"
+				"simple-concat": "^1.0.0"
 			}
 		},
 		"slash": {
@@ -9097,12 +9090,96 @@
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
 			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
-		"sntp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"hoek": "4.x.x"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sol-digger": {
@@ -9127,114 +9204,25 @@
 				"yargs": "^4.7.1"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+				"fs-extra": {
+					"version": "0.30.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 					"requires": {
-						"lcid": "^1.0.0"
+						"graceful-fs": "^4.1.6"
 					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
 					"version": "4.8.1",
@@ -9255,15 +9243,6 @@
 						"window-size": "^0.2.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"lodash.assign": "^4.0.6"
 					}
 				}
 			}
@@ -9282,7 +9261,51 @@
 				"sol-explore": "^1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "^0.18.4"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"req-cwd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
+					"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
+					"requires": {
+						"req-from": "^1.0.1"
+					}
+				},
+				"req-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
+					"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
+					"requires": {
+						"resolve-from": "^2.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				}
 			}
+		},
+		"solidity-parser-antlr": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz",
+			"integrity": "sha512-g1RWj6m377CBlUBlyffhv4UOO48ue+gL7GlmE9i77N8bxaKgzWvTl1xzvDadaubJoz2euPpk3A7qTPbqkUof1w=="
 		},
 		"solidity-parser-sc": {
 			"version": "0.4.1",
@@ -9294,114 +9317,78 @@
 				"yargs": "^4.6.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				"commander": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"ms": "0.7.1"
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"os-locale": {
+				"diff": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
+				"escape-string-regexp": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"inherits": "2",
+						"minimatch": "0.3"
 					}
 				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"lru-cache": "2",
+						"sigmund": "~1.0.0"
 					}
 				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				"mocha": {
+					"version": "2.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+					"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+					"requires": {
+						"commander": "2.3.0",
+						"debug": "2.2.0",
+						"diff": "1.4.0",
+						"escape-string-regexp": "1.0.2",
+						"glob": "3.2.11",
+						"growl": "1.9.2",
+						"jade": "0.26.3",
+						"mkdirp": "0.5.1",
+						"supports-color": "1.2.0",
+						"to-iso-string": "0.0.2"
+					}
 				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"supports-color": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
 				},
 				"yargs": {
 					"version": "4.8.1",
@@ -9423,22 +9410,13 @@
 						"y18n": "^3.2.1",
 						"yargs-parser": "^2.4.1"
 					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"lodash.assign": "^4.0.6"
-					}
 				}
 			}
 		},
 		"solium": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/solium/-/solium-1.0.4.tgz",
-			"integrity": "sha512-IiWV5YLSuRplNAOXMhrOH8yi5J4PbNEbZaxhSdxtgEeK9tA6OXcAvwTsq2I8qRzqf6m3Bxr6OhiGboQaLtGC4Q==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/solium/-/solium-1.1.7.tgz",
+			"integrity": "sha512-yYbalsrzJCU+QJ0HZvxAT4IQIqI1e6KPW2vop0NaHwdijqhQC9fJkVioCrL18NbO2Z8rdcnx8Y0JpvYJWrIjRg==",
 			"requires": {
 				"ajv": "^5.2.2",
 				"chokidar": "^1.6.0",
@@ -9447,42 +9425,59 @@
 				"js-string-escape": "^1.0.1",
 				"lodash": "^4.14.2",
 				"sol-digger": "0.0.2",
-				"sol-explore": "^1.6.1",
-				"solium-plugin-security": "0.0.2",
-				"solparse": "1.4.0"
+				"sol-explore": "1.6.1",
+				"solium-plugin-security": "0.1.1",
+				"solparse": "2.2.5",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
 					}
 				},
-				"commander": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"requires": {
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
+					}
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -9497,6 +9492,22 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
 					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
 				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -9510,15 +9521,61 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
 				"growl": {
 					"version": "1.10.3",
 					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
 					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
 				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
 				"mocha": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+					"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
 					"requires": {
 						"browser-stdout": "1.3.0",
 						"commander": "2.11.0",
@@ -9530,12 +9587,29 @@
 						"he": "1.1.1",
 						"mkdirp": "0.5.1",
 						"supports-color": "4.4.0"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.11.0",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+							"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+						}
 					}
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"sol-explore": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/sol-explore/-/sol-explore-1.6.1.tgz",
+					"integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs="
+				},
 				"solparse": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
-					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.5.tgz",
+					"integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
 					"requires": {
 						"mocha": "^4.0.1",
 						"pegjs": "^0.10.0",
@@ -9549,40 +9623,13 @@
 					"requires": {
 						"has-flag": "^2.0.0"
 					}
-				},
-				"yargs": {
-					"version": "10.0.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-					"requires": {
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
 				}
 			}
 		},
 		"solium-plugin-security": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.0.2.tgz",
-			"integrity": "sha512-2xjJoAWeY1Ynz1ExxtCVSABAMPrDV/AqhjE/X6jXMHJ1ubT+j9kDt5HKaHNOCa2MWoTna281HzcZlTioR1/ObA=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+			"integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
 		},
 		"sort-keys": {
 			"version": "2.0.0",
@@ -9602,6 +9649,18 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -9610,23 +9669,46 @@
 				"source-map": "^0.5.6"
 			}
 		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
 		"spdx-correct": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-license-ids": "^1.0.2"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
 		"spdx-expression-parse": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
 		},
 		"spdx-license-ids": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
 		},
 		"split2": {
 			"version": "2.2.0",
@@ -9642,9 +9724,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -9657,14 +9739,33 @@
 			}
 		},
 		"stable": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-			"integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
 		},
 		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -9681,13 +9782,13 @@
 			}
 		},
 		"stream-http": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
-				"readable-stream": "^2.2.6",
+				"readable-stream": "^2.3.6",
 				"to-arraybuffer": "^1.0.0",
 				"xtend": "^4.0.0"
 			}
@@ -9740,32 +9841,13 @@
 			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string.prototype.trim": {
@@ -9779,17 +9861,9 @@
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -9800,9 +9874,12 @@
 			}
 		},
 		"strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
+			}
 		},
 		"strip-bom-stream": {
 			"version": "2.0.0",
@@ -9811,16 +9888,6 @@
 			"requires": {
 				"first-chunk-stream": "^2.0.0",
 				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				}
 			}
 		},
 		"strip-dirs": {
@@ -9844,15 +9911,13 @@
 				"is-hex-prefixed": "1.0.0"
 			}
 		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-		},
 		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"swarm-js": {
 			"version": "0.1.37",
@@ -9891,6 +9956,14 @@
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^2.1.0"
 					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
 				}
 			}
 		},
@@ -9899,26 +9972,44 @@
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 		},
+		"sync-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.0.0.tgz",
+			"integrity": "sha512-jGNIAlCi9iU4X3Dm4oQnNQshDD3h0/1A7r79LyqjbjUnj69sX6mShAXlhRXgImsfVKtTcnra1jfzabdZvp+Lmw==",
+			"requires": {
+				"http-response-object": "^3.0.1",
+				"sync-rpc": "^1.2.1",
+				"then-request": "^6.0.0"
+			}
+		},
+		"sync-rpc": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
+			"integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+			"requires": {
+				"get-port": "^3.1.0"
+			}
+		},
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
 			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
 		"tape": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-			"integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+			"integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
 			"requires": {
 				"deep-equal": "~1.0.1",
 				"defined": "~1.0.0",
 				"for-each": "~0.3.2",
-				"function-bind": "~1.1.0",
+				"function-bind": "~1.1.1",
 				"glob": "~7.1.2",
 				"has": "~1.0.1",
 				"inherits": "~2.0.3",
 				"minimist": "~1.2.0",
-				"object-inspect": "~1.3.0",
-				"resolve": "~1.4.0",
+				"object-inspect": "~1.5.0",
+				"resolve": "~1.5.0",
 				"resumer": "~0.0.0",
 				"string.prototype.trim": "~1.1.2",
 				"through": "~2.3.8"
@@ -9941,14 +10032,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"resolve": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
 				}
 			}
 		},
@@ -9962,26 +10045,29 @@
 				"inherits": "2"
 			}
 		},
-		"tar-fs": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-			"requires": {
-				"chownr": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			}
-		},
 		"tar-stream": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+			"integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
 			"requires": {
 				"bl": "^1.0.0",
+				"buffer-alloc": "^1.1.0",
 				"end-of-stream": "^1.0.0",
-				"readable-stream": "^2.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.0",
 				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+					"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+					"requires": {
+						"readable-stream": "^2.3.5",
+						"safe-buffer": "^5.1.1"
+					}
+				}
 			}
 		},
 		"tar.gz": {
@@ -10000,11 +10086,6 @@
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
 					"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-				},
-				"commander": {
-					"version": "2.15.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-					"integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
 				}
 			}
 		},
@@ -10038,6 +10119,39 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
 			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
+		},
+		"then-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.0.tgz",
+			"integrity": "sha512-xA+7uEMc+jsQIoyySJ93Ad08Kuqnik7u6jLS5hR91Z3smAoCfL3M8/MqMlobAa9gzBfO9pA88A/AntfepkkMJQ==",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/form-data": "0.0.33",
+				"@types/node": "^8.0.0",
+				"@types/qs": "^6.2.31",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.6.0",
+				"form-data": "^2.2.0",
+				"http-basic": "^7.0.0",
+				"http-response-object": "^3.0.1",
+				"promise": "^8.0.0",
+				"qs": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "8.10.17",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
+					"integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg=="
+				},
+				"promise": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+					"integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				}
+			}
 		},
 		"thenify": {
 			"version": "3.3.0",
@@ -10075,9 +10189,9 @@
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -10119,6 +10233,11 @@
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
+		"to-buffer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -10129,12 +10248,47 @@
 			"resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
 			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE="
 		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
 		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
 				"punycode": "^1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
 			}
 		},
 		"trim": {
@@ -10157,38 +10311,12 @@
 				"solc": "0.4.18"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
-				},
 				"debug": {
 					"version": "2.6.8",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"requires": {
 						"ms": "2.0.0"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.2",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -10215,6 +10343,11 @@
 						"supports-color": "3.1.2"
 					}
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
 				"supports-color": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -10234,21 +10367,93 @@
 				"ethereumjs-wallet": "^0.6.0",
 				"web3": "^0.18.2",
 				"web3-provider-engine": "^8.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				},
+				"web3-provider-engine": {
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+					"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+					"requires": {
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
+					},
+					"dependencies": {
+						"bignumber.js": {
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "git+https://github.com/debris/bignumber.js.git#master"
+						},
+						"web3": {
+							"version": "0.16.0",
+							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+							"requires": {
+								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
+							}
+						}
+					}
+				}
 			}
 		},
 		"truffle-privatekey-provider": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.5.tgz",
-			"integrity": "sha512-I4agR/KbFA+XLLYxN32YeMTm5D9ySMQ5yN/CaRywCYceaZM+cPIXJQoX5R+L6S5i9OSm0aebbOGsdYSVU4YGaQ==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.6.tgz",
+			"integrity": "sha512-x4tsMeXolhae9mzIA5k9bbq4FdhzSI/UGyAKU/B9xepE0lMCfhpuQv8WM2xdLlqyDtiHouC8z5+rmSmcK8bGEQ==",
 			"requires": {
 				"ethereumjs-wallet": "^0.6.0",
 				"web3": "^0.20.1",
 				"web3-provider-engine": "^8.4.0"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"bignumber.js": {
 					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
 				},
 				"web3": {
 					"version": "0.20.6",
@@ -10260,11 +10465,43 @@
 						"utf8": "^2.1.1",
 						"xhr2": "*",
 						"xmlhttprequest": "*"
+					}
+				},
+				"web3-provider-engine": {
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+					"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+					"requires": {
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
 					},
 					"dependencies": {
 						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "git+https://github.com/debris/bignumber.js.git#master"
+						},
+						"web3": {
+							"version": "0.16.0",
+							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+							"requires": {
+								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
+							}
 						}
 					}
 				}
@@ -10309,21 +10546,6 @@
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.18"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-				},
-				"mime-types": {
-					"version": "2.1.18",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"requires": {
-						"mime-db": "~1.33.0"
-					}
-				}
 			}
 		},
 		"typedarray": {
@@ -10367,6 +10589,26 @@
 				"yargs": "~3.10.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -10424,13 +10666,50 @@
 						"ieee754": "^1.1.4",
 						"isarray": "^1.0.0"
 					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
 		"underscore": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz",
+			"integrity": "sha512-4IV1DSSxC1QK48j9ONFK1MoIAKKkbE8i7u55w2R6IqBqbT7A/iG7aZBCR2Bi8piF0Uz+i/MG1aeqLwl/5vqF+A=="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
 		},
 		"universalify": {
 			"version": "0.1.1",
@@ -10447,15 +10726,69 @@
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
-		"untildify": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
+			}
 		},
-		"unzip-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+		"untildify": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
+		},
+		"uri-js": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+			"integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
@@ -10490,6 +10823,21 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"use": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"requires": {
+				"kind-of": "^6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
 		},
 		"utf8": {
 			"version": "2.1.2",
@@ -10532,12 +10880,12 @@
 			"integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA=="
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "~1.0.0",
-				"spdx-expression-parse": "~1.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"varint": {
@@ -10588,16 +10936,6 @@
 				"strip-bom": "^2.0.0",
 				"strip-bom-stream": "^2.0.0",
 				"vinyl": "^1.1.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				}
 			}
 		},
 		"vm-browserify": {
@@ -10609,153 +10947,202 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"requires": {
-				"async": "^2.1.2",
-				"chokidar": "^1.7.0",
-				"graceful-fs": "^4.1.2"
+				"chokidar": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"neo-async": "^2.5.0"
 			}
 		},
 		"web3": {
-			"version": "0.18.4",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-			"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+			"version": "1.0.0-beta.26",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
+			"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-				"crypto-js": "^3.1.4",
-				"utf8": "^2.1.1",
-				"xhr2": "*",
-				"xmlhttprequest": "*"
+				"web3-bzz": "^1.0.0-beta.26",
+				"web3-core": "^1.0.0-beta.26",
+				"web3-eth": "^1.0.0-beta.26",
+				"web3-eth-personal": "^1.0.0-beta.26",
+				"web3-net": "^1.0.0-beta.26",
+				"web3-shh": "^1.0.0-beta.26",
+				"web3-utils": "^1.0.0-beta.26"
 			}
 		},
 		"web3-bzz": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.31.tgz",
-			"integrity": "sha1-rrp8lVhhqZupLdHKj3x6EngyhZ0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+			"integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
 			"requires": {
 				"got": "7.1.0",
 				"swarm-js": "0.1.37",
 				"underscore": "1.8.3"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.31.tgz",
-			"integrity": "sha1-q9FJzEEshTZb9NEZfHSeP1Dj6qE=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+			"integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
 			"requires": {
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-requestmanager": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-requestmanager": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-core-helpers": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.31.tgz",
-			"integrity": "sha1-cETI89P3NRWLoeZrhPbECQiCFlw=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+			"integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-eth-iban": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-eth-iban": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-method": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.31.tgz",
-			"integrity": "sha1-IRkLm4zxUDUT6Diw9O73Jg/uCTs=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+			"integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-promievent": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-promievent": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-promievent": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.31.tgz",
-			"integrity": "sha1-3alb5l7NeSTjAKXphHfBuwpX6PM=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+			"integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
 			"requires": {
 				"any-promise": "1.3.0",
 				"eventemitter3": "1.1.1"
 			}
 		},
 		"web3-core-requestmanager": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.31.tgz",
-			"integrity": "sha1-S/ZntBTUbgZtmTCZTzT0b7QI++c=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+			"integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-providers-http": "1.0.0-beta.31",
-				"web3-providers-ipc": "1.0.0-beta.31",
-				"web3-providers-ws": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-providers-http": "1.0.0-beta.34",
+				"web3-providers-ipc": "1.0.0-beta.34",
+				"web3-providers-ws": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-subscriptions": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.31.tgz",
-			"integrity": "sha1-fpAG3iCosEB6wTZO9WuHz8TQ8ks=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+			"integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
 			"requires": {
 				"eventemitter3": "1.1.1",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.31.tgz",
-			"integrity": "sha1-t7SwdVNLOjsKtbVpe9UIXXnrYcY=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+			"integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-eth-abi": "1.0.0-beta.31",
-				"web3-eth-accounts": "1.0.0-beta.31",
-				"web3-eth-contract": "1.0.0-beta.31",
-				"web3-eth-iban": "1.0.0-beta.31",
-				"web3-eth-personal": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-eth-abi": "1.0.0-beta.34",
+				"web3-eth-accounts": "1.0.0-beta.34",
+				"web3-eth-contract": "1.0.0-beta.34",
+				"web3-eth-iban": "1.0.0-beta.34",
+				"web3-eth-personal": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth-abi": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.31.tgz",
-			"integrity": "sha1-xQ457cINFrTDWQKegpuEE5THL8E=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+			"integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
 			"requires": {
 				"bn.js": "4.11.6",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			},
 			"dependencies": {
 				"bn.js": {
 					"version": "4.11.6",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				}
 			}
 		},
 		"web3-eth-accounts": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.31.tgz",
-			"integrity": "sha1-Mnm9BpbYK8ThUswddWx74i0xkq0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+			"integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
 			"requires": {
-				"any-promise": "^1.3.0",
-				"crypto-browserify": "^3.12.0",
+				"any-promise": "1.3.0",
+				"crypto-browserify": "3.12.0",
 				"eth-lib": "0.2.7",
 				"scrypt.js": "0.2.0",
 				"underscore": "1.8.3",
 				"uuid": "2.0.1",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			},
 			"dependencies": {
 				"eth-lib": {
@@ -10768,6 +11155,11 @@
 						"xhr-request-promise": "^0.1.2"
 					}
 				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				},
 				"uuid": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
@@ -10776,55 +11168,69 @@
 			}
 		},
 		"web3-eth-contract": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.31.tgz",
-			"integrity": "sha1-J5RkM/kdiVMBPi2X/Yt4qe1rbtw=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+			"integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-promievent": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-eth-abi": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-promievent": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-eth-abi": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth-iban": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.31.tgz",
-			"integrity": "sha1-7WS+0zO7BApvKU+06dGOrdvr/8o=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+			"integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
 			"requires": {
-				"bn.js": "^4.11.6",
-				"web3-utils": "1.0.0-beta.31"
+				"bn.js": "4.11.6",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
 			}
 		},
 		"web3-eth-personal": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.31.tgz",
-			"integrity": "sha1-Kw1ghZIOndzfu63yCnFfDMN3HYA=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+			"integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-net": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.31.tgz",
-			"integrity": "sha1-0mv8oOoXUvX9XXITTgDlE60efhk=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+			"integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-provider-engine": {
-			"version": "8.6.1",
-			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
-			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+			"version": "8.1.19",
+			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
+			"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
 			"requires": {
 				"async": "^2.1.2",
 				"clone": "^2.0.0",
@@ -10842,24 +11248,17 @@
 				"xtend": "^4.0.1"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"bignumber.js": {
 					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-					"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-				},
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "^6.24.0",
-						"babelify": "^7.3.0",
-						"bn.js": "^4.8.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"secp256k1": "^3.0.1"
-					}
+					"from": "git+https://github.com/debris/bignumber.js.git#master"
 				},
 				"web3": {
 					"version": "0.16.0",
@@ -10870,75 +11269,71 @@
 						"crypto-js": "^3.1.4",
 						"utf8": "^2.1.1",
 						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-						}
 					}
 				}
 			}
 		},
 		"web3-providers-http": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.31.tgz",
-			"integrity": "sha1-E0Ce9ErhYjzVxNzT20sI1vu6RTI=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+			"integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
 			"requires": {
-				"web3-core-helpers": "1.0.0-beta.31",
+				"web3-core-helpers": "1.0.0-beta.34",
 				"xhr2": "0.1.4"
 			}
 		},
 		"web3-providers-ipc": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.31.tgz",
-			"integrity": "sha1-zm2mcPqhlFjmIt/tm+QAWE/DNyQ=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+			"integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
 			"requires": {
 				"oboe": "2.1.3",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-providers-ws": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.31.tgz",
-			"integrity": "sha1-zHG3Do2LUyAaUzdDcHww6MCZ4o0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+			"integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
 			},
 			"dependencies": {
-				"websocket": {
-					"version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-					"from": "websocket@git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-					"requires": {
-						"debug": "^2.2.0",
-						"nan": "^2.3.3",
-						"typedarray-to-buffer": "^3.1.2",
-						"yaeti": "^0.0.6"
-					}
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				}
 			}
 		},
 		"web3-shh": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.31.tgz",
-			"integrity": "sha1-AW0gS+K7obfzs5FQJyGdJ07+XlI=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+			"integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34"
 			}
 		},
 		"web3-utils": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.31.tgz",
-			"integrity": "sha1-DxgSXT6WmK6Cy/b6Ka3B4WFvKTY=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+			"integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
 			"requires": {
 				"bn.js": "4.11.6",
-				"eth-lib": "^0.1.27",
+				"eth-lib": "0.1.27",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
 				"randomhex": "0.1.5",
@@ -10951,6 +11346,11 @@
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
 				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				},
 				"utf8": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
@@ -10960,43 +11360,92 @@
 		},
 		"webcrypto-shim": {
 			"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-			"from": "webcrypto-shim@github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+			"from": "github:dignifiedquire/webcrypto-shim#master"
 		},
 		"webpack": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+			"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
 			"requires": {
 				"acorn": "^5.0.0",
 				"acorn-dynamic-import": "^2.0.0",
-				"ajv": "^5.1.5",
-				"ajv-keywords": "^2.0.0",
+				"ajv": "^4.7.0",
+				"ajv-keywords": "^1.1.1",
 				"async": "^2.1.2",
-				"enhanced-resolve": "^3.4.0",
-				"escope": "^3.6.0",
+				"enhanced-resolve": "^3.3.0",
 				"interpret": "^1.0.0",
 				"json-loader": "^0.5.4",
 				"json5": "^0.5.1",
 				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
+				"loader-utils": "^0.2.16",
 				"memory-fs": "~0.4.1",
 				"mkdirp": "~0.5.0",
 				"node-libs-browser": "^2.0.0",
 				"source-map": "^0.5.3",
-				"supports-color": "^4.2.1",
-				"tapable": "^0.2.7",
-				"uglifyjs-webpack-plugin": "^0.4.6",
-				"watchpack": "^1.4.0",
+				"supports-color": "^3.1.0",
+				"tapable": "~0.2.5",
+				"uglify-js": "^2.8.27",
+				"watchpack": "^1.3.1",
 				"webpack-sources": "^1.0.1",
-				"yargs": "^8.0.2"
+				"yargs": "^6.0.0"
 			},
 			"dependencies": {
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"requires": {
-						"has-flag": "^2.0.0"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
+					}
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -11009,20 +11458,62 @@
 				"jscodeshift": "^0.4.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
 				"ast-types": {
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
 					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
 				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
 				},
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
 				},
 				"jscodeshift": {
 					"version": "0.4.1",
@@ -11046,6 +11537,26 @@
 						"write-file-atomic": "^1.2.0"
 					}
 				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
 				"recast": {
 					"version": "0.12.9",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
@@ -11066,9 +11577,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.15.tgz",
-			"integrity": "sha512-bjNeIUO51D4OsmZ5ufzcpzVoacjxfWNfeBZKYL3jc+EMfCME3TyfdCPSUoKiOnebQChfupQuIRpAnx7L4l3Hew==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.3.tgz",
+			"integrity": "sha512-5AsKoL/Ccn8iTrwk3uErdyhetGH+c7VRQ7Itim2GL0IhBRq5rtojVDk00buMRmFmBpw1RvHXq97Gup965LbozA==",
 			"requires": {
 				"chalk": "^2.3.2",
 				"cross-spawn": "^6.0.5",
@@ -11095,7 +11606,7 @@
 				"webpack-addons": "^1.1.5",
 				"yargs": "^11.1.0",
 				"yeoman-environment": "^2.0.0",
-				"yeoman-generator": "^2.0.3"
+				"yeoman-generator": "^2.0.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11103,28 +11614,10 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
 				},
 				"cliui": {
 					"version": "4.1.0",
@@ -11164,9 +11657,9 @@
 					}
 				},
 				"got": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-					"integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+					"integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
 					"requires": {
 						"@sindresorhus/is": "^0.7.0",
 						"cacheable-request": "^2.1.1",
@@ -11187,15 +11680,30 @@
 						"url-to-options": "^1.0.1"
 					}
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
 				},
 				"p-cancelable": {
 					"version": "0.4.1",
@@ -11220,10 +11728,14 @@
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
 					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 				},
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -11231,14 +11743,6 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
 						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				},
 				"tapable": {
@@ -11253,6 +11757,11 @@
 					"requires": {
 						"prepend-http": "^2.0.0"
 					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "11.1.0",
@@ -11284,9 +11793,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
-			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -11299,10 +11808,20 @@
 				}
 			}
 		},
+		"websocket": {
+			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+			"requires": {
+				"debug": "^2.2.0",
+				"nan": "^2.3.3",
+				"typedarray-to-buffer": "^3.1.2",
+				"yaeti": "^0.0.6"
+			}
+		},
 		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"which": {
 			"version": "1.3.0",
@@ -11313,34 +11832,14 @@
 			}
 		},
 		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"wide-align": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"requires": {
-				"string-width": "^1.0.2"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
-			}
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
 		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -11354,18 +11853,6 @@
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
 			}
 		},
 		"wrappy": {
@@ -11394,9 +11881,9 @@
 			}
 		},
 		"xhr": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-			"integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
 			"requires": {
 				"global": "~4.3.0",
 				"is-function": "^1.0.1",
@@ -11416,18 +11903,6 @@
 				"timed-out": "^4.0.1",
 				"url-set-query": "^1.0.0",
 				"xhr": "^2.0.4"
-			},
-			"dependencies": {
-				"simple-get": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-					"integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
-					"requires": {
-						"decompress-response": "^3.3.0",
-						"once": "^1.3.1",
-						"simple-concat": "^1.0.0"
-					}
-				}
 			}
 		},
 		"xhr-request-promise": {
@@ -11469,67 +11944,98 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"requires": {
-				"camelcase": "^4.1.0",
-				"cliui": "^3.2.0",
+				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
 				"get-caller-file": "^1.0.1",
 				"os-locale": "^2.0.0",
-				"read-pkg-up": "^2.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1",
-				"yargs-parser": "^7.0.0"
+				"yargs-parser": "^8.1.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
 						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"requires": {
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"requires": {
-				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				}
+				"camelcase": "^3.0.0",
+				"lodash.assign": "^4.0.6"
 			}
 		},
 		"yauzl": {
@@ -11542,21 +12048,23 @@
 			}
 		},
 		"yeoman-environment": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-			"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+			"integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
 			"requires": {
 				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
 				"debug": "^3.1.0",
 				"diff": "^3.3.1",
 				"escape-string-regexp": "^1.0.2",
-				"globby": "^6.1.0",
+				"globby": "^8.0.1",
 				"grouped-queue": "^0.3.3",
-				"inquirer": "^3.3.0",
+				"inquirer": "^5.2.0",
 				"is-scoped": "^1.0.0",
-				"lodash": "^4.17.4",
+				"lodash": "^4.17.10",
 				"log-symbols": "^2.1.0",
 				"mem-fs": "^1.1.0",
+				"strip-ansi": "^4.0.0",
 				"text-table": "^0.2.0",
 				"untildify": "^3.0.2"
 			},
@@ -11566,22 +12074,16 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -11597,31 +12099,10 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -11630,37 +12111,29 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"yeoman-generator": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
-			"integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
 			"requires": {
 				"async": "^2.6.0",
 				"chalk": "^2.3.0",
 				"cli-table": "^0.3.1",
-				"cross-spawn": "^5.1.0",
+				"cross-spawn": "^6.0.5",
 				"dargs": "^5.1.0",
-				"dateformat": "^3.0.2",
+				"dateformat": "^3.0.3",
 				"debug": "^3.1.0",
 				"detect-conflict": "^1.0.0",
 				"error": "^7.0.2",
 				"find-up": "^2.1.0",
 				"github-username": "^4.0.0",
-				"istextorbinary": "^2.1.0",
-				"lodash": "^4.17.4",
+				"istextorbinary": "^2.2.1",
+				"lodash": "^4.17.10",
 				"make-dir": "^1.1.0",
-				"mem-fs-editor": "^3.0.2",
+				"mem-fs-editor": "^4.0.0",
 				"minimist": "^1.2.0",
 				"pretty-bytes": "^4.0.2",
 				"read-chunk": "^2.1.0",
@@ -11673,22 +12146,24 @@
 				"yeoman-environment": "^2.0.5"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"lodash": "^4.17.10"
 					}
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -11698,24 +12173,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -11732,6 +12189,11 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"parse-json": {
 					"version": "4.0.0",
@@ -11775,22 +12237,19 @@
 					}
 				},
 				"shelljs": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-					"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+					"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
 					"requires": {
 						"glob": "^7.0.0",
 						"interpret": "^1.0.0",
 						"rechoir": "^0.6.2"
 					}
 				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				}
 			}
 		}

--- a/apps/survey/package-lock.json
+++ b/apps/survey/package-lock.json
@@ -3,13 +3,13 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@aragon/cli": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.0.6.tgz",
-			"integrity": "sha512-MvmLlN2o2+ixax/xPpp4ZRY5XAOyhIDXaqax/lqRQq3nIQBxWV4KxAWQS2sM0B6ZncFRDvKsWAU+4mqmk606Dg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.2.0.tgz",
+			"integrity": "sha512-CkbgxET1xRHqxCnAWD3zEzeNiVeIlA+0FFbP3n32dGu21vxQZk5bHUxjhpSU5Uc28Fa7CNv9pK3niFwMrqexDA==",
 			"requires": {
 				"chalk": "^2.1.0",
 				"eth-ens-namehash": "^2.0.0",
-				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
+				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#48f3e968d781f44f8bf8c32476948651d4d14ef4",
 				"find-up": "^2.1.0",
 				"fs-extra": "^4.0.2",
 				"ganache-core": "~2.0.2",
@@ -24,146 +24,62 @@
 				"tmp-promise": "^1.0.4",
 				"web3": "1.0.0-beta.26",
 				"yargs": "^10.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"js-sha3": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-					"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"web3": {
-					"version": "1.0.0-beta.26",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
-					"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
-					"requires": {
-						"web3-bzz": "^1.0.0-beta.26",
-						"web3-core": "^1.0.0-beta.26",
-						"web3-eth": "^1.0.0-beta.26",
-						"web3-eth-personal": "^1.0.0-beta.26",
-						"web3-net": "^1.0.0-beta.26",
-						"web3-shh": "^1.0.0-beta.26",
-						"web3-utils": "^1.0.0-beta.26"
-					}
-				},
-				"yargs": {
-					"version": "10.1.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
-				}
 			}
 		},
 		"@aragon/os": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.1.tgz",
-			"integrity": "sha512-6Q4SSc6YuLOGjXiH2SbN586KpJgszOtjYtfXNmf+HXtTCEn4iNPQrZ5gPoA2tcjBIz8pof79nXfTBM3ZSw5z6w==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.7.tgz",
+			"integrity": "sha512-NSEi9uUooxWTjwBzogabP8KO0idBGmFoUc+5IHaWaVelTwS11vqjJ83jc9cUo1s08ei/qNjEiFqDi7ieS0719w==",
 			"requires": {
 				"homedir": "^0.6.0",
-				"truffle-privatekey-provider": "0.0.5"
+				"truffle-hdwallet-provider": "0.0.3",
+				"truffle-privatekey-provider": "0.0.6"
 			}
+		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
+			"integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
 		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+		},
+		"@types/concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/form-data": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "9.6.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
+			"integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig=="
+		},
+		"@types/qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q=="
 		},
 		"abbrev": {
 			"version": "1.0.9",
@@ -171,18 +87,19 @@
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
 		},
 		"abi-decoder": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.0.9.tgz",
-			"integrity": "sha1-a8/Yb39j++yFc9l3izpPkruS4B8=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.1.0.tgz",
+			"integrity": "sha512-nvLArBx0XOJufWyaghMKtIofZDBwEMdVZoqcetQOIe1qYeKZk4+kRYGPEJ5lt7dD3MLulw//amUzOJLM8eW5RA==",
 			"requires": {
 				"babel-core": "^6.23.1",
 				"babel-loader": "^6.3.2",
 				"babel-plugin-add-module-exports": "^0.2.1",
 				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+				"babel-plugin-transform-runtime": "^6.23.0",
 				"babel-preset-es2015": "^6.22.0",
 				"chai": "^3.5.0",
 				"web3": "^0.18.4",
-				"webpack": "^2.2.1"
+				"webpack": "^2.7.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -194,125 +111,22 @@
 						"json-stable-stringify": "^1.0.1"
 					}
 				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"lodash": "^4.17.10"
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -320,6 +134,18 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
 						"has-flag": "^1.0.0"
+					}
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
 					}
 				},
 				"webpack": {
@@ -349,11 +175,6 @@
 						"webpack-sources": "^1.0.1",
 						"yargs": "^6.0.0"
 					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"yargs": {
 					"version": "6.6.0",
@@ -386,9 +207,9 @@
 			}
 		},
 		"abstract-leveldown": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+			"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
 			"requires": {
 				"xtend": "~4.0.0"
 			}
@@ -400,27 +221,12 @@
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-				},
-				"mime-types": {
-					"version": "2.1.18",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"requires": {
-						"mime-db": "~1.33.0"
-					}
-				}
 			}
 		},
 		"acorn": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
@@ -443,9 +249,9 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -454,9 +260,9 @@
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -484,9 +290,12 @@
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"any-observable": {
 			"version": "0.2.0",
@@ -499,32 +308,18 @@
 			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
-			}
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -535,17 +330,19 @@
 			"integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "^1.0.1"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
@@ -571,14 +368,19 @@
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
@@ -586,9 +388,9 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -613,18 +415,20 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
 		"ast-types": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
 			"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA=="
 		},
 		"async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-			"requires": {
-				"lodash": "^4.14.0"
-			}
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"async-each": {
 			"version": "1.0.1",
@@ -637,6 +441,16 @@
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
 				"async": "^2.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				}
 			}
 		},
 		"async-limiter": {
@@ -649,15 +463,176 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"atob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+		},
+		"babel-cli": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"requires": {
+				"babel-core": "^6.26.0",
+				"babel-polyfill": "^6.26.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"chokidar": "^1.6.1",
+				"commander": "^2.11.0",
+				"convert-source-map": "^1.5.0",
+				"fs-readdir-recursive": "^1.0.0",
+				"glob": "^7.1.2",
+				"lodash": "^4.17.4",
+				"output-file-sync": "^1.1.2",
+				"path-is-absolute": "^1.0.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.6",
+				"v8flags": "^2.1.1"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+					"optional": true,
+					"requires": {
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
+					}
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"optional": true,
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"optional": true
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"optional": true,
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"optional": true,
+					"requires": {
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
+					}
+				},
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"optional": true,
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"optional": true,
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"optional": true,
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"optional": true,
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				}
+			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -667,12 +642,36 @@
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
 				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -684,21 +683,36 @@
 				"babel-traverse": "^6.26.0",
 				"babel-types": "^6.26.0",
 				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.0",
-				"debug": "^2.6.8",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
 				"json5": "^0.5.1",
 				"lodash": "^4.17.4",
 				"minimatch": "^3.0.4",
 				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.7",
+				"private": "^0.1.8",
 				"slash": "^1.0.0",
-				"source-map": "^0.5.6"
+				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-generator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -706,7 +720,7 @@
 				"detect-indent": "^4.0.0",
 				"jsesc": "^1.3.0",
 				"lodash": "^4.17.4",
-				"source-map": "^0.5.6",
+				"source-map": "^0.5.7",
 				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
@@ -872,19 +886,6 @@
 				"loader-utils": "^0.2.16",
 				"mkdirp": "^0.5.1",
 				"object-assign": "^4.0.1"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				}
 			}
 		},
 		"babel-messages": {
@@ -1123,9 +1124,9 @@
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"version": "6.26.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -1273,6 +1274,14 @@
 				"regenerator-transform": "^0.10.0"
 			}
 		},
+		"babel-plugin-transform-runtime": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -1280,6 +1289,23 @@
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-polyfill": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"regenerator-runtime": "^0.10.5"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.10.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+				}
 			}
 		},
 		"babel-preset-es2015": {
@@ -1395,6 +1421,21 @@
 				"globals": "^9.18.0",
 				"invariant": "^2.2.2",
 				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-types": {
@@ -1408,15 +1449,6 @@
 				"to-fast-properties": "^1.0.3"
 			}
 		},
-		"babelify": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-			"integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-			"requires": {
-				"babel-core": "^6.0.14",
-				"object-assign": "^4.0.0"
-			}
-		},
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
@@ -1427,15 +1459,70 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
 		"base-x": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
 			"integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
 		},
 		"base64-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
@@ -1452,13 +1539,14 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bignumber.js": {
-			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-			"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
 		},
 		"binary-extensions": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"binaryextensions": {
 			"version": "2.1.1",
@@ -1491,11 +1579,24 @@
 			}
 		},
 		"bl": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+			"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
 			"requires": {
-				"readable-stream": "^2.0.5"
+				"readable-stream": "~1.0.26"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				}
 			}
 		},
 		"blakejs": {
@@ -1522,47 +1623,71 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
-				"iconv-lite": "0.4.19",
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
-			}
-		},
-		"boom": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"requires": {
-				"hoek": "4.x.x"
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"brorand": {
@@ -1576,9 +1701,9 @@
 			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
 		},
 		"browserify-aes": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -1589,9 +1714,9 @@
 			}
 		},
 		"browserify-cipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -1599,9 +1724,9 @@
 			}
 		},
 		"browserify-des": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -1623,6 +1748,13 @@
 			"integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
 			"requires": {
 				"js-sha3": "^0.3.1"
+			},
+			"dependencies": {
+				"js-sha3": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+					"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+				}
 			}
 		},
 		"browserify-sign": {
@@ -1640,11 +1772,11 @@
 			}
 		},
 		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
-				"pako": "~0.2.0"
+				"pako": "~1.0.5"
 			}
 		},
 		"bs58": {
@@ -1672,12 +1804,38 @@
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
 			}
+		},
+		"buffer-alloc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+			"integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+			"requires": {
+				"buffer-alloc-unsafe": "^0.1.0",
+				"buffer-fill": "^0.1.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+			"integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-fill": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+			"integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
 		},
 		"buffer-from": {
 			"version": "0.1.2",
@@ -1731,6 +1889,22 @@
 				"typewise-core": "^1.2"
 			}
 		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
 		"cacheable-request": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
@@ -1743,6 +1917,13 @@
 				"lowercase-keys": "1.0.0",
 				"normalize-url": "2.0.1",
 				"responselike": "1.0.2"
+			},
+			"dependencies": {
+				"lowercase-keys": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+				}
 			}
 		},
 		"cachedown": {
@@ -1752,22 +1933,17 @@
 			"requires": {
 				"abstract-leveldown": "^2.4.1",
 				"lru-cache": "^3.2.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-					"requires": {
-						"pseudomap": "^1.0.1"
-					}
-				}
 			}
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1794,15 +1970,13 @@
 			}
 		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
@@ -1819,25 +1993,23 @@
 			}
 		},
 		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 			"requires": {
-				"anymatch": "^1.3.0",
+				"anymatch": "^2.0.0",
 				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.1.2",
+				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.1",
 				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^2.1.1",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.0"
 			}
-		},
-		"chownr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 		},
 		"cids": {
 			"version": "0.5.3",
@@ -1856,6 +2028,27 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
 			}
 		},
 		"cli-cursor": {
@@ -1900,16 +2093,6 @@
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -1920,18 +2103,6 @@
 			"requires": {
 				"slice-ansi": "0.0.4",
 				"string-width": "^1.0.1"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
 			}
 		},
 		"cli-width": {
@@ -1940,13 +2111,13 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
-				"wordwrap": "0.0.2"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"clone": {
@@ -1980,35 +2151,6 @@
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
 				"readable-stream": "^2.3.5"
-			},
-			"dependencies": {
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"co": {
@@ -2037,6 +2179,15 @@
 				}
 			}
 		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -2051,27 +2202,35 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+			"integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": ">= 1.0.0"
+			}
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2079,13 +2238,21 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
+				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
+			},
+			"dependencies": {
+				"buffer-from": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+				}
 			}
 		},
 		"console-browserify": {
@@ -2095,11 +2262,6 @@
 			"requires": {
 				"date-now": "^0.1.4"
 			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -2117,9 +2279,9 @@
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-source-map": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -2131,10 +2293,15 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
 		"core-js": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-			"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+			"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -2151,29 +2318,30 @@
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
 				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -2191,22 +2359,15 @@
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			}
-		},
-		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"requires": {
-				"boom": "5.x.x"
 			},
 			"dependencies": {
-				"boom": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"hoek": "4.x.x"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -2281,11 +2442,11 @@
 			"integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+			"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "0.7.2"
 			}
 		},
 		"decamelize": {
@@ -2408,9 +2569,9 @@
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -2423,6 +2584,16 @@
 			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
 			"requires": {
 				"abstract-leveldown": "~2.6.0"
+			},
+			"dependencies": {
+				"abstract-leveldown": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+					"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+					"requires": {
+						"xtend": "~4.0.0"
+					}
+				}
 			}
 		},
 		"define-properties": {
@@ -2441,6 +2612,48 @@
 				}
 			}
 		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
 		"defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -2450,11 +2663,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -2494,18 +2702,42 @@
 			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
 		},
 		"diff": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
 		},
 		"diffie-hellman": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			}
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"dom-walk": {
@@ -2514,9 +2746,9 @@
 			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
 		},
 		"domain-browser": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"drbg.js": {
 			"version": "1.0.1",
@@ -2553,9 +2785,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
-			"version": "2.5.9",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-			"integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -2595,9 +2827,9 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2619,11 +2851,11 @@
 			"integrity": "sha512-5rfRs+m+6pwoKRCFqpsA5+qsLngFms1aWPrxfKbrObCzQaPc3M3yPloZx+BL9UE3dK58cxw36XVQbFRSCCfGSQ=="
 		},
 		"errno": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
-				"prr": "~0.0.0"
+				"prr": "~1.0.1"
 			}
 		},
 		"error": {
@@ -2644,9 +2876,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-			"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"requires": {
 				"es-to-primitive": "^1.1.1",
 				"function-bind": "^1.1.1",
@@ -2666,12 +2898,13 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.35",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+			"version": "0.10.42",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
 			"requires": {
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "~3.1.1"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "1"
 			}
 		},
 		"es6-iterator": {
@@ -2751,6 +2984,11 @@
 				"source-map": "~0.2.0"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -2779,17 +3017,16 @@
 			}
 		},
 		"esprima": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esrecurse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"requires": {
-				"estraverse": "^4.1.0",
-				"object-assign": "^4.0.1"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -2824,40 +3061,74 @@
 			}
 		},
 		"eth-gas-reporter": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.1.tgz",
-			"integrity": "sha512-ky5P27RRaDxD5EAzRL+xEBTq6uyfFj1Dyan2Epq5rfV66wEDtDkGTCYBefRaQpuXJ5C/U6Jsv5TR12qn7Mb83g==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.5.tgz",
+			"integrity": "sha512-SO3XePkWnl3d5HuIE+0jv6as03RJKRVeZ4/IQc+ukLeo6Vm5aez2/d1yfnxd2zE+MmoFGwvYuN6erk3CUxiHWg==",
 			"requires": {
 				"abi-decoder": "^1.0.8",
 				"cli-table2": "^0.2.0",
 				"colors": "^1.1.2",
 				"lodash": "^4.17.4",
+				"mocha": "^3.5.3",
 				"req-cwd": "^2.0.0",
 				"request": "^2.83.0",
 				"request-promise-native": "^1.0.5",
-				"shelljs": "^0.7.8"
+				"shelljs": "^0.7.8",
+				"solidity-parser-antlr": "^0.2.10",
+				"sync-request": "^6.0.0"
 			},
 			"dependencies": {
-				"req-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
-					"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"requires": {
-						"req-from": "^2.0.0"
+						"ms": "2.0.0"
 					}
 				},
-				"req-from": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
-					"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"mocha": {
+					"version": "3.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+					"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
 					"requires": {
-						"resolve-from": "^3.0.0"
+						"browser-stdout": "1.3.0",
+						"commander": "2.9.0",
+						"debug": "2.6.8",
+						"diff": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.1",
+						"growl": "1.9.2",
+						"he": "1.1.1",
+						"json3": "3.3.2",
+						"lodash.create": "3.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "3.1.2"
+					},
+					"dependencies": {
+						"growl": {
+							"version": "1.9.2",
+							"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+							"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+						}
 					}
 				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
@@ -2876,13 +3147,13 @@
 			}
 		},
 		"ethereum-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-			"integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
+			"integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
 		},
 		"ethereum-ens": {
-			"version": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
-			"from": "ethereum-ens@git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
+			"version": "git+https://github.com/Arachnid/ensjs.git#48f3e968d781f44f8bf8c32476948651d4d14ef4",
+			"from": "git+https://github.com/Arachnid/ensjs.git",
 			"requires": {
 				"bluebird": "^3.4.7",
 				"eth-ens-namehash": "^2.0.0",
@@ -2893,20 +3164,10 @@
 				"web3": "^0.19.1"
 			},
 			"dependencies": {
-				"bignumber.js": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-					"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-				},
 				"js-sha3": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
 					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-				},
-				"pako": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-					"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 				},
 				"web3": {
 					"version": "0.19.1",
@@ -2923,41 +3184,47 @@
 			}
 		},
 		"ethereumjs-account": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
-			"integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+			"integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
 			"requires": {
-				"ethereumjs-util": "^4.0.1",
-				"rlp": "^2.0.0"
+				"ethereumjs-util": "^5.0.0",
+				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"ethereumjs-block": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
-			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
+			"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
 			"requires": {
-				"async": "^2.0.1",
-				"ethereum-common": "0.2.0",
-				"ethereumjs-tx": "^1.2.2",
-				"ethereumjs-util": "^5.0.0",
+				"async": "^1.5.2",
+				"ethereum-common": "0.0.16",
+				"ethereumjs-tx": "^1.0.0",
+				"ethereumjs-util": "^4.0.1",
 				"merkle-patricia-tree": "^2.1.2"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 					"requires": {
-						"babel-preset-es2015": "^6.24.0",
-						"babelify": "^7.3.0",
 						"bn.js": "^4.8.0",
 						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
+						"keccakjs": "^0.2.0",
 						"rlp": "^2.0.0",
 						"secp256k1": "^3.0.1"
 					}
 				}
+			}
+		},
+		"ethereumjs-testrpc": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.3.tgz",
+			"integrity": "sha512-lAxxsxDKK69Wuwqym2K49VpXtBvLEsXr1sryNG4AkvL5DomMdeCBbu3D87UEevKenLHBiT8GTjARwN6Yj039gA==",
+			"requires": {
+				"webpack": "^3.0.0"
 			}
 		},
 		"ethereumjs-testrpc-sc": {
@@ -2969,9 +3236,9 @@
 			}
 		},
 		"ethereumjs-tx": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
-			"integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz",
+			"integrity": "sha512-kOgUd5jC+0tgV7t52UDECMMz9Uf+Lro+6fSpCvzWemtXfMEcwI3EOxf5mVPMRbTFkMMhuERokNNVF3jItAjidg==",
 			"requires": {
 				"ethereum-common": "^0.0.18",
 				"ethereumjs-util": "^5.0.0"
@@ -2981,33 +3248,20 @@
 					"version": "0.0.18",
 					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 					"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-				},
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "^6.24.0",
-						"babelify": "^7.3.0",
-						"bn.js": "^4.8.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"secp256k1": "^3.0.1"
-					}
 				}
 			}
 		},
 		"ethereumjs-util": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-			"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
+			"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
 			"requires": {
-				"bn.js": "^4.8.0",
+				"bn.js": "^4.11.0",
 				"create-hash": "^1.1.2",
-				"keccakjs": "^0.2.0",
+				"ethjs-util": "^0.1.3",
+				"keccak": "^1.0.2",
 				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1",
 				"secp256k1": "^3.0.1"
 			}
 		},
@@ -3027,6 +3281,61 @@
 				"merkle-patricia-tree": "^2.1.2",
 				"rustbn.js": "~0.1.1",
 				"safe-buffer": "^5.1.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"ethereum-common": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+					"integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+				},
+				"ethereumjs-block": {
+					"version": "1.7.1",
+					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+					"integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+					"requires": {
+						"async": "^2.0.1",
+						"ethereum-common": "0.2.0",
+						"ethereumjs-tx": "^1.2.2",
+						"ethereumjs-util": "^5.0.0",
+						"merkle-patricia-tree": "^2.1.2"
+					},
+					"dependencies": {
+						"ethereumjs-util": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"requires": {
+								"bn.js": "^4.11.0",
+								"create-hash": "^1.1.2",
+								"ethjs-util": "^0.1.3",
+								"keccak": "^1.0.2",
+								"rlp": "^2.0.0",
+								"safe-buffer": "^5.1.1",
+								"secp256k1": "^3.0.1"
+							}
+						}
+					}
+				},
+				"ethereumjs-util": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+					"requires": {
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
+					}
+				}
 			}
 		},
 		"ethereumjs-wallet": {
@@ -3041,6 +3350,20 @@
 				"scrypt.js": "^0.2.0",
 				"utf8": "^2.1.1",
 				"uuid": "^2.0.1"
+			},
+			"dependencies": {
+				"ethereumjs-util": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+					"requires": {
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
+					}
+				}
 			}
 		},
 		"ethjs-unit": {
@@ -3116,11 +3439,35 @@
 			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"expand-range": {
@@ -3129,12 +3476,42 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
 				"fill-range": "^2.1.0"
+			},
+			"dependencies": {
+				"fill-range": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"requires": {
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^3.0.0",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				}
 			}
-		},
-		"expand-template": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-			"integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
@@ -3181,10 +3558,89 @@
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "~2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "~1.6.15"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": ">= 1.3.1 < 2"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 				}
 			}
 		},
@@ -3192,6 +3648,25 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
 		},
 		"external-editor": {
 			"version": "2.2.0",
@@ -3214,11 +3689,67 @@
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"extsprintf": {
@@ -3235,9 +3766,22 @@
 			}
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-glob": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.0.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.10"
+			}
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -3276,15 +3820,24 @@
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fill-range": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^1.1.3",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"finalhandler": {
@@ -3299,6 +3852,26 @@
 				"parseurl": "~1.3.2",
 				"statuses": "~1.4.0",
 				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
 			}
 		},
 		"find-cache-dir": {
@@ -3333,9 +3906,9 @@
 			"integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
 		},
 		"flow-parser": {
-			"version": "0.70.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
-			"integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg=="
+			"version": "0.72.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.72.0.tgz",
+			"integrity": "sha512-kFaDtviKlD/rHi6NRp42KTbnPgz/nKcWUJQhqDnLDeKA8uGcRVSy0YlQjaf9M3pFo5PgC3SNFnCPpQGLtHjH2w=="
 		},
 		"for-each": {
 			"version": "0.3.2",
@@ -3369,12 +3942,12 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.5",
+				"combined-stream": "1.0.6",
 				"mime-types": "^2.1.12"
 			}
 		},
@@ -3382,6 +3955,14 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
 		},
 		"fresh": {
 			"version": "0.5.2",
@@ -3397,16 +3978,19 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs-extra": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-			"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"jsonfile": "^2.1.0",
-				"klaw": "^1.0.0",
-				"path-is-absolute": "^1.0.0",
-				"rimraf": "^2.2.8"
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs-promise": {
@@ -3428,8 +4012,21 @@
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^2.1.0"
 					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
 				}
 			}
+		},
+		"fs-readdir-recursive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -3437,291 +4034,111 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"optional": true,
 			"requires": {
-				"nan": "^2.3.0",
-				"node-pre-gyp": "^0.6.39"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+					"version": "1.1.1",
+					"bundled": true,
 					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"optional": true,
-					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true
 				},
 				"aproba": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+					"version": "1.2.0",
+					"bundled": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
 					}
 				},
-				"asn1": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-					"optional": true
-				},
 				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-					"optional": true,
-					"requires": {
-						"tweetnacl": "^0.14.3"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-					"requires": {
-						"inherits": "~2.0.0"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-					"requires": {
-						"hoek": "2.x.x"
-					}
+					"version": "1.0.0",
+					"bundled": true
 				},
 				"brace-expansion": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"version": "1.1.11",
+					"bundled": true,
 					"requires": {
-						"balanced-match": "^0.4.1",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-					"requires": {
-						"delayed-stream": "~1.0.0"
-					}
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-					"requires": {
-						"boom": "2.x.x"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
+					"bundled": true,
+					"optional": true
 				},
 				"debug": {
-					"version": "2.6.8",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"version": "2.6.9",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"deep-extend": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"version": "0.5.1",
+					"bundled": true,
 					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
 					"optional": true
 				},
 				"detect-libc": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+					"version": "1.0.3",
+					"bundled": true,
 					"optional": true
 				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-					"optional": true,
-					"requires": {
-						"fstream": "^1.0.0",
-						"inherits": "2",
-						"minimatch": "^3.0.0"
-					}
+					"bundled": true,
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -3734,27 +4151,10 @@
 						"wide-align": "^1.1.0"
 					}
 				},
-				"getpass": {
-					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
-				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
+					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -3764,64 +4164,31 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"optional": true,
-					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
-					}
-				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"optional": true
 				},
-				"hawk": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
+					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -3829,175 +4196,117 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true
 				},
 				"ini": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+					"version": "1.3.5",
+					"bundled": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-					"optional": true
-				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"bundled": true,
 					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-					"optional": true,
-					"requires": {
-						"jsbn": "~0.1.0"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-					"optional": true,
-					"requires": {
-						"jsonify": "~0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-					"requires": {
-						"mime-db": "~1.27.0"
-					}
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"optional": true
 				},
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
 				"node-pre-gyp": {
-					"version": "0.6.39",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+					"version": "0.10.0",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
-						"hawk": "3.1.3",
 						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
 						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
 						"rc": "^1.1.7",
-						"request": "2.81.0",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
-						"tar": "^2.2.1",
-						"tar-pack": "^3.4.0"
+						"tar": "^4"
 					}
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
 						"osenv": "^0.1.4"
 					}
 				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
 				"npmlog": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+					"version": "4.1.2",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -4008,45 +4317,33 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"osenv": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+					"version": "0.1.5",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -4055,39 +4352,20 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+					"bundled": true,
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"version": "2.0.0",
+					"bundled": true,
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+					"version": "1.2.7",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
+						"deep-extend": "^0.5.1",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -4095,124 +4373,65 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
-					"version": "2.2.9",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+					"version": "2.3.6",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
+						"inherits": "~2.0.3",
 						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
 						"util-deprecate": "~1.0.1"
 					}
 				},
-				"request": {
-					"version": "2.81.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"optional": true,
-					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
-					}
-				},
 				"rimraf": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"version": "2.6.2",
+					"bundled": true,
+					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"optional": true
 				},
 				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"version": "5.5.0",
+					"bundled": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-					"requires": {
-						"hoek": "2.x.x"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-					"optional": true,
-					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jodid25519": "^1.0.0",
-						"jsbn": "~0.1.0",
-						"tweetnacl": "~0.14.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4220,113 +4439,47 @@
 					}
 				},
 				"string_decoder": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "~5.1.0"
 					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"optional": true
 				},
 				"tar": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+					"version": "4.4.1",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.2.0",
-						"fstream": "^1.0.10",
-						"fstream-ignore": "^1.0.5",
-						"once": "^1.3.3",
-						"readable-stream": "^2.1.4",
-						"rimraf": "^2.5.1",
-						"tar": "^2.2.1",
-						"uid-number": "^0.0.6"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-					"optional": true,
-					"requires": {
-						"punycode": "^1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+					"bundled": true,
 					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -4334,8 +4487,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true
 				}
 			}
 		},
@@ -4380,9 +4536,9 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-					"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -4436,242 +4592,15 @@
 						"json-stable-stringify": "^1.0.1"
 					}
 				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-					"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
-				},
-				"debug": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-					"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-					"requires": {
-						"ms": "0.7.2"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"ethereum-common": {
-					"version": "0.0.16",
-					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
-					"integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
-				},
-				"ethereumjs-block": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
-					"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
-					"requires": {
-						"async": "^1.5.2",
-						"ethereum-common": "0.0.16",
-						"ethereumjs-tx": "^1.0.0",
-						"ethereumjs-util": "^4.0.1",
-						"merkle-patricia-tree": "^2.1.2"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "4.5.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-							"requires": {
-								"bn.js": "^4.8.0",
-								"create-hash": "^1.1.2",
-								"keccakjs": "^0.2.0",
-								"rlp": "^2.0.0",
-								"secp256k1": "^3.0.1"
-							}
-						}
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.1.5",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
-					"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.2",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "^3.1.3",
-						"emojis-list": "^2.0.0",
-						"json5": "^0.5.0",
-						"object-assign": "^4.0.1"
-					}
-				},
-				"mocha": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
-					"integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
-					"requires": {
-						"browser-stdout": "1.3.0",
-						"commander": "2.9.0",
-						"debug": "2.6.0",
-						"diff": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"glob": "7.1.1",
-						"growl": "1.9.2",
-						"json3": "3.3.2",
-						"lodash.create": "3.1.1",
-						"mkdirp": "0.5.1",
-						"supports-color": "3.1.2"
-					}
-				},
-				"ms": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
 				"supports-color": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -4686,58 +4615,6 @@
 						"utf8": "^2.1.1",
 						"xhr2": "*",
 						"xmlhttprequest": "*"
-					}
-				},
-				"web3-provider-engine": {
-					"version": "8.1.19",
-					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
-					"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
-					"requires": {
-						"async": "^2.1.2",
-						"clone": "^2.0.0",
-						"ethereumjs-block": "^1.2.2",
-						"ethereumjs-tx": "^1.2.0",
-						"ethereumjs-util": "^5.0.1",
-						"ethereumjs-vm": "^2.0.2",
-						"isomorphic-fetch": "^2.2.0",
-						"request": "^2.67.0",
-						"semaphore": "^1.0.3",
-						"solc": "^0.4.2",
-						"tape": "^4.4.0",
-						"web3": "^0.16.0",
-						"xhr": "^2.2.0",
-						"xtend": "^4.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "2.6.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-							"requires": {
-								"lodash": "^4.14.0"
-							}
-						},
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-						},
-						"web3": {
-							"version": "0.16.0",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-							"requires": {
-								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-								"crypto-js": "^3.1.4",
-								"utf8": "^2.1.1",
-								"xmlhttprequest": "*"
-							},
-							"dependencies": {
-								"bignumber.js": {
-									"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-									"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-								}
-							}
-						}
 					}
 				},
 				"webpack": {
@@ -4769,11 +4646,11 @@
 					},
 					"dependencies": {
 						"async": {
-							"version": "2.6.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+							"version": "2.6.1",
+							"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+							"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 							"requires": {
-								"lodash": "^4.14.0"
+								"lodash": "^4.17.10"
 							}
 						},
 						"yargs": {
@@ -4797,11 +4674,6 @@
 							}
 						}
 					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"yargs": {
 					"version": "7.1.0",
@@ -4843,33 +4715,6 @@
 				}
 			}
 		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
-			}
-		},
 		"generic-pool": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz",
@@ -4880,10 +4725,20 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -4907,11 +4762,6 @@
 			"resolved": "https://registry.npmjs.org/git-clone/-/git-clone-0.1.0.tgz",
 			"integrity": "sha1-DXYWN3gJOu9/HDAjjyqe8/B6Lrk="
 		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-		},
 		"github-username": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
@@ -4921,13 +4771,14 @@
 			}
 		},
 		"glob": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 			"requires": {
+				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "2 || 3",
+				"minimatch": "^3.0.2",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
@@ -4941,19 +4792,6 @@
 				"yargs": "~1.2.6"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
@@ -4976,6 +4814,29 @@
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
 			}
 		},
 		"glob-escape": {
@@ -4984,12 +4845,28 @@
 			"integrity": "sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0="
 		},
 		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
+		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global": {
 			"version": "4.3.2",
@@ -4998,13 +4875,6 @@
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
-			},
-			"dependencies": {
-				"process": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-				}
 			}
 		},
 		"global-modules": {
@@ -5035,15 +4905,17 @@
 			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"requires": {
 				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -5058,6 +4930,11 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -5116,10 +4993,14 @@
 				"uglify-js": "^2.6"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
 				},
 				"source-map": {
 					"version": "0.4.4",
@@ -5167,9 +5048,9 @@
 			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-localstorage": {
 			"version": "1.0.1",
@@ -5189,17 +5070,42 @@
 				"has-symbol-support-x": "^1.4.1"
 			}
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"hash-base": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"requires": {
-				"inherits": "^2.0.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"hash.js": {
@@ -5209,17 +5115,6 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"hawk": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"requires": {
-				"boom": "4.x.x",
-				"cryptiles": "3.x.x",
-				"hoek": "4.x.x",
-				"sntp": "2.x.x"
 			}
 		},
 		"hdkey": {
@@ -5251,11 +5146,6 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
-		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -5279,9 +5169,22 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"http-basic": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/http-basic/-/http-basic-7.0.0.tgz",
+			"integrity": "sha1-gvClBr6UJzLsje6+6A50bvVzbbo=",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/node": "^9.4.1",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.4.6",
+				"http-response-object": "^3.0.1",
+				"parse-cache-control": "^1.0.1"
+			}
 		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
@@ -5289,27 +5192,28 @@
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
-				"depd": "1.1.1",
+				"depd": "~1.1.2",
 				"inherits": "2.0.3",
-				"setprototypeof": "1.0.3",
-				"statuses": ">= 1.3.1 < 2"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-				}
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
 			}
 		},
 		"http-https": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
 			"integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
+		},
+		"http-response-object": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.1.tgz",
+			"integrity": "sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==",
+			"requires": {
+				"@types/node": "^9.3.0"
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -5322,9 +5226,9 @@
 			}
 		},
 		"https-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"humble-localstorage": {
 			"version": "1.4.2",
@@ -5336,9 +5240,12 @@
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"idna-uts46-hx": {
 			"version": "2.3.1",
@@ -5346,19 +5253,17 @@
 			"integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
 			"requires": {
 				"punycode": "2.1.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-				}
 			}
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+		},
+		"ignore": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
 		},
 		"immediate": {
 			"version": "3.2.3",
@@ -5417,9 +5322,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "5.2.0",
@@ -5446,28 +5351,19 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -5476,21 +5372,13 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"interpret": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-			"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"into-stream": {
 			"version": "3.1.0",
@@ -5502,9 +5390,9 @@
 			}
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -5559,6 +5447,14 @@
 				"tar-stream": "^1.5.4"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -5586,6 +5482,15 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -5625,6 +5530,14 @@
 				"stable": "^0.1.6"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -5641,6 +5554,14 @@
 						"base-x": "^3.0.2"
 					}
 				}
+			}
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"requires": {
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -5674,10 +5595,35 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
 			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -5698,9 +5644,9 @@
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -5724,11 +5670,11 @@
 			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-hex-prefixed": {
@@ -5770,9 +5716,9 @@
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -5797,10 +5743,33 @@
 				}
 			}
 		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"requires": {
+				"is-number": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
+		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
@@ -5864,9 +5833,14 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isbinaryfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+			"integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -5874,12 +5848,9 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
@@ -5916,15 +5887,32 @@
 				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
@@ -5990,9 +5978,9 @@
 			}
 		},
 		"js-sha3": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
-			"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
+			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -6005,19 +5993,12 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				}
 			}
 		},
 		"jsbn": {
@@ -6048,10 +6029,82 @@
 				"write-file-atomic": "^1.2.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
 				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+					"version": "7.0.0-beta.47",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
 				}
 			}
 		},
@@ -6109,9 +6162,9 @@
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -6133,14 +6186,13 @@
 			}
 		},
 		"keccak": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
-			"integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+			"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
 			"requires": {
 				"bindings": "^1.2.1",
 				"inherits": "^2.0.3",
 				"nan": "^2.2.1",
-				"prebuild-install": "^2.0.0",
 				"safe-buffer": "^5.1.0"
 			}
 		},
@@ -6195,6 +6247,11 @@
 				"invert-kv": "^1.0.0"
 			}
 		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+		},
 		"level-codec": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
@@ -6219,11 +6276,6 @@
 				"xtend": "^4.0.0"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -6234,11 +6286,6 @@
 						"isarray": "0.0.1",
 						"string_decoder": "~0.10.x"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -6251,15 +6298,16 @@
 			}
 		},
 		"level-sublevel": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
-			"integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
+			"integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
 			"requires": {
 				"bytewise": "~1.1.0",
 				"levelup": "~0.19.0",
 				"ltgt": "~2.1.1",
+				"pull-defer": "^0.2.2",
 				"pull-level": "^2.0.3",
-				"pull-stream": "^3.4.5",
+				"pull-stream": "^3.6.8",
 				"typewiselite": "~1.0.0",
 				"xtend": "~4.0.0"
 			},
@@ -6279,14 +6327,6 @@
 						}
 					}
 				},
-				"bl": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-					"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-					"requires": {
-						"readable-stream": "~1.0.26"
-					}
-				},
 				"deferred-leveldown": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
@@ -6294,11 +6334,6 @@
 					"requires": {
 						"abstract-leveldown": "~0.12.1"
 					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"levelup": {
 					"version": "0.19.1",
@@ -6326,6 +6361,11 @@
 					"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
 					"integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
 				},
+				"prr": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -6341,11 +6381,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
 					"integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -6358,11 +6393,6 @@
 				"xtend": "~2.1.1"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -6373,11 +6403,6 @@
 						"isarray": "0.0.1",
 						"string_decoder": "~0.10.x"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xtend": {
 					"version": "2.1.2",
@@ -6403,10 +6428,10 @@
 				"xtend": "~4.0.0"
 			},
 			"dependencies": {
-				"prr": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+				"semver": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
 				}
 			}
 		},
@@ -6449,6 +6474,14 @@
 						"minimalistic-assert": "^1.0.0"
 					}
 				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -6482,6 +6515,16 @@
 				"nodeify": "^1.0.1",
 				"safe-buffer": "^5.1.1",
 				"secp256k1": "^3.3.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				}
 			}
 		},
 		"listr": {
@@ -6508,6 +6551,23 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"figures": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -6529,6 +6589,11 @@
 					"requires": {
 						"chalk": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -6552,6 +6617,23 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"figures": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -6573,6 +6655,11 @@
 					"requires": {
 						"chalk": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -6587,6 +6674,23 @@
 				"figures": "^1.7.0"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -6617,18 +6721,24 @@
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
 				"pify": "^2.0.0",
-				"strip-bom": "^3.0.0"
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"loader-runner": {
@@ -6637,13 +6747,14 @@
 			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
 		},
 		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 			"requires": {
 				"big.js": "^3.1.3",
 				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"json5": "^0.5.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"localstorage-down": {
@@ -6690,9 +6801,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",
@@ -6779,39 +6890,6 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"requires": {
 				"chalk": "^2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"log-update": {
@@ -6871,28 +6949,27 @@
 			}
 		},
 		"lowercase-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "^1.0.1"
 			}
 		},
 		"ltgt": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-			"integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
 		},
 		"make-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
 				"pify": "^3.0.0"
 			},
@@ -6904,6 +6981,24 @@
 				}
 			}
 		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"math-random": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+		},
 		"md5.js": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -6911,17 +7006,6 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
-			},
-			"dependencies": {
-				"hash-base": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-					"requires": {
-						"inherits": "^2.0.1",
-						"safe-buffer": "^5.0.1"
-					}
-				}
 			}
 		},
 		"media-typer": {
@@ -6948,15 +7032,16 @@
 			}
 		},
 		"mem-fs-editor": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+			"integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
 			"requires": {
 				"commondir": "^1.0.1",
-				"deep-extend": "^0.4.0",
-				"ejs": "^2.3.1",
+				"deep-extend": "^0.5.1",
+				"ejs": "^2.5.9",
 				"glob": "^7.0.3",
-				"globby": "^6.1.0",
+				"globby": "^8.0.0",
+				"isbinaryfile": "^3.0.2",
 				"mkdirp": "^0.5.0",
 				"multimatch": "^2.0.0",
 				"rimraf": "^2.2.8",
@@ -6968,19 +7053,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
 					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
 				},
 				"replace-ext": {
 					"version": "1.0.0",
@@ -7013,16 +7085,6 @@
 				"inherits": "~2.0.1",
 				"ltgt": "~2.2.0",
 				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				}
 			}
 		},
 		"memory-fs": {
@@ -7044,26 +7106,24 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
+		"merge2": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
+		},
 		"merkle-patricia-tree": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.2.0.tgz",
-			"integrity": "sha1-ekeHsSYqsA/psgSrRxsAUzIwbvo=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+			"integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
 			"requires": {
 				"async": "^1.4.2",
-				"ethereumjs-util": "^4.0.0",
+				"ethereumjs-util": "^5.0.0",
 				"level-ws": "0.0.0",
 				"levelup": "^1.2.1",
 				"memdown": "^1.0.0",
 				"readable-stream": "^2.0.0",
 				"rlp": "^2.0.0",
 				"semaphore": ">=1.0.1"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				}
 			}
 		},
 		"methods": {
@@ -7072,23 +7132,30 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"miller-rabin": {
@@ -7106,22 +7173,22 @@
 			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "~1.30.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.0",
@@ -7137,9 +7204,9 @@
 			}
 		},
 		"minimalistic-assert": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
@@ -7159,6 +7226,25 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -7176,74 +7262,47 @@
 			}
 		},
 		"mocha": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-			"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
+			"integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
 			"requires": {
-				"commander": "2.3.0",
-				"debug": "2.2.0",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.2",
-				"glob": "3.2.11",
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.0",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
 				"growl": "1.9.2",
-				"jade": "0.26.3",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
 				"mkdirp": "0.5.1",
-				"supports-color": "1.2.0",
-				"to-iso-string": "0.0.2"
+				"supports-color": "3.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
+				"growl": {
+					"version": "1.9.2",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+					"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
 				},
-				"escape-string-regexp": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
-				},
-				"glob": {
-					"version": "3.2.11",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-					"requires": {
-						"inherits": "2",
-						"minimatch": "0.3"
-					}
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
 		"mock-fs": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.2.tgz",
-			"integrity": "sha512-dF+yxZSojSiI8AXGoxj5qdFWpucndc54Ug+TwlpHFaV7j22MGG+OML2+FVa6xAZtjb/OFFQhOC37Jegx2GbEwA=="
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
+			"integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w=="
 		},
 		"mout": {
 			"version": "0.11.1",
@@ -7251,14 +7310,14 @@
 			"integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+			"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
 		},
 		"multiaddr": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.0.2.tgz",
-			"integrity": "sha512-TLEujk9VD1SR8HgV00rr1I3MWOk4t0GSDvxzzOO1m1hfxdv4DkFHmKKUHngUCiWHDeClHKSSV23Ig5/Mav3MQw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
+			"integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
 			"requires": {
 				"bs58": "^4.0.1",
 				"ip": "^1.1.5",
@@ -7352,10 +7411,13 @@
 				"nodeify": "^1.0.1"
 			},
 			"dependencies": {
-				"js-sha3": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-					"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				}
 			}
 		},
@@ -7401,14 +7463,40 @@
 			}
 		},
 		"nan": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
 		},
 		"nano-json-stream-parser": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
 			"integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
 		},
 		"ndjson": {
 			"version": "1.5.0",
@@ -7438,18 +7526,15 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
 			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
 		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		},
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
 			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
-		},
-		"node-abi": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
-			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
-			"requires": {
-				"semver": "^5.4.1"
-			}
 		},
 		"node-dir": {
 			"version": "0.1.8",
@@ -7466,44 +7551,57 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-			"integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
 		},
 		"node-libs-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"requires": {
 				"assert": "^1.1.1",
-				"browserify-zlib": "^0.1.4",
+				"browserify-zlib": "^0.2.0",
 				"buffer": "^4.3.0",
 				"console-browserify": "^1.1.0",
 				"constants-browserify": "^1.0.0",
 				"crypto-browserify": "^3.11.0",
 				"domain-browser": "^1.1.1",
 				"events": "^1.0.0",
-				"https-browserify": "0.0.1",
-				"os-browserify": "^0.2.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "^0.11.0",
+				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.0.5",
+				"readable-stream": "^2.3.3",
 				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.3.1",
-				"string_decoder": "^0.10.25",
-				"timers-browserify": "^2.0.2",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
 				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
+				"process": {
+					"version": "0.11.10",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
 				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
 				}
 			}
 		},
@@ -7551,11 +7649,6 @@
 					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
 			}
-		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -7609,17 +7702,6 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -7651,15 +7733,43 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
 		"object-inspect": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-			"integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+			"integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
 		},
 		"object-keys": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
 			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "^3.0.0"
+			}
 		},
 		"object.omit": {
 			"version": "2.0.1",
@@ -7668,6 +7778,14 @@
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "^3.0.1"
 			}
 		},
 		"oboe": {
@@ -7708,11 +7826,10 @@
 			}
 		},
 		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+			"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
 			"requires": {
-				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
 			}
 		},
@@ -7747,6 +7864,23 @@
 				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -7768,6 +7902,11 @@
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -7777,9 +7916,9 @@
 			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
 		},
 		"os-browserify": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
@@ -7787,19 +7926,27 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"output-file-sync": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"requires": {
+				"graceful-fs": "^4.1.4",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.1.0"
+			}
 		},
 		"p-cancelable": {
 			"version": "0.3.0",
@@ -7830,9 +7977,12 @@
 			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
 		},
 		"p-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "^1.0.0"
+			}
 		},
 		"p-locate": {
 			"version": "2.0.0",
@@ -7860,15 +8010,20 @@
 				"p-finally": "^1.0.0"
 			}
 		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
 		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 		},
 		"parse-asn1": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -7876,6 +8031,11 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3"
 			}
+		},
+		"parse-cache-control": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+			"integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -7886,6 +8046,21 @@
 				"is-dotfile": "^1.0.0",
 				"is-extglob": "^1.0.0",
 				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
 			}
 		},
 		"parse-headers": {
@@ -7915,10 +8090,20 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
 			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -7946,17 +8131,19 @@
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"pify": "^2.0.0"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -7966,9 +8153,9 @@
 			}
 		},
 		"peer-id": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.6.tgz",
-			"integrity": "sha512-NyJgPRy108amQClcuBI/VZtyFJLDaTsPC3nVhZ87mpY5JVFmI2Er4atMap6/ToRJxm/RBX1Nh8CMxzlXCpfKKw==",
+			"version": "0.10.7",
+			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+			"integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
 			"requires": {
 				"async": "^2.6.0",
 				"libp2p-crypto": "~0.12.1",
@@ -7976,10 +8163,13 @@
 				"multihashes": "~0.4.13"
 			},
 			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				}
 			}
 		},
@@ -8079,33 +8269,10 @@
 				}
 			}
 		},
-		"prebuild-install": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-			"integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
-			"requires": {
-				"expand-template": "^1.0.2",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"node-abi": "^2.1.1",
-				"noop-logger": "^0.1.1",
-				"npmlog": "^4.0.1",
-				"os-homedir": "^1.0.1",
-				"pump": "^1.0.1",
-				"rc": "^1.1.6",
-				"simple-get": "^1.4.2",
-				"tar-fs": "^1.13.0",
-				"tunnel-agent": "^0.6.0",
-				"xtend": "4.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -8146,14 +8313,14 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise": {
 			"version": "1.3.0",
@@ -8199,9 +8366,9 @@
 			}
 		},
 		"prr": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -8209,9 +8376,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -8224,6 +8391,11 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
 			"integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+		},
+		"pull-defer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
+			"integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
 		},
 		"pull-level": {
 			"version": "2.0.4",
@@ -8254,9 +8426,9 @@
 			"integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
 		},
 		"pull-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz",
-			"integrity": "sha1-HqFMbxMXTmrE3vDCpOdlZ7fLDFw="
+			"version": "3.6.8",
+			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.8.tgz",
+			"integrity": "sha512-wQUIptQBcM0rFsUhZoEpOT3vUn73DtTGVq3NQ86c4T7iMOSprDzeKWYq2ksXnbwiuExTKvt+8G9fzNLFQuiO+A=="
 		},
 		"pull-traverse": {
 			"version": "1.0.3",
@@ -8272,23 +8444,23 @@
 			}
 		},
 		"pump": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-			"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
 			}
 		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 		},
 		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "5.1.1",
@@ -8311,54 +8483,39 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"randomatic": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				},
 				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"randombytes": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -8375,32 +8532,14 @@
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
 			"requires": {
 				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
 				"unpipe": "1.0.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-			"requires": {
-				"deep-extend": "~0.4.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
 			}
 		},
 		"read-chunk": {
@@ -8420,36 +8559,70 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				}
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
 				"isarray": "~1.0.0",
-				"process-nextick-args": "~1.0.6",
+				"process-nextick-args": "~2.0.0",
 				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.0.3",
+				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
 			}
 		},
 		"readdirp": {
@@ -8474,11 +8647,6 @@
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8495,14 +8663,14 @@
 			}
 		},
 		"regenerate": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerator-runtime": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
@@ -8520,6 +8688,15 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -8574,25 +8751,25 @@
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"req-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
-			"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
+			"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
 			"requires": {
-				"req-from": "^1.0.1"
+				"req-from": "^2.0.0"
 			}
 		},
 		"req-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
-			"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
+			"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
 			"requires": {
-				"resolve-from": "^2.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.6.0",
@@ -8602,7 +8779,6 @@
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.1",
 				"har-validator": "~5.0.3",
-				"hawk": "~6.0.2",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -8612,16 +8788,15 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.1",
 				"safe-buffer": "^5.1.1",
-				"stringstream": "~0.0.5",
 				"tough-cookie": "~2.3.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"uuid": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 				}
 			}
 		},
@@ -8659,9 +8834,12 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"requires": {
+				"path-parse": "^1.0.5"
+			}
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
@@ -8669,13 +8847,6 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
 				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				}
 			}
 		},
 		"resolve-dir": {
@@ -8688,9 +8859,14 @@
 			}
 		},
 		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"responselike": {
 			"version": "1.0.2",
@@ -8717,6 +8893,11 @@
 				"through": "~2.3.4"
 			}
 		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -8731,29 +8912,14 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
 				"glob": "^7.0.5"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"ripemd160": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"requires": {
-				"hash-base": "^2.0.0",
+				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
 			}
 		},
@@ -8784,16 +8950,6 @@
 			"integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
 			"requires": {
 				"optimist": "~0.3.5"
-			},
-			"dependencies": {
-				"optimist": {
-					"version": "0.3.7",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-					"requires": {
-						"wordwrap": "~0.0.2"
-					}
-				}
 			}
 		},
 		"run-async": {
@@ -8812,22 +8968,9 @@
 			}
 		},
 		"rustbn.js": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
-			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"requires": {
-				"rx-lite": "*"
-			}
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+			"integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
 		},
 		"rxjs": {
 			"version": "5.5.10",
@@ -8838,9 +8981,22 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sandwich-stream": {
 			"version": "1.0.0",
@@ -8878,9 +9034,9 @@
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
-			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+			"integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
 			"requires": {
 				"bindings": "^1.2.1",
 				"bip66": "^1.1.3",
@@ -8889,7 +9045,6 @@
 				"drbg.js": "^1.0.1",
 				"elliptic": "^6.2.3",
 				"nan": "^2.2.1",
-				"prebuild-install": "^2.0.0",
 				"safe-buffer": "^5.1.0"
 			}
 		},
@@ -8922,9 +9077,9 @@
 			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
 		},
 		"semver": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"send": {
 			"version": "0.16.2",
@@ -8944,6 +9099,26 @@
 				"on-finished": "~2.3.0",
 				"range-parser": "~1.2.0",
 				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
 			}
 		},
 		"serve-static": {
@@ -8979,31 +9154,52 @@
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-			"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"sha.js": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
 		},
 		"sha3": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
-			"integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+			"integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
 			"requires": {
-				"nan": "^2.0.5"
+				"nan": "2.10.0"
 			}
 		},
 		"shebang-command": {
@@ -9032,21 +9228,6 @@
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
 				"rechoir": "^0.6.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"sigmund": {
@@ -9073,13 +9254,13 @@
 			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
 		},
 		"simple-get": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-			"integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
 			"requires": {
+				"decompress-response": "^3.3.0",
 				"once": "^1.3.1",
-				"unzip-response": "^1.0.0",
-				"xtend": "^4.0.0"
+				"simple-concat": "^1.0.0"
 			}
 		},
 		"slash": {
@@ -9097,12 +9278,96 @@
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
 			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
-		"sntp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"hoek": "4.x.x"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sol-digger": {
@@ -9127,114 +9392,25 @@
 				"yargs": "^4.7.1"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+				"fs-extra": {
+					"version": "0.30.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 					"requires": {
-						"lcid": "^1.0.0"
+						"graceful-fs": "^4.1.6"
 					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
 					"version": "4.8.1",
@@ -9255,15 +9431,6 @@
 						"window-size": "^0.2.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "^3.0.0",
-						"lodash.assign": "^4.0.6"
 					}
 				}
 			}
@@ -9282,7 +9449,51 @@
 				"sol-explore": "^1.6.2",
 				"solidity-parser-sc": "0.4.1",
 				"web3": "^0.18.4"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"req-cwd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
+					"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
+					"requires": {
+						"req-from": "^1.0.1"
+					}
+				},
+				"req-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
+					"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
+					"requires": {
+						"resolve-from": "^2.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				}
 			}
+		},
+		"solidity-parser-antlr": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz",
+			"integrity": "sha512-g1RWj6m377CBlUBlyffhv4UOO48ue+gL7GlmE9i77N8bxaKgzWvTl1xzvDadaubJoz2euPpk3A7qTPbqkUof1w=="
 		},
 		"solidity-parser-sc": {
 			"version": "0.4.1",
@@ -9294,114 +9505,85 @@
 				"yargs": "^4.6.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				"commander": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"ms": "0.7.1"
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"os-locale": {
+				"diff": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"string-width": {
+				"escape-string-regexp": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"inherits": "2",
+						"minimatch": "0.3"
 					}
 				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"lru-cache": "2",
+						"sigmund": "~1.0.0"
 					}
 				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				"mocha": {
+					"version": "2.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+					"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+					"requires": {
+						"commander": "2.3.0",
+						"debug": "2.2.0",
+						"diff": "1.4.0",
+						"escape-string-regexp": "1.0.2",
+						"glob": "3.2.11",
+						"growl": "1.9.2",
+						"jade": "0.26.3",
+						"mkdirp": "0.5.1",
+						"supports-color": "1.2.0",
+						"to-iso-string": "0.0.2"
+					},
+					"dependencies": {
+						"growl": {
+							"version": "1.9.2",
+							"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+							"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+						}
+					}
 				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"supports-color": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
 				},
 				"yargs": {
 					"version": "4.8.1",
@@ -9423,22 +9605,42 @@
 						"y18n": "^3.2.1",
 						"yargs-parser": "^2.4.1"
 					}
+				}
+			}
+		},
+		"solidity-sha3": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
+			"integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
+			"requires": {
+				"babel-cli": "*",
+				"babel-preset-es2015": "*",
+				"babel-register": "*",
+				"left-pad": "^1.1.1",
+				"web3": "^0.16.0"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+					"from": "git+https://github.com/debris/bignumber.js.git#master"
 				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+				"web3": {
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
 					"requires": {
-						"camelcase": "^3.0.0",
-						"lodash.assign": "^4.0.6"
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xmlhttprequest": "*"
 					}
 				}
 			}
 		},
 		"solium": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/solium/-/solium-1.0.4.tgz",
-			"integrity": "sha512-IiWV5YLSuRplNAOXMhrOH8yi5J4PbNEbZaxhSdxtgEeK9tA6OXcAvwTsq2I8qRzqf6m3Bxr6OhiGboQaLtGC4Q==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/solium/-/solium-1.1.7.tgz",
+			"integrity": "sha512-yYbalsrzJCU+QJ0HZvxAT4IQIqI1e6KPW2vop0NaHwdijqhQC9fJkVioCrL18NbO2Z8rdcnx8Y0JpvYJWrIjRg==",
 			"requires": {
 				"ajv": "^5.2.2",
 				"chokidar": "^1.6.0",
@@ -9447,42 +9649,59 @@
 				"js-string-escape": "^1.0.1",
 				"lodash": "^4.14.2",
 				"sol-digger": "0.0.2",
-				"sol-explore": "^1.6.1",
-				"solium-plugin-security": "0.0.2",
-				"solparse": "1.4.0"
+				"sol-explore": "1.6.1",
+				"solium-plugin-security": "0.1.1",
+				"solparse": "2.2.5",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
 					}
 				},
-				"commander": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"requires": {
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
+					}
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -9497,6 +9716,22 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
 					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
 				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -9510,15 +9745,61 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
 				"growl": {
 					"version": "1.10.3",
 					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
 					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
 				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
 				"mocha": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+					"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
 					"requires": {
 						"browser-stdout": "1.3.0",
 						"commander": "2.11.0",
@@ -9530,12 +9811,29 @@
 						"he": "1.1.1",
 						"mkdirp": "0.5.1",
 						"supports-color": "4.4.0"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.11.0",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+							"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+						}
 					}
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"sol-explore": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/sol-explore/-/sol-explore-1.6.1.tgz",
+					"integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs="
+				},
 				"solparse": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
-					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.5.tgz",
+					"integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
 					"requires": {
 						"mocha": "^4.0.1",
 						"pegjs": "^0.10.0",
@@ -9549,40 +9847,13 @@
 					"requires": {
 						"has-flag": "^2.0.0"
 					}
-				},
-				"yargs": {
-					"version": "10.0.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-					"requires": {
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
 				}
 			}
 		},
 		"solium-plugin-security": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.0.2.tgz",
-			"integrity": "sha512-2xjJoAWeY1Ynz1ExxtCVSABAMPrDV/AqhjE/X6jXMHJ1ubT+j9kDt5HKaHNOCa2MWoTna281HzcZlTioR1/ObA=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+			"integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
 		},
 		"sort-keys": {
 			"version": "2.0.0",
@@ -9602,6 +9873,18 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -9610,23 +9893,46 @@
 				"source-map": "^0.5.6"
 			}
 		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
 		"spdx-correct": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-license-ids": "^1.0.2"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
 		"spdx-expression-parse": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
 		},
 		"spdx-license-ids": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
 		},
 		"split2": {
 			"version": "2.2.0",
@@ -9642,9 +9948,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -9657,14 +9963,33 @@
 			}
 		},
 		"stable": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-			"integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
 		},
 		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -9681,13 +10006,13 @@
 			}
 		},
 		"stream-http": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
-				"readable-stream": "^2.2.6",
+				"readable-stream": "^2.3.6",
 				"to-arraybuffer": "^1.0.0",
 				"xtend": "^4.0.0"
 			}
@@ -9740,32 +10065,13 @@
 			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string.prototype.trim": {
@@ -9779,17 +10085,9 @@
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -9800,9 +10098,12 @@
 			}
 		},
 		"strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
+			}
 		},
 		"strip-bom-stream": {
 			"version": "2.0.0",
@@ -9811,16 +10112,6 @@
 			"requires": {
 				"first-chunk-stream": "^2.0.0",
 				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				}
 			}
 		},
 		"strip-dirs": {
@@ -9844,15 +10135,13 @@
 				"is-hex-prefixed": "1.0.0"
 			}
 		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-		},
 		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"swarm-js": {
 			"version": "0.1.37",
@@ -9891,6 +10180,14 @@
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^2.1.0"
 					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
 				}
 			}
 		},
@@ -9899,26 +10196,44 @@
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 		},
+		"sync-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.0.0.tgz",
+			"integrity": "sha512-jGNIAlCi9iU4X3Dm4oQnNQshDD3h0/1A7r79LyqjbjUnj69sX6mShAXlhRXgImsfVKtTcnra1jfzabdZvp+Lmw==",
+			"requires": {
+				"http-response-object": "^3.0.1",
+				"sync-rpc": "^1.2.1",
+				"then-request": "^6.0.0"
+			}
+		},
+		"sync-rpc": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
+			"integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+			"requires": {
+				"get-port": "^3.1.0"
+			}
+		},
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
 			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
 		"tape": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-			"integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+			"integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
 			"requires": {
 				"deep-equal": "~1.0.1",
 				"defined": "~1.0.0",
 				"for-each": "~0.3.2",
-				"function-bind": "~1.1.0",
+				"function-bind": "~1.1.1",
 				"glob": "~7.1.2",
 				"has": "~1.0.1",
 				"inherits": "~2.0.3",
 				"minimist": "~1.2.0",
-				"object-inspect": "~1.3.0",
-				"resolve": "~1.4.0",
+				"object-inspect": "~1.5.0",
+				"resolve": "~1.5.0",
 				"resumer": "~0.0.0",
 				"string.prototype.trim": "~1.1.2",
 				"through": "~2.3.8"
@@ -9941,14 +10256,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"resolve": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-					"requires": {
-						"path-parse": "^1.0.5"
-					}
 				}
 			}
 		},
@@ -9962,26 +10269,29 @@
 				"inherits": "2"
 			}
 		},
-		"tar-fs": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-			"requires": {
-				"chownr": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			}
-		},
 		"tar-stream": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+			"integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
 			"requires": {
 				"bl": "^1.0.0",
+				"buffer-alloc": "^1.1.0",
 				"end-of-stream": "^1.0.0",
-				"readable-stream": "^2.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.0",
 				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+					"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+					"requires": {
+						"readable-stream": "^2.3.5",
+						"safe-buffer": "^5.1.1"
+					}
+				}
 			}
 		},
 		"tar.gz": {
@@ -10000,11 +10310,6 @@
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
 					"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-				},
-				"commander": {
-					"version": "2.15.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-					"integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
 				}
 			}
 		},
@@ -10038,6 +10343,39 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
 			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
+		},
+		"then-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.0.tgz",
+			"integrity": "sha512-xA+7uEMc+jsQIoyySJ93Ad08Kuqnik7u6jLS5hR91Z3smAoCfL3M8/MqMlobAa9gzBfO9pA88A/AntfepkkMJQ==",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/form-data": "0.0.33",
+				"@types/node": "^8.0.0",
+				"@types/qs": "^6.2.31",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.6.0",
+				"form-data": "^2.2.0",
+				"http-basic": "^7.0.0",
+				"http-response-object": "^3.0.1",
+				"promise": "^8.0.0",
+				"qs": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "8.10.17",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
+					"integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg=="
+				},
+				"promise": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+					"integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				}
+			}
 		},
 		"thenify": {
 			"version": "3.3.0",
@@ -10075,9 +10413,9 @@
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -10119,6 +10457,11 @@
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
+		"to-buffer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -10129,12 +10472,47 @@
 			"resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
 			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE="
 		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
 		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
 				"punycode": "^1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
 			}
 		},
 		"trim": {
@@ -10157,38 +10535,12 @@
 				"solc": "0.4.18"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
-				},
 				"debug": {
 					"version": "2.6.8",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"requires": {
 						"ms": "2.0.0"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.2",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -10215,6 +10567,11 @@
 						"supports-color": "3.1.2"
 					}
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
 				"supports-color": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -10234,21 +10591,93 @@
 				"ethereumjs-wallet": "^0.6.0",
 				"web3": "^0.18.2",
 				"web3-provider-engine": "^8.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				},
+				"web3-provider-engine": {
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+					"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+					"requires": {
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
+					},
+					"dependencies": {
+						"bignumber.js": {
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "git+https://github.com/debris/bignumber.js.git#master"
+						},
+						"web3": {
+							"version": "0.16.0",
+							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+							"requires": {
+								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
+							}
+						}
+					}
+				}
 			}
 		},
 		"truffle-privatekey-provider": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.5.tgz",
-			"integrity": "sha512-I4agR/KbFA+XLLYxN32YeMTm5D9ySMQ5yN/CaRywCYceaZM+cPIXJQoX5R+L6S5i9OSm0aebbOGsdYSVU4YGaQ==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.6.tgz",
+			"integrity": "sha512-x4tsMeXolhae9mzIA5k9bbq4FdhzSI/UGyAKU/B9xepE0lMCfhpuQv8WM2xdLlqyDtiHouC8z5+rmSmcK8bGEQ==",
 			"requires": {
 				"ethereumjs-wallet": "^0.6.0",
 				"web3": "^0.20.1",
 				"web3-provider-engine": "^8.4.0"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"bignumber.js": {
 					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
 				},
 				"web3": {
 					"version": "0.20.6",
@@ -10260,11 +10689,43 @@
 						"utf8": "^2.1.1",
 						"xhr2": "*",
 						"xmlhttprequest": "*"
+					}
+				},
+				"web3-provider-engine": {
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+					"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+					"requires": {
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
 					},
 					"dependencies": {
 						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "git+https://github.com/debris/bignumber.js.git#master"
+						},
+						"web3": {
+							"version": "0.16.0",
+							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+							"requires": {
+								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
+							}
 						}
 					}
 				}
@@ -10309,21 +10770,6 @@
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.18"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-				},
-				"mime-types": {
-					"version": "2.1.18",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"requires": {
-						"mime-db": "~1.33.0"
-					}
-				}
 			}
 		},
 		"typedarray": {
@@ -10367,6 +10813,26 @@
 				"yargs": "~3.10.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -10424,13 +10890,50 @@
 						"ieee754": "^1.1.4",
 						"isarray": "^1.0.0"
 					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
 		"underscore": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz",
+			"integrity": "sha512-4IV1DSSxC1QK48j9ONFK1MoIAKKkbE8i7u55w2R6IqBqbT7A/iG7aZBCR2Bi8piF0Uz+i/MG1aeqLwl/5vqF+A=="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
 		},
 		"universalify": {
 			"version": "0.1.1",
@@ -10447,15 +10950,61 @@
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
-		"untildify": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
+			}
 		},
-		"unzip-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+		"untildify": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
@@ -10490,6 +11039,26 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"use": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"requires": {
+				"kind-of": "^6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"user-home": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
 		},
 		"utf8": {
 			"version": "2.1.2",
@@ -10531,13 +11100,21 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz",
 			"integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA=="
 		},
-		"validate-npm-package-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+		"v8flags": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
 			"requires": {
-				"spdx-correct": "~1.0.0",
-				"spdx-expression-parse": "~1.0.0"
+				"user-home": "^1.1.1"
+			}
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"varint": {
@@ -10588,16 +11165,6 @@
 				"strip-bom": "^2.0.0",
 				"strip-bom-stream": "^2.0.0",
 				"vinyl": "^1.1.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				}
 			}
 		},
 		"vm-browserify": {
@@ -10609,153 +11176,202 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"requires": {
-				"async": "^2.1.2",
-				"chokidar": "^1.7.0",
-				"graceful-fs": "^4.1.2"
+				"chokidar": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"neo-async": "^2.5.0"
 			}
 		},
 		"web3": {
-			"version": "0.18.4",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-			"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+			"version": "1.0.0-beta.26",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
+			"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-				"crypto-js": "^3.1.4",
-				"utf8": "^2.1.1",
-				"xhr2": "*",
-				"xmlhttprequest": "*"
+				"web3-bzz": "^1.0.0-beta.26",
+				"web3-core": "^1.0.0-beta.26",
+				"web3-eth": "^1.0.0-beta.26",
+				"web3-eth-personal": "^1.0.0-beta.26",
+				"web3-net": "^1.0.0-beta.26",
+				"web3-shh": "^1.0.0-beta.26",
+				"web3-utils": "^1.0.0-beta.26"
 			}
 		},
 		"web3-bzz": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.31.tgz",
-			"integrity": "sha1-rrp8lVhhqZupLdHKj3x6EngyhZ0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+			"integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
 			"requires": {
 				"got": "7.1.0",
 				"swarm-js": "0.1.37",
 				"underscore": "1.8.3"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.31.tgz",
-			"integrity": "sha1-q9FJzEEshTZb9NEZfHSeP1Dj6qE=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+			"integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
 			"requires": {
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-requestmanager": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-requestmanager": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-core-helpers": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.31.tgz",
-			"integrity": "sha1-cETI89P3NRWLoeZrhPbECQiCFlw=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+			"integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-eth-iban": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-eth-iban": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-method": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.31.tgz",
-			"integrity": "sha1-IRkLm4zxUDUT6Diw9O73Jg/uCTs=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+			"integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-promievent": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-promievent": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-promievent": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.31.tgz",
-			"integrity": "sha1-3alb5l7NeSTjAKXphHfBuwpX6PM=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+			"integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
 			"requires": {
 				"any-promise": "1.3.0",
 				"eventemitter3": "1.1.1"
 			}
 		},
 		"web3-core-requestmanager": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.31.tgz",
-			"integrity": "sha1-S/ZntBTUbgZtmTCZTzT0b7QI++c=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+			"integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-providers-http": "1.0.0-beta.31",
-				"web3-providers-ipc": "1.0.0-beta.31",
-				"web3-providers-ws": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-providers-http": "1.0.0-beta.34",
+				"web3-providers-ipc": "1.0.0-beta.34",
+				"web3-providers-ws": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-subscriptions": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.31.tgz",
-			"integrity": "sha1-fpAG3iCosEB6wTZO9WuHz8TQ8ks=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+			"integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
 			"requires": {
 				"eventemitter3": "1.1.1",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.31.tgz",
-			"integrity": "sha1-t7SwdVNLOjsKtbVpe9UIXXnrYcY=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+			"integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-eth-abi": "1.0.0-beta.31",
-				"web3-eth-accounts": "1.0.0-beta.31",
-				"web3-eth-contract": "1.0.0-beta.31",
-				"web3-eth-iban": "1.0.0-beta.31",
-				"web3-eth-personal": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-eth-abi": "1.0.0-beta.34",
+				"web3-eth-accounts": "1.0.0-beta.34",
+				"web3-eth-contract": "1.0.0-beta.34",
+				"web3-eth-iban": "1.0.0-beta.34",
+				"web3-eth-personal": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth-abi": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.31.tgz",
-			"integrity": "sha1-xQ457cINFrTDWQKegpuEE5THL8E=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+			"integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
 			"requires": {
 				"bn.js": "4.11.6",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			},
 			"dependencies": {
 				"bn.js": {
 					"version": "4.11.6",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				}
 			}
 		},
 		"web3-eth-accounts": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.31.tgz",
-			"integrity": "sha1-Mnm9BpbYK8ThUswddWx74i0xkq0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+			"integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
 			"requires": {
-				"any-promise": "^1.3.0",
-				"crypto-browserify": "^3.12.0",
+				"any-promise": "1.3.0",
+				"crypto-browserify": "3.12.0",
 				"eth-lib": "0.2.7",
 				"scrypt.js": "0.2.0",
 				"underscore": "1.8.3",
 				"uuid": "2.0.1",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			},
 			"dependencies": {
 				"eth-lib": {
@@ -10768,6 +11384,11 @@
 						"xhr-request-promise": "^0.1.2"
 					}
 				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				},
 				"uuid": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
@@ -10776,55 +11397,69 @@
 			}
 		},
 		"web3-eth-contract": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.31.tgz",
-			"integrity": "sha1-J5RkM/kdiVMBPi2X/Yt4qe1rbtw=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+			"integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-promievent": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-eth-abi": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-promievent": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-eth-abi": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth-iban": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.31.tgz",
-			"integrity": "sha1-7WS+0zO7BApvKU+06dGOrdvr/8o=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+			"integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
 			"requires": {
-				"bn.js": "^4.11.6",
-				"web3-utils": "1.0.0-beta.31"
+				"bn.js": "4.11.6",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
 			}
 		},
 		"web3-eth-personal": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.31.tgz",
-			"integrity": "sha1-Kw1ghZIOndzfu63yCnFfDMN3HYA=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+			"integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-net": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.31.tgz",
-			"integrity": "sha1-0mv8oOoXUvX9XXITTgDlE60efhk=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+			"integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-provider-engine": {
-			"version": "8.6.1",
-			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
-			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+			"version": "8.1.19",
+			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
+			"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
 			"requires": {
 				"async": "^2.1.2",
 				"clone": "^2.0.0",
@@ -10842,24 +11477,17 @@
 				"xtend": "^4.0.1"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"bignumber.js": {
 					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-					"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-				},
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "^6.24.0",
-						"babelify": "^7.3.0",
-						"bn.js": "^4.8.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"secp256k1": "^3.0.1"
-					}
+					"from": "git+https://github.com/debris/bignumber.js.git#master"
 				},
 				"web3": {
 					"version": "0.16.0",
@@ -10870,75 +11498,71 @@
 						"crypto-js": "^3.1.4",
 						"utf8": "^2.1.1",
 						"xmlhttprequest": "*"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-						}
 					}
 				}
 			}
 		},
 		"web3-providers-http": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.31.tgz",
-			"integrity": "sha1-E0Ce9ErhYjzVxNzT20sI1vu6RTI=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+			"integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
 			"requires": {
-				"web3-core-helpers": "1.0.0-beta.31",
+				"web3-core-helpers": "1.0.0-beta.34",
 				"xhr2": "0.1.4"
 			}
 		},
 		"web3-providers-ipc": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.31.tgz",
-			"integrity": "sha1-zm2mcPqhlFjmIt/tm+QAWE/DNyQ=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+			"integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
 			"requires": {
 				"oboe": "2.1.3",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-providers-ws": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.31.tgz",
-			"integrity": "sha1-zHG3Do2LUyAaUzdDcHww6MCZ4o0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+			"integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
 			},
 			"dependencies": {
-				"websocket": {
-					"version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-					"from": "websocket@git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-					"requires": {
-						"debug": "^2.2.0",
-						"nan": "^2.3.3",
-						"typedarray-to-buffer": "^3.1.2",
-						"yaeti": "^0.0.6"
-					}
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				}
 			}
 		},
 		"web3-shh": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.31.tgz",
-			"integrity": "sha1-AW0gS+K7obfzs5FQJyGdJ07+XlI=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+			"integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34"
 			}
 		},
 		"web3-utils": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.31.tgz",
-			"integrity": "sha1-DxgSXT6WmK6Cy/b6Ka3B4WFvKTY=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+			"integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
 			"requires": {
 				"bn.js": "4.11.6",
-				"eth-lib": "^0.1.27",
+				"eth-lib": "0.1.27",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
 				"randomhex": "0.1.5",
@@ -10951,6 +11575,11 @@
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
 				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				},
 				"utf8": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
@@ -10960,12 +11589,12 @@
 		},
 		"webcrypto-shim": {
 			"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
-			"from": "webcrypto-shim@github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+			"from": "github:dignifiedquire/webcrypto-shim#master"
 		},
 		"webpack": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+			"integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
 			"requires": {
 				"acorn": "^5.0.0",
 				"acorn-dynamic-import": "^2.0.0",
@@ -10991,12 +11620,158 @@
 				"yargs": "^8.0.2"
 			},
 			"dependencies": {
+				"ajv-keywords": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"requires": {
 						"has-flag": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"requires": {
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"requires": {
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -11009,20 +11784,62 @@
 				"jscodeshift": "^0.4.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
 				"ast-types": {
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
 					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
 				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
 				},
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
 				},
 				"jscodeshift": {
 					"version": "0.4.1",
@@ -11046,6 +11863,26 @@
 						"write-file-atomic": "^1.2.0"
 					}
 				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
 				"recast": {
 					"version": "0.12.9",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
@@ -11066,9 +11903,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.15.tgz",
-			"integrity": "sha512-bjNeIUO51D4OsmZ5ufzcpzVoacjxfWNfeBZKYL3jc+EMfCME3TyfdCPSUoKiOnebQChfupQuIRpAnx7L4l3Hew==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.3.tgz",
+			"integrity": "sha512-5AsKoL/Ccn8iTrwk3uErdyhetGH+c7VRQ7Itim2GL0IhBRq5rtojVDk00buMRmFmBpw1RvHXq97Gup965LbozA==",
 			"requires": {
 				"chalk": "^2.3.2",
 				"cross-spawn": "^6.0.5",
@@ -11095,7 +11932,7 @@
 				"webpack-addons": "^1.1.5",
 				"yargs": "^11.1.0",
 				"yeoman-environment": "^2.0.0",
-				"yeoman-generator": "^2.0.3"
+				"yeoman-generator": "^2.0.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11103,28 +11940,10 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
 				},
 				"cliui": {
 					"version": "4.1.0",
@@ -11164,9 +11983,9 @@
 					}
 				},
 				"got": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-					"integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+					"integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
 					"requires": {
 						"@sindresorhus/is": "^0.7.0",
 						"cacheable-request": "^2.1.1",
@@ -11187,15 +12006,30 @@
 						"url-to-options": "^1.0.1"
 					}
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
 				},
 				"p-cancelable": {
 					"version": "0.4.1",
@@ -11220,10 +12054,14 @@
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
 					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 				},
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -11231,14 +12069,6 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
 						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				},
 				"tapable": {
@@ -11253,6 +12083,11 @@
 					"requires": {
 						"prepend-http": "^2.0.0"
 					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "11.1.0",
@@ -11284,9 +12119,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
-			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -11299,10 +12134,20 @@
 				}
 			}
 		},
+		"websocket": {
+			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+			"requires": {
+				"debug": "^2.2.0",
+				"nan": "^2.3.3",
+				"typedarray-to-buffer": "^3.1.2",
+				"yaeti": "^0.0.6"
+			}
+		},
 		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"which": {
 			"version": "1.3.0",
@@ -11313,34 +12158,14 @@
 			}
 		},
 		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"wide-align": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"requires": {
-				"string-width": "^1.0.2"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
-			}
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
 		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -11354,18 +12179,6 @@
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
 			}
 		},
 		"wrappy": {
@@ -11394,9 +12207,9 @@
 			}
 		},
 		"xhr": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-			"integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
 			"requires": {
 				"global": "~4.3.0",
 				"is-function": "^1.0.1",
@@ -11416,18 +12229,6 @@
 				"timed-out": "^4.0.1",
 				"url-set-query": "^1.0.0",
 				"xhr": "^2.0.4"
-			},
-			"dependencies": {
-				"simple-get": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-					"integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
-					"requires": {
-						"decompress-response": "^3.3.0",
-						"once": "^1.3.1",
-						"simple-concat": "^1.0.0"
-					}
-				}
 			}
 		},
 		"xhr-request-promise": {
@@ -11469,67 +12270,98 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"requires": {
-				"camelcase": "^4.1.0",
-				"cliui": "^3.2.0",
+				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
 				"get-caller-file": "^1.0.1",
 				"os-locale": "^2.0.0",
-				"read-pkg-up": "^2.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1",
-				"yargs-parser": "^7.0.0"
+				"yargs-parser": "^8.1.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
 						"wrap-ansi": "^2.0.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"requires": {
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"requires": {
-				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				}
+				"camelcase": "^3.0.0",
+				"lodash.assign": "^4.0.6"
 			}
 		},
 		"yauzl": {
@@ -11542,21 +12374,23 @@
 			}
 		},
 		"yeoman-environment": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-			"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+			"integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
 			"requires": {
 				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
 				"debug": "^3.1.0",
 				"diff": "^3.3.1",
 				"escape-string-regexp": "^1.0.2",
-				"globby": "^6.1.0",
+				"globby": "^8.0.1",
 				"grouped-queue": "^0.3.3",
-				"inquirer": "^3.3.0",
+				"inquirer": "^5.2.0",
 				"is-scoped": "^1.0.0",
-				"lodash": "^4.17.4",
+				"lodash": "^4.17.10",
 				"log-symbols": "^2.1.0",
 				"mem-fs": "^1.1.0",
+				"strip-ansi": "^4.0.0",
 				"text-table": "^0.2.0",
 				"untildify": "^3.0.2"
 			},
@@ -11566,22 +12400,16 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -11597,31 +12425,10 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -11630,37 +12437,29 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
 		"yeoman-generator": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
-			"integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
 			"requires": {
 				"async": "^2.6.0",
 				"chalk": "^2.3.0",
 				"cli-table": "^0.3.1",
-				"cross-spawn": "^5.1.0",
+				"cross-spawn": "^6.0.5",
 				"dargs": "^5.1.0",
-				"dateformat": "^3.0.2",
+				"dateformat": "^3.0.3",
 				"debug": "^3.1.0",
 				"detect-conflict": "^1.0.0",
 				"error": "^7.0.2",
 				"find-up": "^2.1.0",
 				"github-username": "^4.0.0",
-				"istextorbinary": "^2.1.0",
-				"lodash": "^4.17.4",
+				"istextorbinary": "^2.2.1",
+				"lodash": "^4.17.10",
 				"make-dir": "^1.1.0",
-				"mem-fs-editor": "^3.0.2",
+				"mem-fs-editor": "^4.0.0",
 				"minimist": "^1.2.0",
 				"pretty-bytes": "^4.0.2",
 				"read-chunk": "^2.1.0",
@@ -11673,22 +12472,24 @@
 				"yeoman-environment": "^2.0.5"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"lodash": "^4.17.10"
 					}
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -11698,24 +12499,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
@@ -11732,6 +12515,11 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"parse-json": {
 					"version": "4.0.0",
@@ -11775,22 +12563,19 @@
 					}
 				},
 				"shelljs": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-					"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+					"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
 					"requires": {
 						"glob": "^7.0.0",
 						"interpret": "^1.0.0",
 						"rechoir": "^0.6.2"
 					}
 				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				}
 			}
 		}

--- a/apps/token-manager/package-lock.json
+++ b/apps/token-manager/package-lock.json
@@ -3,208 +3,83 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@aragon/cli": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.0.6.tgz",
-			"integrity": "sha512-MvmLlN2o2+ixax/xPpp4ZRY5XAOyhIDXaqax/lqRQq3nIQBxWV4KxAWQS2sM0B6ZncFRDvKsWAU+4mqmk606Dg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.2.0.tgz",
+			"integrity": "sha512-CkbgxET1xRHqxCnAWD3zEzeNiVeIlA+0FFbP3n32dGu21vxQZk5bHUxjhpSU5Uc28Fa7CNv9pK3niFwMrqexDA==",
 			"requires": {
-				"chalk": "2.3.2",
-				"eth-ens-namehash": "2.0.8",
-				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
-				"find-up": "2.1.0",
-				"fs-extra": "4.0.3",
-				"ganache-core": "2.0.2",
-				"git-clone": "0.1.0",
-				"homedir": "0.6.0",
-				"ipfs-api": "14.3.7",
-				"js-sha3": "0.7.0",
-				"multimatch": "2.1.0",
-				"rimraf": "2.6.2",
-				"semver": "5.4.1",
-				"stream-to-string": "1.1.0",
-				"tmp-promise": "1.0.4",
+				"chalk": "^2.1.0",
+				"eth-ens-namehash": "^2.0.0",
+				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#48f3e968d781f44f8bf8c32476948651d4d14ef4",
+				"find-up": "^2.1.0",
+				"fs-extra": "^4.0.2",
+				"ganache-core": "~2.0.2",
+				"git-clone": "^0.1.0",
+				"homedir": "^0.6.0",
+				"ipfs-api": "^14.3.7",
+				"js-sha3": "^0.7.0",
+				"multimatch": "^2.1.0",
+				"rimraf": "^2.6.2",
+				"semver": "^5.4.1",
+				"stream-to-string": "^1.1.0",
+				"tmp-promise": "^1.0.4",
 				"web3": "1.0.0-beta.26",
-				"yargs": "10.1.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "1.9.1"
-					}
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-					"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
-					}
-				},
-				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"ethereum-ens": {
-					"version": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
-					"requires": {
-						"bluebird": "3.5.1",
-						"eth-ens-namehash": "2.0.8",
-						"js-sha3": "0.5.7",
-						"pako": "1.0.6",
-						"text-encoding": "0.6.4",
-						"underscore": "1.8.3",
-						"web3": "0.19.1"
-					},
-					"dependencies": {
-						"js-sha3": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-							"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-						},
-						"web3": {
-							"version": "0.19.1",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
-							"integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
-							"requires": {
-								"bignumber.js": "4.1.0",
-								"crypto-js": "3.1.8",
-								"utf8": "2.1.2",
-								"xhr2": "0.1.4",
-								"xmlhttprequest": "1.8.0"
-							}
-						}
-					}
-				},
-				"fs-extra": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"js-sha3": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-					"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"requires": {
-						"graceful-fs": "4.1.11"
-					}
-				},
-				"pako": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-					"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"requires": {
-						"has-flag": "3.0.0"
-					}
-				},
-				"web3": {
-					"version": "1.0.0-beta.26",
-					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
-					"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
-					"requires": {
-						"web3-bzz": "1.0.0-beta.31",
-						"web3-core": "1.0.0-beta.31",
-						"web3-eth": "1.0.0-beta.31",
-						"web3-eth-personal": "1.0.0-beta.31",
-						"web3-net": "1.0.0-beta.31",
-						"web3-shh": "1.0.0-beta.31",
-						"web3-utils": "1.0.0-beta.31"
-					}
-				},
-				"yargs": {
-					"version": "10.1.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-					"requires": {
-						"camelcase": "4.1.0"
-					}
-				}
+				"yargs": "^10.1.0"
 			}
 		},
 		"@aragon/os": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.4.tgz",
-			"integrity": "sha512-Uvzsrw1+Qc1i7WeyRSBRD9C0gGTnlS4O8nwTieG9pqbuThfevpoCHeR7MqPzhWDo5PLQ4wl6WForRyI/vyvXHw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.7.tgz",
+			"integrity": "sha512-NSEi9uUooxWTjwBzogabP8KO0idBGmFoUc+5IHaWaVelTwS11vqjJ83jc9cUo1s08ei/qNjEiFqDi7ieS0719w==",
 			"requires": {
-				"homedir": "0.6.0",
-				"truffle-privatekey-provider": "0.0.5"
+				"homedir": "^0.6.0",
+				"truffle-hdwallet-provider": "0.0.3",
+				"truffle-privatekey-provider": "0.0.6"
 			}
+		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
+			"integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
 		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+		},
+		"@types/concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/form-data": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "9.6.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
+			"integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig=="
+		},
+		"@types/qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q=="
 		},
 		"abbrev": {
 			"version": "1.0.9",
@@ -212,226 +87,45 @@
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
 		},
 		"abi-decoder": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.0.9.tgz",
-			"integrity": "sha1-a8/Yb39j++yFc9l3izpPkruS4B8=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.1.0.tgz",
+			"integrity": "sha512-nvLArBx0XOJufWyaghMKtIofZDBwEMdVZoqcetQOIe1qYeKZk4+kRYGPEJ5lt7dD3MLulw//amUzOJLM8eW5RA==",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-loader": "6.4.1",
-				"babel-plugin-add-module-exports": "0.2.1",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-preset-es2015": "6.24.1",
-				"chai": "3.5.0",
-				"web3": "0.18.4",
-				"webpack": "2.7.0"
+				"babel-core": "^6.23.1",
+				"babel-loader": "^6.3.2",
+				"babel-plugin-add-module-exports": "^0.2.1",
+				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+				"babel-plugin-transform-runtime": "^6.23.0",
+				"babel-preset-es2015": "^6.22.0",
+				"chai": "^3.5.0",
+				"web3": "^0.18.4",
+				"webpack": "^2.7.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
-				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				},
-				"webpack": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
-					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
-					"requires": {
-						"acorn": "5.2.1",
-						"acorn-dynamic-import": "2.0.2",
-						"ajv": "4.11.8",
-						"ajv-keywords": "1.5.1",
-						"async": "2.6.0",
-						"enhanced-resolve": "3.4.1",
-						"interpret": "1.0.4",
-						"json-loader": "0.5.7",
-						"json5": "0.5.1",
-						"loader-runner": "2.3.0",
-						"loader-utils": "0.2.17",
-						"memory-fs": "0.4.1",
-						"mkdirp": "0.5.1",
-						"node-libs-browser": "2.0.0",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3",
-						"tapable": "0.2.8",
-						"uglify-js": "2.8.29",
-						"watchpack": "1.4.0",
-						"webpack-sources": "1.0.2",
-						"yargs": "6.6.0"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "3.0.0"
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
 					}
 				}
 			}
 		},
 		"abstract-leveldown": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+			"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
 			"requires": {
-				"xtend": "4.0.1"
+				"xtend": "~4.0.0"
 			}
 		},
 		"accepts": {
@@ -439,36 +133,21 @@
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"requires": {
-				"mime-types": "2.1.18",
+				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-				},
-				"mime-types": {
-					"version": "2.1.18",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"requires": {
-						"mime-db": "1.33.0"
-					}
-				}
 			}
 		},
 		"acorn": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.3"
 			},
 			"dependencies": {
 				"acorn": {
@@ -484,29 +163,29 @@
 			"integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
 		},
 		"ajv": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"amdefine": {
@@ -525,9 +204,12 @@
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"any-observable": {
 			"version": "0.2.0",
@@ -540,26 +222,12 @@
 			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
-			}
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.3"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"argparse": {
@@ -567,7 +235,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"argsarray": {
@@ -576,17 +244,19 @@
 			"integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "1.1.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
@@ -603,7 +273,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -612,14 +282,19 @@
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
@@ -627,13 +302,13 @@
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -654,18 +329,20 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
 		"ast-types": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
 			"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA=="
 		},
 		"async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-			"requires": {
-				"lodash": "4.17.4"
-			}
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"async-each": {
 			"version": "1.0.1",
@@ -677,7 +354,17 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.6.0"
+				"async": "^2.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				}
 			}
 		},
 		"async-limiter": {
@@ -690,72 +377,109 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
+		"atob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.0",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.0",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.8",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-generator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.4",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-				}
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			}
 		},
 		"babel-helper-bindify-decorators": {
@@ -763,9 +487,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -773,9 +497,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -783,10 +507,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -794,10 +518,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -805,9 +529,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -815,10 +539,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"requires": {
-				"babel-helper-bindify-decorators": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-bindify-decorators": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -826,11 +550,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -838,8 +562,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -847,8 +571,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -856,8 +580,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -865,9 +589,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -875,11 +599,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -887,12 +611,12 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -900,8 +624,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-loader": {
@@ -909,23 +633,10 @@
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
 			"integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
 			"requires": {
-				"find-cache-dir": "0.1.1",
-				"loader-utils": "0.2.17",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
-			},
-			"dependencies": {
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
-					}
-				}
+				"find-cache-dir": "^0.1.1",
+				"loader-utils": "^0.2.16",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"babel-messages": {
@@ -933,7 +644,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-add-module-exports": {
@@ -946,7 +657,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1009,9 +720,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-generators": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-generators": "^6.5.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1019,9 +730,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1029,9 +740,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "6.18.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1039,10 +750,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1050,11 +761,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"requires": {
-				"babel-helper-explode-class": "6.24.1",
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-class": "^6.24.1",
+				"babel-plugin-syntax-decorators": "^6.13.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1062,7 +773,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1070,7 +781,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1078,11 +789,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1090,15 +801,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1106,8 +817,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1115,7 +826,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1123,8 +834,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1132,7 +843,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1140,9 +851,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1150,7 +861,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1158,20 +869,20 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"version": "6.26.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1179,9 +890,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1189,9 +900,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1199,8 +910,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1208,12 +919,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1221,8 +932,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1230,7 +941,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1238,9 +949,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1248,7 +959,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1256,7 +967,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1264,9 +975,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1274,9 +985,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1284,8 +995,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-export-extensions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1293,8 +1004,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1302,8 +1013,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1311,7 +1022,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "0.10.1"
+				"regenerator-transform": "^0.10.0"
+			}
+		},
+		"babel-plugin-transform-runtime": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+			"requires": {
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1319,8 +1038,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-preset-es2015": {
@@ -1328,30 +1047,30 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+				"babel-plugin-transform-es2015-for-of": "^6.22.0",
+				"babel-plugin-transform-es2015-function-name": "^6.24.1",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+				"babel-plugin-transform-es2015-object-super": "^6.24.1",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+				"babel-plugin-transform-regenerator": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1359,9 +1078,9 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "6.24.1",
-				"babel-plugin-transform-export-extensions": "6.22.0",
-				"babel-preset-stage-2": "6.24.1"
+				"babel-plugin-transform-class-constructor-call": "^6.24.1",
+				"babel-plugin-transform-export-extensions": "^6.22.0",
+				"babel-preset-stage-2": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1369,10 +1088,10 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-decorators": "6.24.1",
-				"babel-preset-stage-3": "6.24.1"
+				"babel-plugin-syntax-dynamic-import": "^6.18.0",
+				"babel-plugin-transform-class-properties": "^6.24.1",
+				"babel-plugin-transform-decorators": "^6.24.1",
+				"babel-preset-stage-3": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1380,11 +1099,11 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-generator-functions": "6.24.1",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-object-rest-spread": "6.26.0"
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-generator-functions": "^6.24.1",
+				"babel-plugin-transform-async-to-generator": "^6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
+				"babel-plugin-transform-object-rest-spread": "^6.22.0"
 			}
 		},
 		"babel-register": {
@@ -1392,13 +1111,13 @@
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			}
 		},
 		"babel-runtime": {
@@ -1406,8 +1125,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.11.0"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -1415,11 +1134,11 @@
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1427,15 +1146,30 @@
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"babel-types": {
@@ -1443,19 +1177,10 @@
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "1.0.3"
-			}
-		},
-		"babelify": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-			"integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-			"requires": {
-				"babel-core": "6.26.0",
-				"object-assign": "4.1.1"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babylon": {
@@ -1468,15 +1193,70 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
 		"base-x": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
 			"integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
 		},
 		"base64-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
@@ -1484,7 +1264,7 @@
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big.js": {
@@ -1493,12 +1273,14 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bignumber.js": {
-			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
 		},
 		"binary-extensions": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"binaryextensions": {
 			"version": "2.1.1",
@@ -1515,11 +1297,11 @@
 			"resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
 			"integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
 			"requires": {
-				"create-hash": "1.1.3",
-				"pbkdf2": "3.0.14",
-				"randombytes": "2.0.5",
-				"safe-buffer": "5.1.1",
-				"unorm": "1.4.1"
+				"create-hash": "^1.1.0",
+				"pbkdf2": "^3.0.9",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"unorm": "^1.3.3"
 			}
 		},
 		"bip66": {
@@ -1527,15 +1309,28 @@
 			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
 			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"bl": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+			"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "~1.0.26"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				}
 			}
 		},
 		"blakejs": {
@@ -1548,7 +1343,7 @@
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"bluebird": {
@@ -1562,47 +1357,71 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
 			"requires": {
 				"bytes": "3.0.0",
-				"content-type": "1.0.4",
+				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
-				"on-finished": "2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "1.6.16"
-			}
-		},
-		"boom": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"requires": {
-				"hoek": "4.2.0"
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
+				"on-finished": "~2.3.0",
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"brorand": {
@@ -1616,36 +1435,36 @@
 			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
 		},
 		"browserify-aes": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"browserify-cipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"requires": {
-				"browserify-aes": "1.1.1",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.3"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-rsa": {
@@ -1653,8 +1472,8 @@
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sha3": {
@@ -1662,7 +1481,14 @@
 			"resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
 			"integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
 			"requires": {
-				"js-sha3": "0.3.1"
+				"js-sha3": "^0.3.1"
+			},
+			"dependencies": {
+				"js-sha3": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+					"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+				}
 			}
 		},
 		"browserify-sign": {
@@ -1670,21 +1496,21 @@
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
-				"pako": "0.2.9"
+				"pako": "~1.0.5"
 			}
 		},
 		"bs58": {
@@ -1692,7 +1518,7 @@
 			"resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
 			"integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
 			"requires": {
-				"base-x": "1.1.0"
+				"base-x": "^1.1.0"
 			}
 		},
 		"bs58check": {
@@ -1700,8 +1526,8 @@
 			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
 			"integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
 			"requires": {
-				"bs58": "3.1.0",
-				"create-hash": "1.1.3"
+				"bs58": "^3.1.0",
+				"create-hash": "^1.1.0"
 			}
 		},
 		"buffer": {
@@ -1709,15 +1535,41 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8",
-				"isarray": "1.0.0"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
 			}
+		},
+		"buffer-alloc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+			"integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+			"requires": {
+				"buffer-alloc-unsafe": "^0.1.0",
+				"buffer-fill": "^0.1.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+			"integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-fill": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+			"integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
 		},
 		"buffer-from": {
 			"version": "0.1.2",
@@ -1759,8 +1611,8 @@
 			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
 			"integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
 			"requires": {
-				"bytewise-core": "1.2.3",
-				"typewise": "1.0.3"
+				"bytewise-core": "^1.2.2",
+				"typewise": "^1.0.3"
 			}
 		},
 		"bytewise-core": {
@@ -1768,7 +1620,23 @@
 			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
 			"integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
 			"requires": {
-				"typewise-core": "1.2.0"
+				"typewise-core": "^1.2"
+			}
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			}
 		},
 		"cacheable-request": {
@@ -1783,6 +1651,13 @@
 				"lowercase-keys": "1.0.0",
 				"normalize-url": "2.0.1",
 				"responselike": "1.0.2"
+			},
+			"dependencies": {
+				"lowercase-keys": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+				}
 			}
 		},
 		"cachedown": {
@@ -1790,24 +1665,19 @@
 			"resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
 			"integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
 			"requires": {
-				"abstract-leveldown": "2.6.3",
-				"lru-cache": "3.2.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
-					"requires": {
-						"pseudomap": "1.0.2"
-					}
-				}
+				"abstract-leveldown": "^2.4.1",
+				"lru-cache": "^3.2.0"
 			}
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1819,8 +1689,8 @@
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chai": {
@@ -1828,21 +1698,19 @@
 			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
 			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
 			"requires": {
-				"assertion-error": "1.1.0",
-				"deep-eql": "0.1.3",
-				"type-detect": "1.0.0"
+				"assertion-error": "^1.0.1",
+				"deep-eql": "^0.1.3",
+				"type-detect": "^1.0.0"
 			}
 		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
@@ -1855,38 +1723,36 @@
 			"resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
 			"integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
 			"requires": {
-				"functional-red-black-tree": "1.0.1"
+				"functional-red-black-tree": "^1.0.1"
 			}
 		},
 		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.1.3",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^2.1.1",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.0"
 			}
-		},
-		"chownr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 		},
 		"cids": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
 			"integrity": "sha512-ujWbNP8SeLKg5KmGrxYZM4c+ttd+wwvegrdtgmbi2KNFUbQN4pqsGZaGQE3rhjayXTbKFq36bYDbKhsnD0eMsg==",
 			"requires": {
-				"multibase": "0.4.0",
-				"multicodec": "0.2.6",
-				"multihashes": "0.4.13"
+				"multibase": "~0.4.0",
+				"multicodec": "~0.2.6",
+				"multihashes": "~0.4.13"
 			}
 		},
 		"cipher-base": {
@@ -1894,8 +1760,29 @@
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
 			}
 		},
 		"cli-cursor": {
@@ -1903,7 +1790,7 @@
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -1931,25 +1818,15 @@
 			"resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
 			"integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
 			"requires": {
-				"colors": "1.1.2",
-				"lodash": "3.10.1",
-				"string-width": "1.0.2"
+				"colors": "^1.1.2",
+				"lodash": "^3.10.1",
+				"string-width": "^1.0.1"
 			},
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
 				}
 			}
 		},
@@ -1959,19 +1836,7 @@
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "1.0.2"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				}
+				"string-width": "^1.0.1"
 			}
 		},
 		"cli-width": {
@@ -1980,13 +1845,13 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
-				"wordwrap": "0.0.2"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"clone": {
@@ -2004,7 +1869,7 @@
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"requires": {
-				"mimic-response": "1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"clone-stats": {
@@ -2017,38 +1882,9 @@
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"requires": {
-				"inherits": "2.0.3",
-				"process-nextick-args": "2.0.0",
-				"readable-stream": "2.3.6"
-			},
-			"dependencies": {
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
-				}
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
 			}
 		},
 		"co": {
@@ -2066,8 +1902,8 @@
 			"resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
 			"integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
 			"requires": {
-				"bs58": "2.0.1",
-				"create-hash": "1.1.3"
+				"bs58": "^2.0.1",
+				"create-hash": "^1.1.1"
 			},
 			"dependencies": {
 				"bs58": {
@@ -2077,12 +1913,21 @@
 				}
 			}
 		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -2091,27 +1936,35 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+			"integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": ">= 1.0.0"
+			}
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -2119,13 +1972,21 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			},
+			"dependencies": {
+				"buffer-from": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+				}
 			}
 		},
 		"console-browserify": {
@@ -2133,13 +1994,8 @@
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -2157,9 +2013,9 @@
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-source-map": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -2171,10 +2027,15 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
 		"core-js": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-			"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+			"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -2186,41 +2047,42 @@
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
 			"integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
 			"requires": {
-				"object-assign": "4.1.1",
-				"vary": "1.1.2"
+				"object-assign": "^4",
+				"vary": "^1"
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
-			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.9"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
-			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-spawn": {
@@ -2228,25 +2090,18 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
-			}
-		},
-		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"requires": {
-				"boom": "5.2.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			},
 			"dependencies": {
-				"boom": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"requires": {
-						"hoek": "4.2.0"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -2256,17 +2111,17 @@
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
-				"browserify-cipher": "1.0.0",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.0",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"diffie-hellman": "5.0.2",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.14",
-				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5",
-				"randomfill": "1.0.3"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -2279,7 +2134,7 @@
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"requires": {
-				"es5-ext": "0.10.35"
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"d64": {
@@ -2297,7 +2152,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-fns": {
@@ -2321,11 +2176,11 @@
 			"integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
 		},
 		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+			"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "0.7.2"
 			}
 		},
 		"decamelize": {
@@ -2343,14 +2198,14 @@
 			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
 			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
 			"requires": {
-				"decompress-tar": "4.1.1",
-				"decompress-tarbz2": "4.1.1",
-				"decompress-targz": "4.1.1",
-				"decompress-unzip": "4.0.1",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.2.0",
-				"pify": "2.3.0",
-				"strip-dirs": "2.1.0"
+				"decompress-tar": "^4.0.0",
+				"decompress-tarbz2": "^4.0.0",
+				"decompress-targz": "^4.0.0",
+				"decompress-unzip": "^4.0.1",
+				"graceful-fs": "^4.1.10",
+				"make-dir": "^1.0.0",
+				"pify": "^2.3.0",
+				"strip-dirs": "^2.0.0"
 			}
 		},
 		"decompress-response": {
@@ -2358,7 +2213,7 @@
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"requires": {
-				"mimic-response": "1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"decompress-tar": {
@@ -2366,9 +2221,9 @@
 			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
 			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
 			"requires": {
-				"file-type": "5.2.0",
-				"is-stream": "1.1.0",
-				"tar-stream": "1.5.5"
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0",
+				"tar-stream": "^1.5.2"
 			}
 		},
 		"decompress-tarbz2": {
@@ -2376,11 +2231,11 @@
 			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
 			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
 			"requires": {
-				"decompress-tar": "4.1.1",
-				"file-type": "6.2.0",
-				"is-stream": "1.1.0",
-				"seek-bzip": "1.0.5",
-				"unbzip2-stream": "1.2.5"
+				"decompress-tar": "^4.1.0",
+				"file-type": "^6.1.0",
+				"is-stream": "^1.1.0",
+				"seek-bzip": "^1.0.5",
+				"unbzip2-stream": "^1.0.9"
 			},
 			"dependencies": {
 				"file-type": {
@@ -2395,9 +2250,9 @@
 			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
 			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
 			"requires": {
-				"decompress-tar": "4.1.1",
-				"file-type": "5.2.0",
-				"is-stream": "1.1.0"
+				"decompress-tar": "^4.1.1",
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0"
 			}
 		},
 		"decompress-unzip": {
@@ -2405,10 +2260,10 @@
 			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
 			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
 			"requires": {
-				"file-type": "3.9.0",
-				"get-stream": "2.3.1",
-				"pify": "2.3.0",
-				"yauzl": "2.9.1"
+				"file-type": "^3.8.0",
+				"get-stream": "^2.2.0",
+				"pify": "^2.3.0",
+				"yauzl": "^2.4.2"
 			},
 			"dependencies": {
 				"file-type": {
@@ -2421,8 +2276,8 @@
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
 					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 					"requires": {
-						"object-assign": "4.1.1",
-						"pinkie-promise": "2.0.1"
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -2448,9 +2303,9 @@
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -2462,7 +2317,17 @@
 			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
 			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
 			"requires": {
-				"abstract-leveldown": "2.6.3"
+				"abstract-leveldown": "~2.6.0"
+			},
+			"dependencies": {
+				"abstract-leveldown": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+					"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+					"requires": {
+						"xtend": "~4.0.0"
+					}
+				}
 			}
 		},
 		"define-properties": {
@@ -2470,14 +2335,56 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			},
 			"dependencies": {
 				"object-keys": {
 					"version": "1.0.11",
 					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
 					"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+				}
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -2491,11 +2398,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -2506,8 +2408,8 @@
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"destroy": {
@@ -2525,7 +2427,7 @@
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"detect-node": {
@@ -2534,18 +2436,42 @@
 			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
 		},
 		"diff": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
 		},
 		"diffie-hellman": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
-			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
+			}
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"dom-walk": {
@@ -2554,18 +2480,18 @@
 			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
 		},
 		"domain-browser": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"drbg.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
 			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
 			"requires": {
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6"
+				"browserify-aes": "^1.0.6",
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4"
 			}
 		},
 		"duplexer3": {
@@ -2579,7 +2505,7 @@
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"editions": {
@@ -2593,9 +2519,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
-			"version": "2.5.9",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-			"integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -2607,13 +2533,13 @@
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emojis-list": {
@@ -2631,15 +2557,15 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -2647,10 +2573,10 @@
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.4.1",
-				"object-assign": "4.1.1",
-				"tapable": "0.2.8"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.4.0",
+				"object-assign": "^4.0.1",
+				"tapable": "^0.2.7"
 			}
 		},
 		"envinfo": {
@@ -2659,11 +2585,11 @@
 			"integrity": "sha512-5rfRs+m+6pwoKRCFqpsA5+qsLngFms1aWPrxfKbrObCzQaPc3M3yPloZx+BL9UE3dK58cxw36XVQbFRSCCfGSQ=="
 		},
 		"errno": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
-				"prr": "0.0.0"
+				"prr": "~1.0.1"
 			}
 		},
 		"error": {
@@ -2671,8 +2597,8 @@
 			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
 			"requires": {
-				"string-template": "0.2.1",
-				"xtend": "4.0.1"
+				"string-template": "~0.2.1",
+				"xtend": "~4.0.0"
 			}
 		},
 		"error-ex": {
@@ -2680,19 +2606,19 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-			"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -2700,18 +2626,19 @@
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.35",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+			"version": "0.10.42",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
 			"requires": {
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "1"
 			}
 		},
 		"es6-iterator": {
@@ -2719,9 +2646,9 @@
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"es6-map": {
@@ -2729,12 +2656,12 @@
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-set": "0.1.5",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-set": {
@@ -2742,11 +2669,11 @@
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -2754,8 +2681,8 @@
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"es6-weak-map": {
@@ -2763,10 +2690,10 @@
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"escape-html": {
@@ -2784,13 +2711,18 @@
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
 			"requires": {
-				"esprima": "2.7.3",
-				"estraverse": "1.9.3",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.2.0"
+				"esprima": "^2.7.1",
+				"estraverse": "^1.9.1",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.2.0"
 			},
 			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -2802,7 +2734,7 @@
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
 					"optional": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -2812,24 +2744,23 @@
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"requires": {
-				"es6-map": "0.1.5",
-				"es6-weak-map": "2.0.2",
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"es6-map": "^0.1.3",
+				"es6-weak-map": "^2.0.1",
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"esprima": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esrecurse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -2852,8 +2783,8 @@
 			"resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
 			"integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
 			"requires": {
-				"idna-uts46-hx": "2.3.1",
-				"js-sha3": "0.5.7"
+				"idna-uts46-hx": "^2.3.1",
+				"js-sha3": "^0.5.7"
 			},
 			"dependencies": {
 				"js-sha3": {
@@ -2864,40 +2795,67 @@
 			}
 		},
 		"eth-gas-reporter": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.1.tgz",
-			"integrity": "sha512-ky5P27RRaDxD5EAzRL+xEBTq6uyfFj1Dyan2Epq5rfV66wEDtDkGTCYBefRaQpuXJ5C/U6Jsv5TR12qn7Mb83g==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.5.tgz",
+			"integrity": "sha512-SO3XePkWnl3d5HuIE+0jv6as03RJKRVeZ4/IQc+ukLeo6Vm5aez2/d1yfnxd2zE+MmoFGwvYuN6erk3CUxiHWg==",
 			"requires": {
-				"abi-decoder": "1.0.9",
-				"cli-table2": "0.2.0",
-				"colors": "1.1.2",
-				"lodash": "4.17.4",
-				"req-cwd": "2.0.0",
-				"request": "2.83.0",
-				"request-promise-native": "1.0.5",
-				"shelljs": "0.7.8"
+				"abi-decoder": "^1.0.8",
+				"cli-table2": "^0.2.0",
+				"colors": "^1.1.2",
+				"lodash": "^4.17.4",
+				"mocha": "^3.5.3",
+				"req-cwd": "^2.0.0",
+				"request": "^2.83.0",
+				"request-promise-native": "^1.0.5",
+				"shelljs": "^0.7.8",
+				"solidity-parser-antlr": "^0.2.10",
+				"sync-request": "^6.0.0"
 			},
 			"dependencies": {
-				"req-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
-					"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"requires": {
-						"req-from": "2.0.0"
+						"ms": "2.0.0"
 					}
 				},
-				"req-from": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
-					"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"mocha": {
+					"version": "3.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+					"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
 					"requires": {
-						"resolve-from": "3.0.0"
+						"browser-stdout": "1.3.0",
+						"commander": "2.9.0",
+						"debug": "2.6.8",
+						"diff": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.1",
+						"growl": "1.9.2",
+						"he": "1.1.1",
+						"json3": "3.3.2",
+						"lodash.create": "3.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "3.1.2"
 					}
 				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
@@ -2906,27 +2864,72 @@
 			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
 			"integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0",
-				"keccakjs": "0.2.1",
-				"nano-json-stream-parser": "0.1.2",
-				"servify": "0.1.12",
-				"ws": "3.3.3",
-				"xhr-request-promise": "0.1.2"
+				"bn.js": "^4.11.6",
+				"elliptic": "^6.4.0",
+				"keccakjs": "^0.2.1",
+				"nano-json-stream-parser": "^0.1.2",
+				"servify": "^0.1.12",
+				"ws": "^3.0.0",
+				"xhr-request-promise": "^0.1.2"
 			}
 		},
 		"ethereum-common": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-			"integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
+			"integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
+		},
+		"ethereum-ens": {
+			"version": "git+https://github.com/Arachnid/ensjs.git#48f3e968d781f44f8bf8c32476948651d4d14ef4",
+			"from": "git+https://github.com/Arachnid/ensjs.git",
+			"requires": {
+				"bluebird": "^3.4.7",
+				"eth-ens-namehash": "^2.0.0",
+				"js-sha3": "^0.5.7",
+				"pako": "^1.0.4",
+				"text-encoding": "^0.6.4",
+				"underscore": "^1.8.3",
+				"web3": "^0.19.1"
+			},
+			"dependencies": {
+				"js-sha3": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+				},
+				"web3": {
+					"version": "0.19.1",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
+					"integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
+					"requires": {
+						"bignumber.js": "^4.0.2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				}
+			}
 		},
 		"ethereumjs-account": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
-			"integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+			"integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
 			"requires": {
-				"ethereumjs-util": "4.5.0",
-				"rlp": "2.0.0"
+				"ethereumjs-util": "^5.0.0",
+				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"ethereumjs-block": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
+			"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
+			"requires": {
+				"async": "^1.5.2",
+				"ethereum-common": "0.0.16",
+				"ethereumjs-tx": "^1.0.0",
+				"ethereumjs-util": "^4.0.1",
+				"merkle-patricia-tree": "^2.1.2"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
@@ -2934,40 +2937,11 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
 					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"keccakjs": "0.2.1",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
-					}
-				}
-			}
-		},
-		"ethereumjs-block": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
-			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
-			"requires": {
-				"async": "2.6.0",
-				"ethereum-common": "0.2.0",
-				"ethereumjs-tx": "1.3.3",
-				"ethereumjs-util": "5.1.2",
-				"merkle-patricia-tree": "2.2.0"
-			},
-			"dependencies": {
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "6.24.1",
-						"babelify": "7.3.0",
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				}
 			}
@@ -2977,50 +2951,238 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
 			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
-				"webpack": "3.10.0"
+				"webpack": "^3.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+					"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0",
+						"uri-js": "^4.2.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "^2.0.0"
+					}
+				},
+				"webpack": {
+					"version": "3.12.0",
+					"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
+					"integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+					"requires": {
+						"acorn": "^5.0.0",
+						"acorn-dynamic-import": "^2.0.0",
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0",
+						"async": "^2.1.2",
+						"enhanced-resolve": "^3.4.0",
+						"escope": "^3.6.0",
+						"interpret": "^1.0.0",
+						"json-loader": "^0.5.4",
+						"json5": "^0.5.1",
+						"loader-runner": "^2.3.0",
+						"loader-utils": "^1.1.0",
+						"memory-fs": "~0.4.1",
+						"mkdirp": "~0.5.0",
+						"node-libs-browser": "^2.0.0",
+						"source-map": "^0.5.3",
+						"supports-color": "^4.2.1",
+						"tapable": "^0.2.7",
+						"uglifyjs-webpack-plugin": "^0.4.6",
+						"watchpack": "^1.4.0",
+						"webpack-sources": "^1.0.1",
+						"yargs": "^8.0.2"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"requires": {
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
 			}
 		},
 		"ethereumjs-tx": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
-			"integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz",
+			"integrity": "sha512-kOgUd5jC+0tgV7t52UDECMMz9Uf+Lro+6fSpCvzWemtXfMEcwI3EOxf5mVPMRbTFkMMhuERokNNVF3jItAjidg==",
 			"requires": {
-				"ethereum-common": "0.0.18",
-				"ethereumjs-util": "5.1.2"
+				"ethereum-common": "^0.0.18",
+				"ethereumjs-util": "^5.0.0"
 			},
 			"dependencies": {
 				"ethereum-common": {
 					"version": "0.0.18",
 					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
 					"integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-				},
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "6.24.1",
-						"babelify": "7.3.0",
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
-					}
 				}
 			}
 		},
 		"ethereumjs-util": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-			"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
+			"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"create-hash": "1.1.3",
-				"keccakjs": "0.2.1",
-				"rlp": "2.0.0",
-				"secp256k1": "3.3.1"
+				"bn.js": "^4.11.0",
+				"create-hash": "^1.1.2",
+				"ethjs-util": "^0.1.3",
+				"keccak": "^1.0.2",
+				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1",
+				"secp256k1": "^3.0.1"
 			}
 		},
 		"ethereumjs-vm": {
@@ -3028,17 +3190,72 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
 			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.6.0",
-				"async-eventemitter": "0.2.4",
+				"async": "^2.1.2",
+				"async-eventemitter": "^0.2.2",
 				"ethereum-common": "0.2.0",
-				"ethereumjs-account": "2.0.4",
-				"ethereumjs-block": "1.7.0",
+				"ethereumjs-account": "^2.0.3",
+				"ethereumjs-block": "~1.7.0",
 				"ethereumjs-util": "4.5.0",
-				"fake-merkle-patricia-tree": "1.0.1",
-				"functional-red-black-tree": "1.0.1",
-				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.1",
-				"safe-buffer": "5.1.1"
+				"fake-merkle-patricia-tree": "^1.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"merkle-patricia-tree": "^2.1.2",
+				"rustbn.js": "~0.1.1",
+				"safe-buffer": "^5.1.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"ethereum-common": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+					"integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+				},
+				"ethereumjs-block": {
+					"version": "1.7.1",
+					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+					"integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+					"requires": {
+						"async": "^2.0.1",
+						"ethereum-common": "0.2.0",
+						"ethereumjs-tx": "^1.2.2",
+						"ethereumjs-util": "^5.0.0",
+						"merkle-patricia-tree": "^2.1.2"
+					},
+					"dependencies": {
+						"ethereumjs-util": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+							"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+							"requires": {
+								"bn.js": "^4.11.0",
+								"create-hash": "^1.1.2",
+								"ethjs-util": "^0.1.3",
+								"keccak": "^1.0.2",
+								"rlp": "^2.0.0",
+								"safe-buffer": "^5.1.1",
+								"secp256k1": "^3.0.1"
+							}
+						}
+					}
+				},
+				"ethereumjs-util": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+					"requires": {
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
+					}
+				}
 			}
 		},
 		"ethereumjs-wallet": {
@@ -3046,13 +3263,13 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
 			"integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
 			"requires": {
-				"aes-js": "0.2.4",
-				"bs58check": "1.3.4",
-				"ethereumjs-util": "4.5.0",
-				"hdkey": "0.7.1",
-				"scrypt.js": "0.2.0",
-				"utf8": "2.1.2",
-				"uuid": "2.0.3"
+				"aes-js": "^0.2.3",
+				"bs58check": "^1.0.8",
+				"ethereumjs-util": "^4.4.0",
+				"hdkey": "^0.7.0",
+				"scrypt.js": "^0.2.0",
+				"utf8": "^2.1.1",
+				"uuid": "^2.0.1"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
@@ -3060,11 +3277,11 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
 					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"keccakjs": "0.2.1",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				}
 			}
@@ -3099,8 +3316,8 @@
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"eventemitter3": {
@@ -3118,8 +3335,8 @@
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"requires": {
-				"md5.js": "1.3.4",
-				"safe-buffer": "5.1.1"
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"execa": {
@@ -3127,13 +3344,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit-hook": {
@@ -3142,11 +3359,35 @@
 			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"expand-range": {
@@ -3154,20 +3395,50 @@
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
+			},
+			"dependencies": {
+				"fill-range": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"requires": {
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^3.0.0",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				}
 			}
-		},
-		"expand-template": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-			"integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"requires": {
-				"homedir-polyfill": "1.0.1"
+				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"express": {
@@ -3175,42 +3446,121 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 			"requires": {
-				"accepts": "1.3.5",
+				"accepts": "~1.3.5",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.2",
 				"content-disposition": "0.5.2",
-				"content-type": "1.0.4",
+				"content-type": "~1.0.4",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
 				"finalhandler": "1.1.1",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
-				"methods": "1.1.2",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "2.0.3",
+				"proxy-addr": "~2.0.3",
 				"qs": "6.5.1",
-				"range-parser": "1.2.0",
+				"range-parser": "~1.2.0",
 				"safe-buffer": "5.1.1",
 				"send": "0.16.2",
 				"serve-static": "1.13.2",
 				"setprototypeof": "1.1.0",
-				"statuses": "1.4.0",
-				"type-is": "1.6.16",
+				"statuses": "~1.4.0",
+				"type-is": "~1.6.16",
 				"utils-merge": "1.0.1",
-				"vary": "1.1.2"
+				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"setprototypeof": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "~2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "~1.6.15"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": ">= 1.3.1 < 2"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 				}
 			}
 		},
@@ -3219,14 +3569,33 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"external-editor": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.19",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			},
 			"dependencies": {
 				"tmp": {
@@ -3234,17 +3603,73 @@
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"extsprintf": {
@@ -3257,13 +3682,26 @@
 			"resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
 			"integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
 			"requires": {
-				"checkpoint-store": "1.1.0"
+				"checkpoint-store": "^1.1.0"
 			}
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-glob": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.0.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.10"
+			}
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -3280,7 +3718,7 @@
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"figures": {
@@ -3288,7 +3726,7 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-type": {
@@ -3302,15 +3740,24 @@
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fill-range": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"finalhandler": {
@@ -3319,12 +3766,32 @@
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
-				"statuses": "1.4.0",
-				"unpipe": "1.0.0"
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.4.0",
+				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
 			}
 		},
 		"find-cache-dir": {
@@ -3332,9 +3799,9 @@
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
 			"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
 			"requires": {
-				"commondir": "1.0.1",
-				"mkdirp": "0.5.1",
-				"pkg-dir": "1.0.0"
+				"commondir": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pkg-dir": "^1.0.0"
 			}
 		},
 		"find-up": {
@@ -3342,7 +3809,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"first-chunk-stream": {
@@ -3350,7 +3817,7 @@
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"flatmap": {
@@ -3359,16 +3826,16 @@
 			"integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
 		},
 		"flow-parser": {
-			"version": "0.70.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
-			"integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg=="
+			"version": "0.72.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.72.0.tgz",
+			"integrity": "sha512-kFaDtviKlD/rHi6NRp42KTbnPgz/nKcWUJQhqDnLDeKA8uGcRVSy0YlQjaf9M3pFo5PgC3SNFnCPpQGLtHjH2w=="
 		},
 		"for-each": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
 			"integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
 			"requires": {
-				"is-function": "1.0.1"
+				"is-function": "~1.0.0"
 			}
 		},
 		"for-in": {
@@ -3381,7 +3848,7 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -3395,19 +3862,27 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"asynckit": "^0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
 		},
 		"fresh": {
 			"version": "0.5.2",
@@ -3419,20 +3894,23 @@
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs-extra": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-			"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "2.4.0",
-				"klaw": "1.3.1",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs-promise": {
@@ -3440,10 +3918,10 @@
 			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
 			"integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
 			"requires": {
-				"any-promise": "1.3.0",
-				"fs-extra": "2.1.2",
-				"mz": "2.7.0",
-				"thenify-all": "1.6.0"
+				"any-promise": "^1.3.0",
+				"fs-extra": "^2.0.0",
+				"mz": "^2.6.0",
+				"thenify-all": "^1.6.0"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -3451,8 +3929,16 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
 					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
 					}
 				}
 			}
@@ -3463,905 +3949,464 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"optional": true,
 			"requires": {
-				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.39"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+					"version": "1.1.1",
+					"bundled": true,
 					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true
 				},
 				"aproba": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+					"version": "1.2.0",
+					"bundled": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-					"optional": true
 				},
 				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-					"requires": {
-						"hoek": "2.16.3"
-					}
+					"version": "1.0.0",
+					"bundled": true
 				},
 				"brace-expansion": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+					"version": "1.1.11",
+					"bundled": true,
 					"requires": {
-						"balanced-match": "0.4.2",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-					"requires": {
-						"boom": "2.10.1"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
+					"bundled": true,
+					"optional": true
 				},
 				"debug": {
-					"version": "2.6.8",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"version": "2.6.9",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"deep-extend": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"version": "0.5.1",
+					"bundled": true,
 					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
 					"optional": true
 				},
 				"detect-libc": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+					"version": "1.0.3",
+					"bundled": true,
 					"optional": true
 				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
+					"bundled": true,
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"optional": true
 				},
-				"hawk": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true
 				},
 				"ini": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+					"version": "1.3.5",
+					"bundled": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"bundled": true,
 					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-					"requires": {
-						"mime-db": "1.27.0"
-					}
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.7"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"optional": true
 				},
-				"node-pre-gyp": {
-					"version": "0.6.39",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.2",
-						"hawk": "3.1.3",
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.10.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
 					}
 				},
 				"npmlog": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+					"version": "4.1.2",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"osenv": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+					"version": "0.1.5",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+					"bundled": true,
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+					"version": "2.0.0",
+					"bundled": true,
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+					"version": "1.2.7",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
-					"version": "2.2.9",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+					"version": "2.3.6",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+					"version": "2.6.2",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"optional": true
 				},
 				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"version": "5.5.0",
+					"bundled": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"optional": true
-						}
-					}
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "~5.1.0"
 					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"optional": true
 				},
 				"tar": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+					"version": "4.4.1",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+					"bundled": true,
 					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true
 				}
 			}
 		},
@@ -4370,10 +4415,10 @@
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
 			}
 		},
 		"function-bind": {
@@ -4391,8 +4436,8 @@
 			"resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.0.tgz",
 			"integrity": "sha512-FdTeyk4uLRHGeFiMe+Qnh4Hc5KiTVqvRVVvLDFJEVVKC1P1yHhEgZeh9sp1KhuvxSrxToxgJS25UapYQwH4zHw==",
 			"requires": {
-				"source-map-support": "0.5.5",
-				"webpack-cli": "2.0.15"
+				"source-map-support": "^0.5.3",
+				"webpack-cli": "^2.0.9"
 			},
 			"dependencies": {
 				"buffer-from": {
@@ -4406,12 +4451,12 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-					"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 					"requires": {
-						"buffer-from": "1.0.0",
-						"source-map": "0.6.1"
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
 					}
 				}
 			}
@@ -4421,475 +4466,76 @@
 			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.0.2.tgz",
 			"integrity": "sha512-hfmfqwWDT7zLPwSmAHXExCP8S97yjqGaT7KS93tKj4DY6beU8na46bkH1GZUb02DKXqHC4deTv85xA1yBwV1Lw==",
 			"requires": {
-				"async": "1.5.2",
-				"bip39": "2.4.0",
-				"cachedown": "1.0.0",
-				"chai": "3.5.0",
-				"clone": "2.1.1",
-				"ethereumjs-account": "2.0.4",
-				"ethereumjs-block": "1.2.2",
-				"ethereumjs-tx": "1.3.3",
-				"ethereumjs-util": "5.1.5",
+				"async": "~1.5.0",
+				"bip39": "~2.4.0",
+				"cachedown": "^1.0.0",
+				"chai": "^3.5.0",
+				"clone": "^2.1.1",
+				"ethereumjs-account": "~2.0.4",
+				"ethereumjs-block": "~1.2.2",
+				"ethereumjs-tx": "^1.3.0",
+				"ethereumjs-util": "~5.1.0",
 				"ethereumjs-vm": "2.3.2",
-				"ethereumjs-wallet": "0.6.0",
-				"fake-merkle-patricia-tree": "1.0.1",
-				"heap": "0.2.6",
-				"js-scrypt": "0.2.0",
-				"level-sublevel": "6.6.1",
-				"levelup": "1.3.9",
-				"localstorage-down": "0.6.7",
-				"merkle-patricia-tree": "2.2.0",
-				"mocha": "3.3.0",
-				"on-build-webpack": "0.1.0",
-				"prepend-file": "1.3.1",
-				"seedrandom": "2.4.3",
+				"ethereumjs-wallet": "~0.6.0",
+				"fake-merkle-patricia-tree": "~1.0.1",
+				"heap": "~0.2.6",
+				"js-scrypt": "^0.2.0",
+				"level-sublevel": "^6.6.1",
+				"levelup": "^1.1.0",
+				"localstorage-down": "^0.6.7",
+				"merkle-patricia-tree": "^2.2.0",
+				"mocha": "~3.3.0",
+				"on-build-webpack": "^0.1.0",
+				"prepend-file": "^1.3.1",
+				"seedrandom": "~2.4.2",
 				"shebang-loader": "0.0.1",
 				"solc": "0.4.18",
-				"temp": "0.8.3",
+				"temp": "^0.8.3",
 				"tmp": "0.0.31",
-				"web3": "0.19.1",
-				"web3-provider-engine": "8.1.19",
-				"webpack": "2.7.0",
-				"yargs": "7.1.0"
+				"web3": "^0.19.1",
+				"web3-provider-engine": "~8.1.0",
+				"webpack": "^2.2.1",
+				"yargs": "^7.0.2"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "4.11.8",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
-				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-					"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": "1.0.1"
-					}
-				},
-				"debug": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-					"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-					"requires": {
-						"ms": "0.7.2"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"ethereum-common": {
-					"version": "0.0.16",
-					"resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
-					"integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
-				},
-				"ethereumjs-block": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
-					"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
-					"requires": {
-						"async": "1.5.2",
-						"ethereum-common": "0.0.16",
-						"ethereumjs-tx": "1.3.3",
-						"ethereumjs-util": "4.5.0",
-						"merkle-patricia-tree": "2.2.0"
-					},
-					"dependencies": {
-						"ethereumjs-util": {
-							"version": "4.5.0",
-							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-							"requires": {
-								"bn.js": "4.11.8",
-								"create-hash": "1.1.3",
-								"keccakjs": "0.2.1",
-								"rlp": "2.0.0",
-								"secp256k1": "3.3.1"
-							}
-						}
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.1.5",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
-					"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
-					"requires": {
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"secp256k1": "3.3.1"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
-					}
-				},
-				"mocha": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
-					"integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
-					"requires": {
-						"browser-stdout": "1.3.0",
-						"commander": "2.9.0",
-						"debug": "2.6.0",
-						"diff": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"glob": "7.1.1",
-						"growl": "1.9.2",
-						"json3": "3.3.2",
-						"lodash.create": "3.1.1",
-						"mkdirp": "0.5.1",
-						"supports-color": "3.1.2"
-					}
-				},
-				"ms": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"supports-color": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-					"requires": {
-						"has-flag": "1.0.0"
-					}
-				},
 				"web3": {
 					"version": "0.19.1",
 					"resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
 					"integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
 					"requires": {
-						"bignumber.js": "4.1.0",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
+						"bignumber.js": "^4.0.2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
 					}
-				},
-				"web3-provider-engine": {
-					"version": "8.1.19",
-					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
-					"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
-					"requires": {
-						"async": "2.6.0",
-						"clone": "2.1.1",
-						"ethereumjs-block": "1.2.2",
-						"ethereumjs-tx": "1.3.3",
-						"ethereumjs-util": "5.1.5",
-						"ethereumjs-vm": "2.3.2",
-						"isomorphic-fetch": "2.2.1",
-						"request": "2.83.0",
-						"semaphore": "1.1.0",
-						"solc": "0.4.18",
-						"tape": "4.8.0",
-						"web3": "0.16.0",
-						"xhr": "2.4.0",
-						"xtend": "4.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "2.6.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-							"requires": {
-								"lodash": "4.17.4"
-							}
-						},
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-						},
-						"web3": {
-							"version": "0.16.0",
-							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-							"requires": {
-								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-								"crypto-js": "3.1.8",
-								"utf8": "2.1.2",
-								"xmlhttprequest": "1.8.0"
-							},
-							"dependencies": {
-								"bignumber.js": {
-									"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-								}
-							}
-						}
-					}
-				},
-				"webpack": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
-					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
-					"requires": {
-						"acorn": "5.2.1",
-						"acorn-dynamic-import": "2.0.2",
-						"ajv": "4.11.8",
-						"ajv-keywords": "1.5.1",
-						"async": "2.6.0",
-						"enhanced-resolve": "3.4.1",
-						"interpret": "1.0.4",
-						"json-loader": "0.5.7",
-						"json5": "0.5.1",
-						"loader-runner": "2.3.0",
-						"loader-utils": "0.2.17",
-						"memory-fs": "0.4.1",
-						"mkdirp": "0.5.1",
-						"node-libs-browser": "2.0.0",
-						"source-map": "0.5.7",
-						"supports-color": "3.1.2",
-						"tapable": "0.2.8",
-						"uglify-js": "2.8.29",
-						"watchpack": "1.4.0",
-						"webpack-sources": "1.0.2",
-						"yargs": "6.6.0"
-					},
-					"dependencies": {
-						"async": {
-							"version": "2.6.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-							"requires": {
-								"lodash": "4.17.4"
-							}
-						},
-						"yargs": {
-							"version": "6.6.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-							"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-							"requires": {
-								"camelcase": "3.0.0",
-								"cliui": "3.2.0",
-								"decamelize": "1.2.0",
-								"get-caller-file": "1.0.2",
-								"os-locale": "1.4.0",
-								"read-pkg-up": "1.0.1",
-								"require-directory": "2.1.1",
-								"require-main-filename": "1.0.1",
-								"set-blocking": "2.0.0",
-								"string-width": "1.0.2",
-								"which-module": "1.0.0",
-								"y18n": "3.2.1",
-								"yargs-parser": "4.2.1"
-							}
-						}
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"yargs": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
-					},
-					"dependencies": {
-						"yargs-parser": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-							"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-							"requires": {
-								"camelcase": "3.0.0"
-							}
-						}
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 					"requires": {
-						"camelcase": "3.0.0"
-					}
-				}
-			}
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.2"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -4904,17 +4550,27 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"gh-got": {
@@ -4922,8 +4578,8 @@
 			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
 			"requires": {
-				"got": "7.1.0",
-				"is-plain-obj": "1.1.0"
+				"got": "^7.0.0",
+				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"git-clone": {
@@ -4931,29 +4587,25 @@
 			"resolved": "https://registry.npmjs.org/git-clone/-/git-clone-0.1.0.tgz",
 			"integrity": "sha1-DXYWN3gJOu9/HDAjjyqe8/B6Lrk="
 		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-		},
 		"github-username": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
 			"requires": {
-				"gh-got": "6.0.0"
+				"gh-got": "^6.0.0"
 			}
 		},
 		"glob": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 			"requires": {
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.2",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-all": {
@@ -4961,23 +4613,10 @@
 			"resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
 			"requires": {
-				"glob": "7.1.2",
-				"yargs": "1.2.6"
+				"glob": "^7.0.5",
+				"yargs": "~1.2.6"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
@@ -4988,7 +4627,7 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
 					"requires": {
-						"minimist": "0.1.0"
+						"minimist": "^0.1.0"
 					}
 				}
 			}
@@ -4998,8 +4637,31 @@
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
 			}
 		},
 		"glob-escape": {
@@ -5008,27 +4670,36 @@
 			"integrity": "sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0="
 		},
 		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
+		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"requires": {
-				"min-document": "2.19.0",
-				"process": "0.5.2"
-			},
-			"dependencies": {
-				"process": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-				}
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
 			}
 		},
 		"global-modules": {
@@ -5036,9 +4707,9 @@
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 			"requires": {
-				"global-prefix": "1.0.2",
-				"is-windows": "1.0.2",
-				"resolve-dir": "1.0.1"
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
 			}
 		},
 		"global-prefix": {
@@ -5046,11 +4717,11 @@
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"requires": {
-				"expand-tilde": "2.0.2",
-				"homedir-polyfill": "1.0.1",
-				"ini": "1.3.4",
-				"is-windows": "1.0.2",
-				"which": "1.3.0"
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
 			}
 		},
 		"globals": {
@@ -5059,15 +4730,17 @@
 			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"requires": {
-				"array-union": "1.0.2",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -5075,13 +4748,18 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -5090,20 +4768,20 @@
 			"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
 			"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
 			"requires": {
-				"decompress-response": "3.3.0",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-plain-obj": "1.1.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"isurl": "1.0.0",
-				"lowercase-keys": "1.0.0",
-				"p-cancelable": "0.3.0",
-				"p-timeout": "1.2.1",
-				"safe-buffer": "5.1.1",
-				"timed-out": "4.0.1",
-				"url-parse-lax": "1.0.0",
-				"url-to-options": "1.0.1"
+				"decompress-response": "^3.2.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"p-cancelable": "^0.3.0",
+				"p-timeout": "^1.1.1",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"url-parse-lax": "^1.0.0",
+				"url-to-options": "^1.0.1"
 			}
 		},
 		"graceful-fs": {
@@ -5121,7 +4799,7 @@
 			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.17.2"
 			}
 		},
 		"growl": {
@@ -5134,23 +4812,27 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -5165,8 +4847,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.3.0",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -5174,7 +4856,7 @@
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -5182,7 +4864,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-color": {
@@ -5191,9 +4873,9 @@
 			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-localstorage": {
 			"version": "1.0.1",
@@ -5210,20 +4892,45 @@
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"requires": {
-				"has-symbol-support-x": "1.4.2"
+				"has-symbol-support-x": "^1.4.1"
 			}
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"hash-base": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"hash.js": {
@@ -5231,19 +4938,8 @@
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
-			}
-		},
-		"hawk": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
-				"sntp": "2.1.0"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"hdkey": {
@@ -5251,8 +4947,8 @@
 			"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
-				"coinstring": "2.3.0",
-				"secp256k1": "3.3.1"
+				"coinstring": "^2.0.0",
+				"secp256k1": "^3.0.1"
 			}
 		},
 		"he": {
@@ -5270,23 +4966,18 @@
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"homedir": {
@@ -5299,13 +4990,26 @@
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
 			"requires": {
-				"parse-passwd": "1.0.0"
+				"parse-passwd": "^1.0.0"
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"http-basic": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/http-basic/-/http-basic-7.0.0.tgz",
+			"integrity": "sha1-gvClBr6UJzLsje6+6A50bvVzbbo=",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/node": "^9.4.1",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.4.6",
+				"http-response-object": "^3.0.1",
+				"parse-cache-control": "^1.0.1"
+			}
 		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
@@ -5313,21 +5017,14 @@
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
-				"depd": "1.1.1",
+				"depd": "~1.1.2",
 				"inherits": "2.0.3",
-				"setprototypeof": "1.0.3",
-				"statuses": "1.4.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-				}
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
 			}
 		},
 		"http-https": {
@@ -5335,34 +5032,45 @@
 			"resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
 			"integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
 		},
+		"http-response-object": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.1.tgz",
+			"integrity": "sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==",
+			"requires": {
+				"@types/node": "^9.3.0"
+			}
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"https-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"humble-localstorage": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
 			"integrity": "sha1-0Fqw1SbE7b3b98amDfb/WAUoNGk=",
 			"requires": {
-				"has-localstorage": "1.0.1",
-				"localstorage-memory": "1.0.2"
+				"has-localstorage": "^1.0.1",
+				"localstorage-memory": "^1.0.1"
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"idna-uts46-hx": {
 			"version": "2.3.1",
@@ -5370,19 +5078,17 @@
 			"integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
 			"requires": {
 				"punycode": "2.1.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-				}
 			}
 		},
 		"ieee754": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+		},
+		"ignore": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
 		},
 		"immediate": {
 			"version": "3.2.3",
@@ -5394,8 +5100,8 @@
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			},
 			"dependencies": {
 				"pkg-dir": {
@@ -5403,7 +5109,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				}
 			}
@@ -5418,7 +5124,7 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"indexof": {
@@ -5431,8 +5137,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -5441,28 +5147,28 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
 			"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.0",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.4",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.1.0",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rxjs": "5.5.10",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rxjs": "^5.5.2",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5470,67 +5176,50 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "1.9.1"
-					}
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
 		},
 		"interpret": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-			"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"into-stream": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"requires": {
-				"from2": "2.3.0",
-				"p-is-promise": "1.1.0"
+				"from2": "^2.1.1",
+				"p-is-promise": "^1.1.0"
 			}
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -5553,42 +5242,50 @@
 			"resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-14.3.7.tgz",
 			"integrity": "sha512-SeCKT6KwMuu/qDEMDd5CRj2KhSa1+Dyx63jJgadU2tD6QINyxCy/ooPFBhZRwlGuAhb61IVSV8pfZ0nHNQEINQ==",
 			"requires": {
-				"async": "2.6.0",
-				"bs58": "4.0.1",
-				"cids": "0.5.3",
-				"concat-stream": "1.6.1",
-				"detect-node": "2.0.3",
+				"async": "^2.5.0",
+				"bs58": "^4.0.1",
+				"cids": "~0.5.2",
+				"concat-stream": "^1.6.0",
+				"detect-node": "^2.0.3",
 				"flatmap": "0.0.3",
-				"glob": "7.1.2",
+				"glob": "^7.1.2",
 				"glob-escape": "0.0.2",
-				"ipfs-block": "0.6.1",
-				"ipfs-unixfs": "0.1.14",
-				"ipld-dag-pb": "0.11.4",
-				"is-ipfs": "0.3.2",
-				"is-stream": "1.1.0",
-				"lru-cache": "4.1.1",
-				"multiaddr": "3.0.2",
-				"multihashes": "0.4.13",
-				"multipart-stream": "2.0.1",
-				"ndjson": "1.5.0",
-				"once": "1.4.0",
-				"peer-id": "0.10.6",
-				"peer-info": "0.11.6",
-				"promisify-es6": "1.0.3",
-				"pump": "1.0.2",
-				"qs": "6.5.1",
-				"readable-stream": "2.3.3",
-				"stream-http": "2.7.2",
-				"streamifier": "0.1.1",
-				"tar-stream": "1.5.5"
+				"ipfs-block": "~0.6.0",
+				"ipfs-unixfs": "~0.1.13",
+				"ipld-dag-pb": "~0.11.2",
+				"is-ipfs": "^0.3.2",
+				"is-stream": "^1.1.0",
+				"lru-cache": "^4.1.1",
+				"multiaddr": "^3.0.1",
+				"multihashes": "~0.4.10",
+				"multipart-stream": "^2.0.1",
+				"ndjson": "^1.5.0",
+				"once": "^1.4.0",
+				"peer-id": "~0.10.2",
+				"peer-info": "~0.11.0",
+				"promisify-es6": "^1.0.3",
+				"pump": "^1.0.2",
+				"qs": "^6.5.1",
+				"readable-stream": "^2.3.3",
+				"stream-http": "^2.7.2",
+				"streamifier": "^0.1.1",
+				"tar-stream": "^1.5.4"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -5596,7 +5293,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				},
 				"glob": {
@@ -5604,12 +5301,21 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				}
 			}
@@ -5619,7 +5325,7 @@
 			"resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
 			"integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
 			"requires": {
-				"cids": "0.5.3"
+				"cids": "^0.5.2"
 			}
 		},
 		"ipfs-unixfs": {
@@ -5627,7 +5333,7 @@
 			"resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.14.tgz",
 			"integrity": "sha512-s1tEnwKhdd17MmyC/EUMNVMDYzKhCiHDI11TF8tSBeWkEQp+0WUxkYuqvz0R5TSi2lNDJ/oVnEmwWhki2spUiQ==",
 			"requires": {
-				"protons": "1.0.1"
+				"protons": "^1.0.0"
 			}
 		},
 		"ipld-dag-pb": {
@@ -5635,26 +5341,34 @@
 			"resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.11.4.tgz",
 			"integrity": "sha512-A514Bt4z44bxhPQVzmBFMJsV3res92eBaDX0snzVsLLasBPNh4Z7He8N2mwSeAX9bJNywRBlJbHMQPwC45rqXw==",
 			"requires": {
-				"async": "2.6.0",
-				"bs58": "4.0.1",
+				"async": "^2.6.0",
+				"bs58": "^4.0.1",
 				"buffer-loader": "0.0.1",
-				"cids": "0.5.3",
-				"ipfs-block": "0.6.1",
-				"is-ipfs": "0.3.2",
-				"multihashes": "0.4.13",
-				"multihashing-async": "0.4.8",
-				"protons": "1.0.1",
-				"pull-stream": "3.6.2",
-				"pull-traverse": "1.0.3",
-				"stable": "0.1.6"
+				"cids": "~0.5.2",
+				"ipfs-block": "~0.6.1",
+				"is-ipfs": "~0.3.2",
+				"multihashes": "~0.4.12",
+				"multihashing-async": "~0.4.7",
+				"protons": "^1.0.0",
+				"pull-stream": "^3.6.1",
+				"pull-traverse": "^1.0.3",
+				"stable": "^0.1.6"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"base-x": {
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -5662,9 +5376,17 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
+			}
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"requires": {
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -5677,7 +5399,7 @@
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"requires": {
-				"binary-extensions": "1.10.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -5690,7 +5412,7 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -5698,10 +5420,35 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
 			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -5713,7 +5460,7 @@
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -5722,16 +5469,16 @@
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -5739,7 +5486,7 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-function": {
@@ -5748,11 +5495,11 @@
 			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-hex-prefixed": {
@@ -5765,9 +5512,9 @@
 			"resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.3.2.tgz",
 			"integrity": "sha512-82V1j4LMkYy7H4seQQzOWqo7FiW3I64/1/ryo3dhtWKfOvm7ZolLMRQQfGKs4OXWauh5rAkPnamVcRISHwhmpQ==",
 			"requires": {
-				"bs58": "4.0.1",
-				"cids": "0.5.3",
-				"multihashes": "0.4.13"
+				"bs58": "^4.0.1",
+				"cids": "~0.5.1",
+				"multihashes": "~0.4.9"
 			},
 			"dependencies": {
 				"base-x": {
@@ -5775,7 +5522,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -5783,7 +5530,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -5794,11 +5541,11 @@
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-object": {
@@ -5811,7 +5558,7 @@
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 			"requires": {
-				"symbol-observable": "0.2.4"
+				"symbol-observable": "^0.2.2"
 			},
 			"dependencies": {
 				"symbol-observable": {
@@ -5821,10 +5568,33 @@
 				}
 			}
 		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"requires": {
+				"is-number": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
+		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
@@ -5846,7 +5616,7 @@
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-retry-allowed": {
@@ -5859,7 +5629,7 @@
 			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
 			"requires": {
-				"scoped-regex": "1.0.0"
+				"scoped-regex": "^1.0.0"
 			}
 		},
 		"is-stream": {
@@ -5888,9 +5658,14 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isbinaryfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+			"integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -5898,20 +5673,17 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -5924,38 +5696,55 @@
 			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
 			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
 			"requires": {
-				"abbrev": "1.0.9",
-				"async": "1.5.2",
-				"escodegen": "1.8.1",
-				"esprima": "2.7.3",
-				"glob": "5.0.15",
-				"handlebars": "4.0.11",
-				"js-yaml": "3.11.0",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"once": "1.4.0",
-				"resolve": "1.1.7",
-				"supports-color": "3.2.3",
-				"which": "1.3.0",
-				"wordwrap": "1.0.0"
+				"abbrev": "1.0.x",
+				"async": "1.x",
+				"escodegen": "1.8.x",
+				"esprima": "2.7.x",
+				"glob": "^5.0.15",
+				"handlebars": "^4.0.1",
+				"js-yaml": "3.x",
+				"mkdirp": "0.5.x",
+				"nopt": "3.x",
+				"once": "1.x",
+				"resolve": "1.1.x",
+				"supports-color": "^3.1.0",
+				"which": "^1.1.1",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				},
 				"wordwrap": {
@@ -5970,9 +5759,9 @@
 			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
 			"requires": {
-				"binaryextensions": "2.1.1",
-				"editions": "1.3.4",
-				"textextensions": "2.2.0"
+				"binaryextensions": "2",
+				"editions": "^1.3.3",
+				"textextensions": "2"
 			}
 		},
 		"isurl": {
@@ -5980,8 +5769,8 @@
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"requires": {
-				"has-to-string-tag-x": "1.4.1",
-				"is-object": "1.0.1"
+				"has-to-string-tag-x": "^1.2.0",
+				"is-object": "^1.0.1"
 			}
 		},
 		"jade": {
@@ -6010,13 +5799,13 @@
 			"resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
 			"integrity": "sha1-emK3AbRhbnCtDN5URiequ5nX/jk=",
 			"requires": {
-				"generic-pool": "2.0.4"
+				"generic-pool": "~2.0.4"
 			}
 		},
 		"js-sha3": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
-			"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
+			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -6033,15 +5822,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				}
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -6055,34 +5837,106 @@
 			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.0.tgz",
 			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-preset-es2015": "6.24.1",
-				"babel-preset-stage-1": "6.24.1",
-				"babel-register": "6.26.0",
-				"babylon": "7.0.0-beta.46",
-				"colors": "1.1.2",
-				"flow-parser": "0.70.0",
-				"lodash": "4.17.4",
-				"micromatch": "2.3.11",
-				"neo-async": "2.5.1",
+				"babel-plugin-transform-flow-strip-types": "^6.8.0",
+				"babel-preset-es2015": "^6.9.0",
+				"babel-preset-stage-1": "^6.5.0",
+				"babel-register": "^6.9.0",
+				"babylon": "^7.0.0-beta.30",
+				"colors": "^1.1.2",
+				"flow-parser": "^0.*",
+				"lodash": "^4.13.1",
+				"micromatch": "^2.3.7",
+				"neo-async": "^2.5.0",
 				"node-dir": "0.1.8",
-				"nomnom": "1.8.1",
-				"recast": "0.14.7",
-				"temp": "0.8.3",
-				"write-file-atomic": "1.3.4"
+				"nomnom": "^1.8.1",
+				"recast": "^0.14.1",
+				"temp": "^0.8.1",
+				"write-file-atomic": "^1.2.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
 				"babylon": {
-					"version": "7.0.0-beta.46",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+					"version": "7.0.0-beta.47",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
 				}
 			}
 		},
 		"jsesc": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-buffer": {
 			"version": "3.0.0",
@@ -6114,7 +5968,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -6133,11 +5987,11 @@
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsonify": {
@@ -6157,15 +6011,14 @@
 			}
 		},
 		"keccak": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
-			"integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+			"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
 			"requires": {
-				"bindings": "1.3.0",
-				"inherits": "2.0.3",
-				"nan": "2.7.0",
-				"prebuild-install": "2.3.0",
-				"safe-buffer": "5.1.1"
+				"bindings": "^1.2.1",
+				"inherits": "^2.0.3",
+				"nan": "^2.2.1",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"keccakjs": {
@@ -6173,8 +6026,8 @@
 			"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
 			"integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
 			"requires": {
-				"browserify-sha3": "0.0.1",
-				"sha3": "1.2.0"
+				"browserify-sha3": "^0.0.1",
+				"sha3": "^1.1.0"
 			}
 		},
 		"keypair": {
@@ -6195,7 +6048,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"klaw": {
@@ -6203,7 +6056,7 @@
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.9"
 			}
 		},
 		"lazy-cache": {
@@ -6216,7 +6069,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"level-codec": {
@@ -6229,7 +6082,7 @@
 			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
 			"integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
 			"requires": {
-				"errno": "0.1.4"
+				"errno": "~0.1.1"
 			}
 		},
 		"level-iterator-stream": {
@@ -6237,40 +6090,22 @@
 			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
 			"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
 			"requires": {
-				"inherits": "2.0.3",
-				"level-errors": "1.1.2",
-				"readable-stream": "1.1.14",
-				"xtend": "4.0.1"
+				"inherits": "^2.0.1",
+				"level-errors": "^1.0.3",
+				"readable-stream": "^1.0.33",
+				"xtend": "^4.0.0"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"level-errors": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
-					"integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
-					"requires": {
-						"errno": "0.1.4"
-					}
-				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -6279,21 +6114,22 @@
 			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
 			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
 			"requires": {
-				"ltgt": "2.2.0"
+				"ltgt": "^2.1.2"
 			}
 		},
 		"level-sublevel": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
-			"integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
+			"integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
 			"requires": {
-				"bytewise": "1.1.0",
-				"levelup": "0.19.1",
-				"ltgt": "2.1.3",
-				"pull-level": "2.0.4",
-				"pull-stream": "3.6.2",
-				"typewiselite": "1.0.0",
-				"xtend": "4.0.1"
+				"bytewise": "~1.1.0",
+				"levelup": "~0.19.0",
+				"ltgt": "~2.1.1",
+				"pull-defer": "^0.2.2",
+				"pull-level": "^2.0.3",
+				"pull-stream": "^3.6.8",
+				"typewiselite": "~1.0.0",
+				"xtend": "~4.0.0"
 			},
 			"dependencies": {
 				"abstract-leveldown": {
@@ -6301,7 +6137,7 @@
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
 					"integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
 					"requires": {
-						"xtend": "3.0.0"
+						"xtend": "~3.0.0"
 					},
 					"dependencies": {
 						"xtend": {
@@ -6311,39 +6147,26 @@
 						}
 					}
 				},
-				"bl": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-					"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-					"requires": {
-						"readable-stream": "1.0.34"
-					}
-				},
 				"deferred-leveldown": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
 					"integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
 					"requires": {
-						"abstract-leveldown": "0.12.4"
+						"abstract-leveldown": "~0.12.1"
 					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"levelup": {
 					"version": "0.19.1",
 					"resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
 					"integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
 					"requires": {
-						"bl": "0.8.2",
-						"deferred-leveldown": "0.2.0",
-						"errno": "0.1.4",
-						"prr": "0.0.0",
-						"readable-stream": "1.0.34",
-						"semver": "5.1.1",
-						"xtend": "3.0.0"
+						"bl": "~0.8.1",
+						"deferred-leveldown": "~0.2.0",
+						"errno": "~0.1.1",
+						"prr": "~0.0.0",
+						"readable-stream": "~1.0.26",
+						"semver": "~5.1.0",
+						"xtend": "~3.0.0"
 					},
 					"dependencies": {
 						"xtend": {
@@ -6358,26 +6181,26 @@
 					"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
 					"integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
 				},
+				"prr": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+					"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"semver": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
 					"integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -6386,37 +6209,27 @@
 			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
 			"integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
 			"requires": {
-				"readable-stream": "1.0.34",
-				"xtend": "2.1.2"
+				"readable-stream": "~1.0.15",
+				"xtend": "~2.1.1"
 			},
 			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xtend": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
 					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
 					"requires": {
-						"object-keys": "0.4.0"
+						"object-keys": "~0.4.0"
 					}
 				}
 			}
@@ -6426,19 +6239,19 @@
 			"resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
 			"integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
 			"requires": {
-				"deferred-leveldown": "1.2.2",
-				"level-codec": "7.0.1",
-				"level-errors": "1.0.5",
-				"level-iterator-stream": "1.3.1",
-				"prr": "1.0.1",
-				"semver": "5.4.1",
-				"xtend": "4.0.1"
+				"deferred-leveldown": "~1.2.1",
+				"level-codec": "~7.0.0",
+				"level-errors": "~1.0.3",
+				"level-iterator-stream": "~1.3.0",
+				"prr": "~1.0.1",
+				"semver": "~5.4.1",
+				"xtend": "~4.0.0"
 			},
 			"dependencies": {
-				"prr": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+				"semver": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
 				}
 			}
 		},
@@ -6447,8 +6260,8 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"libp2p-crypto": {
@@ -6456,18 +6269,18 @@
 			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
 			"integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
 			"requires": {
-				"asn1.js": "5.0.0",
-				"async": "2.6.0",
-				"browserify-aes": "1.1.1",
-				"bs58": "4.0.1",
-				"keypair": "1.0.1",
-				"libp2p-crypto-secp256k1": "0.2.2",
-				"multihashing-async": "0.4.8",
-				"node-forge": "0.7.4",
-				"pem-jwk": "1.5.1",
-				"protons": "1.0.1",
-				"rsa-pem-to-jwk": "1.1.3",
-				"tweetnacl": "1.0.0",
+				"asn1.js": "^5.0.0",
+				"async": "^2.6.0",
+				"browserify-aes": "^1.1.1",
+				"bs58": "^4.0.1",
+				"keypair": "^1.0.1",
+				"libp2p-crypto-secp256k1": "~0.2.2",
+				"multihashing-async": "~0.4.7",
+				"node-forge": "^0.7.1",
+				"pem-jwk": "^1.5.1",
+				"protons": "^1.0.1",
+				"rsa-pem-to-jwk": "^1.1.3",
+				"tweetnacl": "^1.0.0",
 				"webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
 			},
 			"dependencies": {
@@ -6476,9 +6289,17 @@
 					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
 					"integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.0"
+						"bn.js": "^4.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
 					}
 				},
 				"base-x": {
@@ -6486,7 +6307,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -6494,16 +6315,13 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				},
 				"tweetnacl": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
 					"integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
-				},
-				"webcrypto-shim": {
-					"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
 				}
 			}
 		},
@@ -6512,11 +6330,21 @@
 			"resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
 			"integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
 			"requires": {
-				"async": "2.6.0",
-				"multihashing-async": "0.4.8",
-				"nodeify": "1.0.1",
-				"safe-buffer": "5.1.1",
-				"secp256k1": "3.3.1"
+				"async": "^2.5.0",
+				"multihashing-async": "~0.4.6",
+				"nodeify": "^1.0.1",
+				"safe-buffer": "^5.1.1",
+				"secp256k1": "^3.3.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				}
 			}
 		},
 		"listr": {
@@ -6524,32 +6352,49 @@
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
 			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"figures": "1.7.0",
-				"indent-string": "2.1.0",
-				"is-observable": "0.2.0",
-				"is-promise": "2.1.0",
-				"is-stream": "1.1.0",
-				"listr-silent-renderer": "1.1.1",
-				"listr-update-renderer": "0.4.0",
-				"listr-verbose-renderer": "0.4.1",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"ora": "0.2.3",
-				"p-map": "1.2.0",
-				"rxjs": "5.5.10",
-				"stream-to-observable": "0.2.0",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"figures": "^1.7.0",
+				"indent-string": "^2.1.0",
+				"is-observable": "^0.2.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.4.0",
+				"listr-verbose-renderer": "^0.4.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"ora": "^0.2.3",
+				"p-map": "^1.1.1",
+				"rxjs": "^5.4.2",
+				"stream-to-observable": "^0.2.0",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"figures": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"is-promise": {
@@ -6562,8 +6407,13 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -6577,23 +6427,40 @@
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"elegant-spinner": "1.0.1",
-				"figures": "1.7.0",
-				"indent-string": "3.2.0",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"figures": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"indent-string": {
@@ -6606,8 +6473,13 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -6616,18 +6488,35 @@
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
+				"chalk": "^1.1.3",
+				"cli-cursor": "^1.0.2",
+				"date-fns": "^1.27.2",
+				"figures": "^1.7.0"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -6635,8 +6524,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"onetime": {
@@ -6649,21 +6538,27 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"loader-runner": {
@@ -6672,13 +6567,14 @@
 			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
 		},
 		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 			"requires": {
-				"big.js": "3.2.0",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"localstorage-down": {
@@ -6688,10 +6584,10 @@
 			"requires": {
 				"abstract-leveldown": "0.12.3",
 				"argsarray": "0.0.1",
-				"buffer-from": "0.1.2",
-				"d64": "1.0.0",
-				"humble-localstorage": "1.4.2",
-				"inherits": "2.0.3",
+				"buffer-from": "^0.1.1",
+				"d64": "^1.0.0",
+				"humble-localstorage": "^1.4.2",
+				"inherits": "^2.0.1",
 				"tiny-queue": "0.2.0"
 			},
 			"dependencies": {
@@ -6700,7 +6596,7 @@
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
 					"integrity": "sha1-EWsexcdxDvei1XBnaLvbREC+EHA=",
 					"requires": {
-						"xtend": "3.0.0"
+						"xtend": "~3.0.0"
 					}
 				},
 				"xtend": {
@@ -6720,22 +6616,22 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._basecopy": {
@@ -6768,9 +6664,9 @@
 			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
 			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._basecreate": "3.0.3",
-				"lodash._isiterateecall": "3.0.9"
+				"lodash._baseassign": "^3.0.0",
+				"lodash._basecreate": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0"
 			}
 		},
 		"lodash.filter": {
@@ -6793,9 +6689,9 @@
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lodash.map": {
@@ -6813,40 +6709,7 @@
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"requires": {
-				"chalk": "2.4.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "1.9.1"
-					}
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "3.0.0"
-					}
-				}
+				"chalk": "^2.0.1"
 			}
 		},
 		"log-update": {
@@ -6854,8 +6717,8 @@
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
+				"ansi-escapes": "^1.0.0",
+				"cli-cursor": "^1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -6868,7 +6731,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -6881,8 +6744,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -6902,34 +6765,33 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+			"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.1"
 			}
 		},
 		"ltgt": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-			"integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
 		},
 		"make-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -6939,24 +6801,31 @@
 				}
 			}
 		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"math-random": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+		},
 		"md5.js": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
-			},
-			"dependencies": {
-				"hash-base": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.1"
-					}
-				}
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"media-typer": {
@@ -6969,7 +6838,7 @@
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"mem-fs": {
@@ -6977,45 +6846,33 @@
 			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
 			"requires": {
-				"through2": "2.0.3",
-				"vinyl": "1.2.0",
-				"vinyl-file": "2.0.0"
+				"through2": "^2.0.0",
+				"vinyl": "^1.1.0",
+				"vinyl-file": "^2.0.0"
 			}
 		},
 		"mem-fs-editor": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+			"integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
 			"requires": {
-				"commondir": "1.0.1",
-				"deep-extend": "0.4.2",
-				"ejs": "2.5.9",
-				"glob": "7.1.2",
-				"globby": "6.1.0",
-				"mkdirp": "0.5.1",
-				"multimatch": "2.1.0",
-				"rimraf": "2.6.2",
-				"through2": "2.0.3",
-				"vinyl": "2.1.0"
+				"commondir": "^1.0.1",
+				"deep-extend": "^0.5.1",
+				"ejs": "^2.5.9",
+				"glob": "^7.0.3",
+				"globby": "^8.0.0",
+				"isbinaryfile": "^3.0.2",
+				"mkdirp": "^0.5.0",
+				"multimatch": "^2.0.0",
+				"rimraf": "^2.2.8",
+				"through2": "^2.0.0",
+				"vinyl": "^2.0.1"
 			},
 			"dependencies": {
 				"clone-stats": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
 					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
 				},
 				"replace-ext": {
 					"version": "1.0.0",
@@ -7027,12 +6884,12 @@
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
 					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
 					"requires": {
-						"clone": "2.1.1",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -7042,22 +6899,12 @@
 			"resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
 			"integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
 			"requires": {
-				"abstract-leveldown": "2.7.2",
-				"functional-red-black-tree": "1.0.1",
-				"immediate": "3.2.3",
-				"inherits": "2.0.3",
-				"ltgt": "2.2.0",
-				"safe-buffer": "5.1.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"requires": {
-						"xtend": "4.0.1"
-					}
-				}
+				"abstract-leveldown": "~2.7.1",
+				"functional-red-black-tree": "^1.0.1",
+				"immediate": "^3.2.3",
+				"inherits": "~2.0.1",
+				"ltgt": "~2.2.0",
+				"safe-buffer": "~5.1.1"
 			}
 		},
 		"memory-fs": {
@@ -7065,8 +6912,8 @@
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"requires": {
-				"errno": "0.1.4",
-				"readable-stream": "2.3.3"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"memorystream": {
@@ -7079,26 +6926,24 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
+		"merge2": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
+		},
 		"merkle-patricia-tree": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.2.0.tgz",
-			"integrity": "sha1-ekeHsSYqsA/psgSrRxsAUzIwbvo=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+			"integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
 			"requires": {
-				"async": "1.5.2",
-				"ethereumjs-util": "4.5.0",
+				"async": "^1.4.2",
+				"ethereumjs-util": "^5.0.0",
 				"level-ws": "0.0.0",
-				"levelup": "1.3.9",
-				"memdown": "1.4.1",
-				"readable-stream": "2.3.3",
-				"rlp": "2.0.0",
-				"semaphore": "1.1.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				}
+				"levelup": "^1.2.1",
+				"memdown": "^1.0.0",
+				"readable-stream": "^2.0.0",
+				"rlp": "^2.0.0",
+				"semaphore": ">=1.0.1"
 			}
 		},
 		"methods": {
@@ -7107,23 +6952,30 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
 			}
 		},
 		"miller-rabin": {
@@ -7131,8 +6983,8 @@
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"mime": {
@@ -7141,22 +6993,22 @@
 			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.0",
@@ -7168,13 +7020,13 @@
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"requires": {
-				"dom-walk": "0.1.1"
+				"dom-walk": "^0.1.0"
 			}
 		},
 		"minimalistic-assert": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
@@ -7186,13 +7038,32 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -7207,78 +7078,46 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
 			"integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "*"
 			}
 		},
 		"mocha": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-			"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
+			"integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
 			"requires": {
-				"commander": "2.3.0",
-				"debug": "2.2.0",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.2",
-				"glob": "3.2.11",
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.0",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
 				"growl": "1.9.2",
-				"jade": "0.26.3",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
 				"mkdirp": "0.5.1",
-				"supports-color": "1.2.0",
-				"to-iso-string": "0.0.2"
+				"supports-color": "3.1.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
-				},
-				"glob": {
-					"version": "3.2.11",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-					"requires": {
-						"inherits": "2.0.3",
-						"minimatch": "0.3.0"
-					}
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
 		"mock-fs": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.2.tgz",
-			"integrity": "sha512-dF+yxZSojSiI8AXGoxj5qdFWpucndc54Ug+TwlpHFaV7j22MGG+OML2+FVa6xAZtjb/OFFQhOC37Jegx2GbEwA=="
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
+			"integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w=="
 		},
 		"mout": {
 			"version": "0.11.1",
@@ -7286,21 +7125,21 @@
 			"integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+			"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
 		},
 		"multiaddr": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.0.2.tgz",
-			"integrity": "sha512-TLEujk9VD1SR8HgV00rr1I3MWOk4t0GSDvxzzOO1m1hfxdv4DkFHmKKUHngUCiWHDeClHKSSV23Ig5/Mav3MQw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
+			"integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
 			"requires": {
-				"bs58": "4.0.1",
-				"ip": "1.1.5",
-				"lodash.filter": "4.6.0",
-				"lodash.map": "4.6.0",
-				"varint": "5.0.0",
-				"xtend": "4.0.1"
+				"bs58": "^4.0.1",
+				"ip": "^1.1.5",
+				"lodash.filter": "^4.6.0",
+				"lodash.map": "^4.6.0",
+				"varint": "^5.0.0",
+				"xtend": "^4.0.1"
 			},
 			"dependencies": {
 				"base-x": {
@@ -7308,7 +7147,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -7316,7 +7155,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -7334,7 +7173,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				}
 			}
@@ -7344,7 +7183,7 @@
 			"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.6.tgz",
 			"integrity": "sha512-VGyRUDkxdJzWnj9x3C49MzI3+TtKKDYNfIBOaWBCNuPk6CE5CwwkL15gJtsLDfLay0fL4xTh4Af3kBbJSxSppw==",
 			"requires": {
-				"varint": "5.0.0"
+				"varint": "^5.0.0"
 			}
 		},
 		"multihashes": {
@@ -7352,8 +7191,8 @@
 			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
 			"integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
 			"requires": {
-				"bs58": "4.0.1",
-				"varint": "5.0.0"
+				"bs58": "^4.0.1",
+				"varint": "^5.0.0"
 			},
 			"dependencies": {
 				"base-x": {
@@ -7361,7 +7200,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -7369,7 +7208,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -7379,18 +7218,21 @@
 			"resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
 			"integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
 			"requires": {
-				"async": "2.6.0",
-				"blakejs": "1.1.0",
-				"js-sha3": "0.7.0",
-				"multihashes": "0.4.13",
-				"murmurhash3js": "3.0.1",
-				"nodeify": "1.0.1"
+				"async": "^2.6.0",
+				"blakejs": "^1.1.0",
+				"js-sha3": "^0.7.0",
+				"multihashes": "~0.4.13",
+				"murmurhash3js": "^3.0.1",
+				"nodeify": "^1.0.1"
 			},
 			"dependencies": {
-				"js-sha3": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-					"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				}
 			}
 		},
@@ -7399,10 +7241,10 @@
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"multipart-stream": {
@@ -7410,9 +7252,9 @@
 			"resolved": "https://registry.npmjs.org/multipart-stream/-/multipart-stream-2.0.1.tgz",
 			"integrity": "sha1-GVyctLLEHnjHKh6POMfQ66HNC6A=",
 			"requires": {
-				"inherits": "2.0.3",
-				"is-stream": "1.1.0",
-				"sandwich-stream": "1.0.0"
+				"inherits": "^2.0.1",
+				"is-stream": "^1.0.1",
+				"sandwich-stream": "^1.0.0"
 			}
 		},
 		"murmurhash3js": {
@@ -7430,30 +7272,56 @@
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
 			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
 			"requires": {
-				"any-promise": "1.3.0",
-				"object-assign": "4.1.1",
-				"thenify-all": "1.6.0"
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
 			}
 		},
 		"nan": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
 		},
 		"nano-json-stream-parser": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
 			"integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
 		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
 		"ndjson": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
 			"integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
 			"requires": {
-				"json-stringify-safe": "5.0.1",
-				"minimist": "1.2.0",
-				"split2": "2.2.0",
-				"through2": "2.0.3"
+				"json-stringify-safe": "^5.0.1",
+				"minimist": "^1.2.0",
+				"split2": "^2.1.0",
+				"through2": "^2.0.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -7473,18 +7341,15 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
 			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
 		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		},
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
 			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
-		},
-		"node-abi": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
-			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
-			"requires": {
-				"semver": "5.4.1"
-			}
 		},
 		"node-dir": {
 			"version": "0.1.8",
@@ -7496,49 +7361,62 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-forge": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
-			"integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA=="
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
 		},
 		"node-libs-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.12.0",
-				"domain-browser": "1.1.7",
-				"events": "1.1.1",
-				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.2.0",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.3",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
-				"timers-browserify": "2.0.4",
+				"process": "^0.11.10",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.3.3",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
+				"process": {
+					"version": "0.11.10",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
 				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
 				}
 			}
 		},
@@ -7547,8 +7425,8 @@
 			"resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
 			"integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
 			"requires": {
-				"is-promise": "1.0.1",
-				"promise": "1.3.0"
+				"is-promise": "~1.0.0",
+				"promise": "~1.3.0"
 			}
 		},
 		"nomnom": {
@@ -7556,8 +7434,8 @@
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 			"requires": {
-				"chalk": "0.4.0",
-				"underscore": "1.6.0"
+				"chalk": "~0.4.0",
+				"underscore": "~1.6.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7570,9 +7448,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -7587,17 +7465,12 @@
 				}
 			}
 		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-		},
 		"nopt": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1.0.9"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -7605,10 +7478,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -7616,7 +7489,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"normalize-url": {
@@ -7624,9 +7497,9 @@
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
 			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
 			"requires": {
-				"prepend-http": "2.0.0",
-				"query-string": "5.1.1",
-				"sort-keys": "2.0.0"
+				"prepend-http": "^2.0.0",
+				"query-string": "^5.0.1",
+				"sort-keys": "^2.0.0"
 			},
 			"dependencies": {
 				"prepend-http": {
@@ -7641,18 +7514,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "2.0.1"
-			}
-		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "1.1.4",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -7686,23 +7548,59 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
 		"object-inspect": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-			"integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+			"integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
 		},
 		"object-keys": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
 			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
 		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "^3.0.1"
 			}
 		},
 		"oboe": {
@@ -7710,7 +7608,7 @@
 			"resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
 			"integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
 			"requires": {
-				"http-https": "1.0.0"
+				"http-https": "^1.0.0"
 			}
 		},
 		"on-build-webpack": {
@@ -7731,7 +7629,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -7739,16 +7637,15 @@
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+			"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.2"
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
@@ -7756,12 +7653,12 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -7776,18 +7673,35 @@
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-spinners": "0.1.2",
-				"object-assign": "4.1.1"
+				"chalk": "^1.1.1",
+				"cli-cursor": "^1.0.2",
+				"cli-spinners": "^0.1.2",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -7800,9 +7714,14 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -7812,9 +7731,9 @@
 			"integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
 		},
 		"os-browserify": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
@@ -7822,13 +7741,11 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -7846,7 +7763,7 @@
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"requires": {
-				"p-reduce": "1.0.0"
+				"p-reduce": "^1.0.0"
 			}
 		},
 		"p-finally": {
@@ -7865,16 +7782,19 @@
 			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
 		},
 		"p-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "^1.0.0"
+			}
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -7892,35 +7812,60 @@
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 			"requires": {
-				"p-finally": "1.0.0"
+				"p-finally": "^1.0.0"
 			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 		},
 		"parse-asn1": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
-			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
-				"asn1.js": "4.9.2",
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.14"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
+		},
+		"parse-cache-control": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+			"integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
 			}
 		},
 		"parse-headers": {
@@ -7928,7 +7873,7 @@
 			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
 			"integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
 			"requires": {
-				"for-each": "0.3.2",
+				"for-each": "^0.3.2",
 				"trim": "0.0.1"
 			}
 		},
@@ -7937,7 +7882,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse-passwd": {
@@ -7950,10 +7895,20 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
 			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -7981,40 +7936,45 @@
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"pify": "2.3.0"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
-			"version": "3.0.14",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
 			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"peer-id": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.6.tgz",
-			"integrity": "sha512-NyJgPRy108amQClcuBI/VZtyFJLDaTsPC3nVhZ87mpY5JVFmI2Er4atMap6/ToRJxm/RBX1Nh8CMxzlXCpfKKw==",
+			"version": "0.10.7",
+			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+			"integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
 			"requires": {
-				"async": "2.6.0",
-				"libp2p-crypto": "0.12.1",
-				"lodash": "4.17.5",
-				"multihashes": "0.4.13"
+				"async": "^2.6.0",
+				"libp2p-crypto": "~0.12.1",
+				"lodash": "^4.17.5",
+				"multihashes": "~0.4.13"
 			},
 			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
 				}
 			}
 		},
@@ -8023,9 +7983,9 @@
 			"resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
 			"integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
 			"requires": {
-				"lodash.uniqby": "4.7.0",
-				"multiaddr": "3.0.2",
-				"peer-id": "0.10.6"
+				"lodash.uniqby": "^4.7.0",
+				"multiaddr": "^3.0.2",
+				"peer-id": "~0.10.5"
 			}
 		},
 		"pegjs": {
@@ -8046,9 +8006,9 @@
 					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
 					"integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
 					"requires": {
-						"bn.js": "1.3.0",
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.0"
+						"bn.js": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"bn.js": {
@@ -8084,7 +8044,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -8092,7 +8052,7 @@
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 			"requires": {
-				"find-up": "1.1.2"
+				"find-up": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -8100,8 +8060,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -8109,38 +8069,15 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
 		},
-		"prebuild-install": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-			"integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
-			"requires": {
-				"expand-template": "1.1.0",
-				"github-from-package": "0.0.0",
-				"minimist": "1.2.0",
-				"mkdirp": "0.5.1",
-				"node-abi": "2.1.2",
-				"noop-logger": "0.1.1",
-				"npmlog": "4.1.2",
-				"os-homedir": "1.0.2",
-				"pump": "1.0.2",
-				"rc": "1.2.2",
-				"simple-get": "1.4.3",
-				"tar-fs": "1.16.0",
-				"tunnel-agent": "0.6.0",
-				"xtend": "4.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
-			}
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -8181,21 +8118,21 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
 			"integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
 			"requires": {
-				"is-promise": "1.0.1"
+				"is-promise": "~1"
 			}
 		},
 		"promise-polyfill": {
@@ -8218,10 +8155,10 @@
 			"resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
 			"integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
 			"requires": {
-				"protocol-buffers-schema": "3.3.2",
-				"safe-buffer": "5.1.1",
-				"signed-varint": "2.0.1",
-				"varint": "5.0.0"
+				"protocol-buffers-schema": "^3.3.1",
+				"safe-buffer": "^5.1.1",
+				"signed-varint": "^2.0.1",
+				"varint": "^5.0.0"
 			}
 		},
 		"proxy-addr": {
@@ -8229,14 +8166,14 @@
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
 			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"requires": {
-				"forwarded": "0.1.2",
+				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.6.0"
 			}
 		},
 		"prr": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -8244,15 +8181,15 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
-			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"pull-cat": {
@@ -8260,18 +8197,23 @@
 			"resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
 			"integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
 		},
+		"pull-defer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
+			"integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
+		},
 		"pull-level": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
 			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
 			"requires": {
-				"level-post": "1.0.7",
-				"pull-cat": "1.1.11",
-				"pull-live": "1.0.1",
-				"pull-pushable": "2.2.0",
-				"pull-stream": "3.6.2",
-				"pull-window": "2.1.4",
-				"stream-to-pull-stream": "1.7.2"
+				"level-post": "^1.0.7",
+				"pull-cat": "^1.1.9",
+				"pull-live": "^1.0.1",
+				"pull-pushable": "^2.0.0",
+				"pull-stream": "^3.4.0",
+				"pull-window": "^2.1.4",
+				"stream-to-pull-stream": "^1.7.1"
 			}
 		},
 		"pull-live": {
@@ -8279,8 +8221,8 @@
 			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
 			"integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
 			"requires": {
-				"pull-cat": "1.1.11",
-				"pull-stream": "3.6.2"
+				"pull-cat": "^1.1.9",
+				"pull-stream": "^3.4.0"
 			}
 		},
 		"pull-pushable": {
@@ -8289,9 +8231,9 @@
 			"integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
 		},
 		"pull-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz",
-			"integrity": "sha1-HqFMbxMXTmrE3vDCpOdlZ7fLDFw="
+			"version": "3.6.8",
+			"resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.8.tgz",
+			"integrity": "sha512-wQUIptQBcM0rFsUhZoEpOT3vUn73DtTGVq3NQ86c4T7iMOSprDzeKWYq2ksXnbwiuExTKvt+8G9fzNLFQuiO+A=="
 		},
 		"pull-traverse": {
 			"version": "1.0.3",
@@ -8303,36 +8245,36 @@
 			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
 			"integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
 			"requires": {
-				"looper": "2.0.0"
+				"looper": "^2.0.0"
 			}
 		},
 		"pump": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-			"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
 			"requires": {
-				"end-of-stream": "1.4.0",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 		},
 		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"requires": {
-				"decode-uri-component": "0.2.0",
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"querystring": {
@@ -8346,57 +8288,42 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"randomatic": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				},
 				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"randombytes": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"requires": {
-				"randombytes": "2.0.5",
-				"safe-buffer": "5.1.1"
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomhex": {
@@ -8410,32 +8337,14 @@
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
 			"requires": {
 				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
 				"unpipe": "1.0.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.4",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
 			}
 		},
 		"read-chunk": {
@@ -8443,8 +8352,8 @@
 			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
 			"requires": {
-				"pify": "3.0.0",
-				"safe-buffer": "5.1.1"
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -8455,36 +8364,70 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "2.0.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				}
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
 			}
 		},
 		"readdirp": {
@@ -8492,10 +8435,10 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"recast": {
@@ -8504,16 +8447,11 @@
 			"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
 			"requires": {
 				"ast-types": "0.11.3",
-				"esprima": "4.0.0",
-				"private": "0.1.8",
-				"source-map": "0.6.1"
+				"esprima": "~4.0.0",
+				"private": "~0.1.5",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8526,27 +8464,27 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.1.7"
+				"resolve": "^1.1.6"
 			}
 		},
 		"regenerate": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerator-runtime": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -8554,7 +8492,16 @@
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -8562,9 +8509,9 @@
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
@@ -8577,7 +8524,14 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
 			}
 		},
 		"remove-trailing-separator": {
@@ -8600,7 +8554,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"replace-ext": {
@@ -8609,54 +8563,52 @@
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"req-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
-			"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
+			"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
 			"requires": {
-				"req-from": "1.0.1"
+				"req-from": "^2.0.0"
 			}
 		},
 		"req-from": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
-			"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
+			"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
 			"requires": {
-				"resolve-from": "2.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"uuid": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 				}
 			}
 		},
@@ -8665,7 +8617,7 @@
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.13.1"
 			}
 		},
 		"request-promise-native": {
@@ -8674,8 +8626,8 @@
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -8694,23 +8646,19 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"requires": {
+				"path-parse": "^1.0.5"
+			}
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
-				"resolve-from": "3.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-				}
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-dir": {
@@ -8718,21 +8666,26 @@
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"requires": {
-				"expand-tilde": "2.0.2",
-				"global-modules": "1.0.0"
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
 			}
 		},
 		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"responselike": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 			"requires": {
-				"lowercase-keys": "1.0.0"
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"restore-cursor": {
@@ -8740,8 +8693,8 @@
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"resumer": {
@@ -8749,15 +8702,20 @@
 			"resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
 			"integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
 			"requires": {
-				"through": "2.3.8"
+				"through": "~2.3.4"
 			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -8765,31 +8723,16 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				}
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"rlp": {
@@ -8802,7 +8745,7 @@
 			"resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
 			"integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
 			"requires": {
-				"object-assign": "2.1.1",
+				"object-assign": "^2.0.0",
 				"rsa-unpack": "0.0.6"
 			},
 			"dependencies": {
@@ -8818,17 +8761,7 @@
 			"resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
 			"integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
 			"requires": {
-				"optimist": "0.3.7"
-			},
-			"dependencies": {
-				"optimist": {
-					"version": "0.3.7",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-					"requires": {
-						"wordwrap": "0.0.2"
-					}
-				}
+				"optimist": "~0.3.5"
 			}
 		},
 		"run-async": {
@@ -8836,7 +8769,7 @@
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			},
 			"dependencies": {
 				"is-promise": {
@@ -8847,22 +8780,9 @@
 			}
 		},
 		"rustbn.js": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.1.tgz",
-			"integrity": "sha512-+Xq0RaL+HEErm4vaTUSWq8uq94OuzOu2UR16LowDvj/C8gclDsoYGp8hKpmakKW2dKqL433v2tkf8HCa2za+Eg=="
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"requires": {
-				"rx-lite": "4.0.8"
-			}
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+			"integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
 		},
 		"rxjs": {
 			"version": "5.5.10",
@@ -8873,9 +8793,22 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sandwich-stream": {
 			"version": "1.0.0",
@@ -8892,7 +8825,7 @@
 			"resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
 			"integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
 			"requires": {
-				"nan": "2.7.0"
+				"nan": "^2.0.8"
 			}
 		},
 		"scrypt.js": {
@@ -8900,8 +8833,8 @@
 			"resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
 			"integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
 			"requires": {
-				"scrypt": "6.0.3",
-				"scryptsy": "1.2.1"
+				"scrypt": "^6.0.2",
+				"scryptsy": "^1.2.1"
 			}
 		},
 		"scryptsy": {
@@ -8909,23 +8842,22 @@
 			"resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
 			"integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
 			"requires": {
-				"pbkdf2": "3.0.14"
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"secp256k1": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
-			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+			"integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
 			"requires": {
-				"bindings": "1.3.0",
-				"bip66": "1.1.5",
-				"bn.js": "4.11.8",
-				"create-hash": "1.1.3",
-				"drbg.js": "1.0.1",
-				"elliptic": "6.4.0",
-				"nan": "2.7.0",
-				"prebuild-install": "2.3.0",
-				"safe-buffer": "5.1.1"
+				"bindings": "^1.2.1",
+				"bip66": "^1.1.3",
+				"bn.js": "^4.11.3",
+				"create-hash": "^1.1.2",
+				"drbg.js": "^1.0.1",
+				"elliptic": "^6.2.3",
+				"nan": "^2.2.1",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"seedrandom": {
@@ -8938,7 +8870,7 @@
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
 			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
 			"requires": {
-				"commander": "2.8.1"
+				"commander": "~2.8.1"
 			},
 			"dependencies": {
 				"commander": {
@@ -8946,7 +8878,7 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
 					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
 					"requires": {
-						"graceful-readlink": "1.0.1"
+						"graceful-readlink": ">= 1.0.0"
 					}
 				}
 			}
@@ -8957,9 +8889,9 @@
 			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
 		},
 		"semver": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"send": {
 			"version": "0.16.2",
@@ -8967,18 +8899,38 @@
 			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
 			"requires": {
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "1.6.2",
+				"http-errors": "~1.6.2",
 				"mime": "1.4.1",
 				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.4.0"
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				}
 			}
 		},
 		"serve-static": {
@@ -8986,9 +8938,9 @@
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 			"requires": {
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
 				"send": "0.16.2"
 			}
 		},
@@ -8997,11 +8949,11 @@
 			"resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
 			"integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
 			"requires": {
-				"body-parser": "1.18.2",
-				"cors": "2.8.4",
-				"express": "4.16.3",
-				"request": "2.83.0",
-				"xhr": "2.4.0"
+				"body-parser": "^1.16.0",
+				"cors": "^2.8.1",
+				"express": "^4.14.0",
+				"request": "^2.79.0",
+				"xhr": "^2.3.3"
 			}
 		},
 		"set-blocking": {
@@ -9014,31 +8966,52 @@
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-			"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"sha.js": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"sha3": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
-			"integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+			"integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
 			"requires": {
-				"nan": "2.7.0"
+				"nan": "2.10.0"
 			}
 		},
 		"shebang-command": {
@@ -9046,7 +9019,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-loader": {
@@ -9064,24 +9037,9 @@
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.0.4",
-				"rechoir": "0.6.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				}
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
 		},
 		"sigmund": {
@@ -9099,7 +9057,7 @@
 			"resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
 			"integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
 			"requires": {
-				"varint": "5.0.0"
+				"varint": "~5.0.0"
 			}
 		},
 		"simple-concat": {
@@ -9108,13 +9066,13 @@
 			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
 		},
 		"simple-get": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-			"integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
 			"requires": {
-				"once": "1.4.0",
-				"unzip-response": "1.0.2",
-				"xtend": "4.0.1"
+				"decompress-response": "^3.3.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
 			}
 		},
 		"slash": {
@@ -9132,12 +9090,96 @@
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
 			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
-		"sntp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"hoek": "4.2.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sol-digger": {
@@ -9155,150 +9197,52 @@
 			"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.18.tgz",
 			"integrity": "sha512-Kq+O3PNF9Pfq7fB+lDYAuoqRdghLmZyfngsg0h1Hj38NKAeVHeGPOGeZasn5KqdPeCzbMFvaGyTySxzGv6aXCg==",
 			"requires": {
-				"fs-extra": "0.30.0",
-				"memorystream": "0.3.1",
-				"require-from-string": "1.2.1",
-				"semver": "5.4.1",
-				"yargs": "4.8.1"
+				"fs-extra": "^0.30.0",
+				"memorystream": "^0.3.1",
+				"require-from-string": "^1.1.0",
+				"semver": "^5.3.0",
+				"yargs": "^4.7.1"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"fs-extra": {
+					"version": "0.30.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.6"
 					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
 					"version": "4.8.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"lodash.assign": "^4.0.3",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.1",
+						"which-module": "^1.0.0",
+						"window-size": "^0.2.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^2.4.1"
 					}
 				}
 			}
@@ -9308,216 +9252,232 @@
 			"resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.4.3.tgz",
 			"integrity": "sha512-ARsACPfgUgZahaHIiVmuYxkJczKXPDekdxdGMtq+78zCA62eCVpSzth1gyVkv+pVdQ5XOmQ/eRWLOFgNsfvxqA==",
 			"requires": {
-				"death": "1.1.0",
+				"death": "^1.1.0",
 				"ethereumjs-testrpc-sc": "6.0.7",
-				"istanbul": "0.4.5",
-				"keccakjs": "0.2.1",
-				"req-cwd": "1.0.1",
-				"shelljs": "0.7.8",
-				"sol-explore": "1.6.2",
+				"istanbul": "^0.4.5",
+				"keccakjs": "^0.2.1",
+				"req-cwd": "^1.0.1",
+				"shelljs": "^0.7.4",
+				"sol-explore": "^1.6.2",
 				"solidity-parser-sc": "0.4.1",
-				"web3": "0.18.4"
+				"web3": "^0.18.4"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"req-cwd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
+					"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
+					"requires": {
+						"req-from": "^1.0.1"
+					}
+				},
+				"req-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
+					"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
+					"requires": {
+						"resolve-from": "^2.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				}
 			}
+		},
+		"solidity-parser-antlr": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz",
+			"integrity": "sha512-g1RWj6m377CBlUBlyffhv4UOO48ue+gL7GlmE9i77N8bxaKgzWvTl1xzvDadaubJoz2euPpk3A7qTPbqkUof1w=="
 		},
 		"solidity-parser-sc": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
 			"integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
 			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"mocha": "^2.4.5",
+				"pegjs": "^0.10.0",
+				"yargs": "^4.6.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				"commander": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
 				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"debug": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"ms": "0.7.1"
 					}
 				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"os-locale": {
+				"diff": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"string-width": {
+				"escape-string-regexp": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"inherits": "2",
+						"minimatch": "0.3"
 					}
 				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"lru-cache": "2",
+						"sigmund": "~1.0.0"
 					}
 				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				"mocha": {
+					"version": "2.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+					"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+					"requires": {
+						"commander": "2.3.0",
+						"debug": "2.2.0",
+						"diff": "1.4.0",
+						"escape-string-regexp": "1.0.2",
+						"glob": "3.2.11",
+						"growl": "1.9.2",
+						"jade": "0.26.3",
+						"mkdirp": "0.5.1",
+						"supports-color": "1.2.0",
+						"to-iso-string": "0.0.2"
+					}
 				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+				"ms": {
+					"version": "0.7.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+				},
+				"supports-color": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
 				},
 				"yargs": {
 					"version": "4.8.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"lodash.assign": "^4.0.3",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.1",
+						"which-module": "^1.0.0",
+						"window-size": "^0.2.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^2.4.1"
 					}
 				}
 			}
 		},
 		"solium": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/solium/-/solium-1.0.4.tgz",
-			"integrity": "sha512-IiWV5YLSuRplNAOXMhrOH8yi5J4PbNEbZaxhSdxtgEeK9tA6OXcAvwTsq2I8qRzqf6m3Bxr6OhiGboQaLtGC4Q==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/solium/-/solium-1.1.7.tgz",
+			"integrity": "sha512-yYbalsrzJCU+QJ0HZvxAT4IQIqI1e6KPW2vop0NaHwdijqhQC9fJkVioCrL18NbO2Z8rdcnx8Y0JpvYJWrIjRg==",
 			"requires": {
-				"ajv": "5.3.0",
-				"chokidar": "1.7.0",
-				"colors": "1.1.2",
-				"commander": "2.11.0",
-				"js-string-escape": "1.0.1",
-				"lodash": "4.17.4",
+				"ajv": "^5.2.2",
+				"chokidar": "^1.6.0",
+				"colors": "^1.1.2",
+				"commander": "^2.9.0",
+				"js-string-escape": "^1.0.1",
+				"lodash": "^4.14.2",
 				"sol-digger": "0.0.2",
-				"sol-explore": "1.6.2",
-				"solium-plugin-security": "0.0.2",
-				"solparse": "1.4.0"
+				"sol-explore": "1.6.1",
+				"solium-plugin-security": "0.1.1",
+				"solparse": "2.2.5",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
-							}
-						}
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
 					}
 				},
-				"commander": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"requires": {
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
+					}
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -9532,17 +9492,41 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
 					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
 				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
 				"glob": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
 					}
 				},
 				"growl": {
@@ -9550,10 +9534,48 @@
 					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
 					"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
 				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
+					}
+				},
 				"mocha": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-					"integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+					"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
 					"requires": {
 						"browser-stdout": "1.3.0",
 						"commander": "2.11.0",
@@ -9565,16 +9587,33 @@
 						"he": "1.1.1",
 						"mkdirp": "0.5.1",
 						"supports-color": "4.4.0"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.11.0",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+							"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+						}
 					}
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"sol-explore": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/sol-explore/-/sol-explore-1.6.1.tgz",
+					"integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs="
+				},
 				"solparse": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
-					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.5.tgz",
+					"integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
 					"requires": {
-						"mocha": "4.0.1",
-						"pegjs": "0.10.0",
-						"yargs": "10.0.3"
+						"mocha": "^4.0.1",
+						"pegjs": "^0.10.0",
+						"yargs": "^10.0.3"
 					}
 				},
 				"supports-color": {
@@ -9582,49 +9621,22 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"requires": {
-						"has-flag": "2.0.0"
-					}
-				},
-				"yargs": {
-					"version": "10.0.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
-					"requires": {
-						"camelcase": "4.1.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
 		},
 		"solium-plugin-security": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.0.2.tgz",
-			"integrity": "sha512-2xjJoAWeY1Ynz1ExxtCVSABAMPrDV/AqhjE/X6jXMHJ1ubT+j9kDt5HKaHNOCa2MWoTna281HzcZlTioR1/ObA=="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+			"integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
 		},
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-list-map": {
@@ -9637,38 +9649,73 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "^0.5.6"
 			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
 		"spdx-expression-parse": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
 		},
 		"spdx-license-ids": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
 		},
 		"split2": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"requires": {
-				"through2": "2.0.3"
+				"through2": "^2.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -9677,29 +9724,48 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stable": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-			"integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
 		},
 		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -9711,20 +9777,20 @@
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-http": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.3.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"stream-to-observable": {
@@ -9732,7 +9798,7 @@
 			"resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
 			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
 			"requires": {
-				"any-observable": "0.2.0"
+				"any-observable": "^0.2.0"
 			}
 		},
 		"stream-to-pull-stream": {
@@ -9740,8 +9806,8 @@
 			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
 			"integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
 			"requires": {
-				"looper": "3.0.0",
-				"pull-stream": "3.6.2"
+				"looper": "^3.0.0",
+				"pull-stream": "^3.2.3"
 			},
 			"dependencies": {
 				"looper": {
@@ -9756,7 +9822,7 @@
 			"resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
 			"integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
 			"requires": {
-				"promise-polyfill": "1.1.6"
+				"promise-polyfill": "^1.1.6"
 			}
 		},
 		"streamifier": {
@@ -9775,32 +9841,13 @@
 			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				}
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string.prototype.trim": {
@@ -9808,54 +9855,39 @@
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
 			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.9.0",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.0",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
+			}
 		},
 		"strip-bom-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
 			"requires": {
-				"first-chunk-stream": "2.0.0",
-				"strip-bom": "2.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				}
+				"first-chunk-stream": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"strip-dirs": {
@@ -9863,7 +9895,7 @@
 			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
 			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
 			"requires": {
-				"is-natural-number": "4.0.1"
+				"is-natural-number": "^4.0.1"
 			}
 		},
 		"strip-eof": {
@@ -9879,34 +9911,32 @@
 				"is-hex-prefixed": "1.0.0"
 			}
 		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-		},
 		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"swarm-js": {
 			"version": "0.1.37",
 			"resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
 			"integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
 			"requires": {
-				"bluebird": "3.5.1",
-				"buffer": "5.1.0",
-				"decompress": "4.2.0",
-				"eth-lib": "0.1.27",
-				"fs-extra": "2.1.2",
-				"fs-promise": "2.0.3",
-				"got": "7.1.0",
-				"mime-types": "2.1.17",
-				"mkdirp-promise": "5.0.1",
-				"mock-fs": "4.4.2",
-				"setimmediate": "1.0.5",
-				"tar.gz": "1.0.7",
-				"xhr-request-promise": "0.1.2"
+				"bluebird": "^3.5.0",
+				"buffer": "^5.0.5",
+				"decompress": "^4.0.0",
+				"eth-lib": "^0.1.26",
+				"fs-extra": "^2.1.2",
+				"fs-promise": "^2.0.0",
+				"got": "^7.1.0",
+				"mime-types": "^2.1.16",
+				"mkdirp-promise": "^5.0.1",
+				"mock-fs": "^4.1.0",
+				"setimmediate": "^1.0.5",
+				"tar.gz": "^1.0.5",
+				"xhr-request-promise": "^0.1.2"
 			},
 			"dependencies": {
 				"buffer": {
@@ -9914,8 +9944,8 @@
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
 					"integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
 					"requires": {
-						"base64-js": "1.2.1",
-						"ieee754": "1.1.8"
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
 					}
 				},
 				"fs-extra": {
@@ -9923,8 +9953,16 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
 					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
 					}
 				}
 			}
@@ -9934,29 +9972,47 @@
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 		},
+		"sync-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.0.0.tgz",
+			"integrity": "sha512-jGNIAlCi9iU4X3Dm4oQnNQshDD3h0/1A7r79LyqjbjUnj69sX6mShAXlhRXgImsfVKtTcnra1jfzabdZvp+Lmw==",
+			"requires": {
+				"http-response-object": "^3.0.1",
+				"sync-rpc": "^1.2.1",
+				"then-request": "^6.0.0"
+			}
+		},
+		"sync-rpc": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
+			"integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+			"requires": {
+				"get-port": "^3.1.0"
+			}
+		},
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
 			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
 		"tape": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-			"integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+			"integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
 			"requires": {
-				"deep-equal": "1.0.1",
-				"defined": "1.0.0",
-				"for-each": "0.3.2",
-				"function-bind": "1.1.1",
-				"glob": "7.1.2",
-				"has": "1.0.1",
-				"inherits": "2.0.3",
-				"minimist": "1.2.0",
-				"object-inspect": "1.3.0",
-				"resolve": "1.4.0",
-				"resumer": "0.0.0",
-				"string.prototype.trim": "1.1.2",
-				"through": "2.3.8"
+				"deep-equal": "~1.0.1",
+				"defined": "~1.0.0",
+				"for-each": "~0.3.2",
+				"function-bind": "~1.1.1",
+				"glob": "~7.1.2",
+				"has": "~1.0.1",
+				"inherits": "~2.0.3",
+				"minimist": "~1.2.0",
+				"object-inspect": "~1.5.0",
+				"resolve": "~1.5.0",
+				"resumer": "~0.0.0",
+				"string.prototype.trim": "~1.1.2",
+				"through": "~2.3.8"
 			},
 			"dependencies": {
 				"glob": {
@@ -9964,26 +10020,18 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				},
-				"resolve": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-					"requires": {
-						"path-parse": "1.0.5"
-					}
 				}
 			}
 		},
@@ -9992,31 +10040,34 @@
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
-			}
-		},
-		"tar-fs": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-			"requires": {
-				"chownr": "1.0.1",
-				"mkdirp": "0.5.1",
-				"pump": "1.0.2",
-				"tar-stream": "1.5.5"
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
 			}
 		},
 		"tar-stream": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+			"integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
 			"requires": {
-				"bl": "1.2.1",
-				"end-of-stream": "1.4.0",
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"bl": "^1.0.0",
+				"buffer-alloc": "^1.1.0",
+				"end-of-stream": "^1.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.0",
+				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+					"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+					"requires": {
+						"readable-stream": "^2.3.5",
+						"safe-buffer": "^5.1.1"
+					}
+				}
 			}
 		},
 		"tar.gz": {
@@ -10024,22 +10075,17 @@
 			"resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
 			"integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
 			"requires": {
-				"bluebird": "2.11.0",
-				"commander": "2.15.0",
-				"fstream": "1.0.11",
-				"mout": "0.11.1",
-				"tar": "2.2.1"
+				"bluebird": "^2.9.34",
+				"commander": "^2.8.1",
+				"fstream": "^1.0.8",
+				"mout": "^0.11.0",
+				"tar": "^2.1.1"
 			},
 			"dependencies": {
 				"bluebird": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
 					"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-				},
-				"commander": {
-					"version": "2.15.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-					"integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
 				}
 			}
 		},
@@ -10048,8 +10094,8 @@
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"rimraf": "2.2.8"
+				"os-tmpdir": "^1.0.0",
+				"rimraf": "~2.2.6"
 			},
 			"dependencies": {
 				"rimraf": {
@@ -10074,12 +10120,45 @@
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
 			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
 		},
+		"then-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.0.tgz",
+			"integrity": "sha512-xA+7uEMc+jsQIoyySJ93Ad08Kuqnik7u6jLS5hR91Z3smAoCfL3M8/MqMlobAa9gzBfO9pA88A/AntfepkkMJQ==",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/form-data": "0.0.33",
+				"@types/node": "^8.0.0",
+				"@types/qs": "^6.2.31",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.6.0",
+				"form-data": "^2.2.0",
+				"http-basic": "^7.0.0",
+				"http-response-object": "^3.0.1",
+				"promise": "^8.0.0",
+				"qs": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "8.10.17",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
+					"integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg=="
+				},
+				"promise": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+					"integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				}
+			}
+		},
 		"thenify": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
 			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
 			"requires": {
-				"any-promise": "1.3.0"
+				"any-promise": "^1.0.0"
 			}
 		},
 		"thenify-all": {
@@ -10087,7 +10166,7 @@
 			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
 			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
 			"requires": {
-				"thenify": "3.3.0"
+				"thenify": ">= 3.1.0 < 4"
 			}
 		},
 		"through": {
@@ -10100,8 +10179,8 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timed-out": {
@@ -10110,11 +10189,11 @@
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"requires": {
-				"setimmediate": "1.0.5"
+				"setimmediate": "^1.0.4"
 			}
 		},
 		"tiny-queue": {
@@ -10127,7 +10206,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
 			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.1"
 			}
 		},
 		"tmp-promise": {
@@ -10135,7 +10214,7 @@
 			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
 			"integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
 			"requires": {
-				"bluebird": "3.5.1",
+				"bluebird": "^3.5.0",
 				"tmp": "0.0.33"
 			},
 			"dependencies": {
@@ -10144,7 +10223,7 @@
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
@@ -10153,6 +10232,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+		},
+		"to-buffer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
@@ -10164,12 +10248,47 @@
 			"resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
 			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE="
 		},
-		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"punycode": "1.4.1"
+				"kind-of": "^3.0.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "^1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
 			}
 		},
 		"trim": {
@@ -10187,43 +10306,17 @@
 			"resolved": "https://registry.npmjs.org/truffle/-/truffle-4.0.5.tgz",
 			"integrity": "sha512-Hyj4LFRdfgoeb1SVV17hLAlO/szCXuuWS3tq26N5BI+avcEYdZl4KhxKMVgf6O/HeEIEuDYCpfLOWplXMfjeHQ==",
 			"requires": {
-				"mocha": "3.5.3",
-				"original-require": "1.0.1",
+				"mocha": "^3.4.2",
+				"original-require": "^1.0.1",
 				"solc": "0.4.18"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-					"requires": {
-						"graceful-readlink": "1.0.1"
-					}
-				},
 				"debug": {
 					"version": "2.6.8",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"requires": {
 						"ms": "2.0.0"
-					}
-				},
-				"diff": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-flag": {
@@ -10250,12 +10343,17 @@
 						"supports-color": "3.1.2"
 					}
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
 				"supports-color": {
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -10265,24 +10363,97 @@
 			"resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-0.0.3.tgz",
 			"integrity": "sha1-Dh3gIQS3PTh14c9wkzBbTqii2EM=",
 			"requires": {
-				"bip39": "2.4.0",
-				"ethereumjs-wallet": "0.6.0",
-				"web3": "0.18.4",
-				"web3-provider-engine": "8.6.1"
+				"bip39": "^2.2.0",
+				"ethereumjs-wallet": "^0.6.0",
+				"web3": "^0.18.2",
+				"web3-provider-engine": "^8.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"bignumber.js": {
+					"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+					"from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+				},
+				"web3": {
+					"version": "0.18.4",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+					"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+					"requires": {
+						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				},
+				"web3-provider-engine": {
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+					"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+					"requires": {
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
+					},
+					"dependencies": {
+						"bignumber.js": {
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "git+https://github.com/debris/bignumber.js.git#master"
+						},
+						"web3": {
+							"version": "0.16.0",
+							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+							"requires": {
+								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
+							}
+						}
+					}
+				}
 			}
 		},
 		"truffle-privatekey-provider": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.5.tgz",
-			"integrity": "sha512-I4agR/KbFA+XLLYxN32YeMTm5D9ySMQ5yN/CaRywCYceaZM+cPIXJQoX5R+L6S5i9OSm0aebbOGsdYSVU4YGaQ==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.6.tgz",
+			"integrity": "sha512-x4tsMeXolhae9mzIA5k9bbq4FdhzSI/UGyAKU/B9xepE0lMCfhpuQv8WM2xdLlqyDtiHouC8z5+rmSmcK8bGEQ==",
 			"requires": {
-				"ethereumjs-wallet": "0.6.0",
-				"web3": "0.20.6",
-				"web3-provider-engine": "8.6.1"
+				"ethereumjs-wallet": "^0.6.0",
+				"web3": "^0.20.1",
+				"web3-provider-engine": "^8.4.0"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
 				},
 				"web3": {
 					"version": "0.20.6",
@@ -10290,14 +10461,47 @@
 					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 					"requires": {
 						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
+					}
+				},
+				"web3-provider-engine": {
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
+					"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+					"requires": {
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
 					},
 					"dependencies": {
 						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "git+https://github.com/debris/bignumber.js.git#master"
+						},
+						"web3": {
+							"version": "0.16.0",
+							"resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+							"requires": {
+								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
+							}
 						}
 					}
 				}
@@ -10313,7 +10517,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -10327,7 +10531,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-detect": {
@@ -10341,22 +10545,7 @@
 			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.18"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.33.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-				},
-				"mime-types": {
-					"version": "2.1.18",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"requires": {
-						"mime-db": "1.33.0"
-					}
-				}
+				"mime-types": "~2.1.18"
 			}
 		},
 		"typedarray": {
@@ -10369,7 +10558,7 @@
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
 			"requires": {
-				"is-typedarray": "1.0.0"
+				"is-typedarray": "^1.0.0"
 			}
 		},
 		"typewise": {
@@ -10377,7 +10566,7 @@
 			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
 			"integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
 			"requires": {
-				"typewise-core": "1.2.0"
+				"typewise-core": "^1.2.0"
 			}
 		},
 		"typewise-core": {
@@ -10395,19 +10584,39 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -10424,9 +10633,9 @@
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
 			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.2"
+				"source-map": "^0.5.6",
+				"uglify-js": "^2.8.29",
+				"webpack-sources": "^1.0.1"
 			}
 		},
 		"ultron": {
@@ -10439,8 +10648,8 @@
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
 			"integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
 			"requires": {
-				"buffer": "3.6.0",
-				"through": "2.3.8"
+				"buffer": "^3.0.1",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"base64-js": {
@@ -10454,16 +10663,53 @@
 					"integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
 					"requires": {
 						"base64-js": "0.0.8",
-						"ieee754": "1.1.8",
-						"isarray": "1.0.0"
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
 					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
 		"underscore": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz",
+			"integrity": "sha512-4IV1DSSxC1QK48j9ONFK1MoIAKKkbE8i7u55w2R6IqBqbT7A/iG7aZBCR2Bi8piF0Uz+i/MG1aeqLwl/5vqF+A=="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
 		},
 		"universalify": {
 			"version": "0.1.1",
@@ -10480,15 +10726,69 @@
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
-		"untildify": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
+			}
 		},
-		"unzip-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+		"untildify": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
+		},
+		"uri-js": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+			"integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
@@ -10511,7 +10811,7 @@
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"url-set-query": {
@@ -10523,6 +10823,21 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"use": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"requires": {
+				"kind-of": "^6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
 		},
 		"utf8": {
 			"version": "2.1.2",
@@ -10565,12 +10880,12 @@
 			"integrity": "sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA=="
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"varint": {
@@ -10588,9 +10903,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vinyl": {
@@ -10598,8 +10913,8 @@
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 			"requires": {
-				"clone": "1.0.4",
-				"clone-stats": "0.0.1",
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
 				"replace-ext": "0.0.1"
 			},
 			"dependencies": {
@@ -10615,22 +10930,12 @@
 			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0",
-				"strip-bom-stream": "2.0.0",
-				"vinyl": "1.2.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				}
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.3.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0",
+				"strip-bom-stream": "^2.0.0",
+				"vinyl": "^1.1.0"
 			}
 		},
 		"vm-browserify": {
@@ -10642,142 +10947,191 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"requires": {
-				"async": "2.6.0",
-				"chokidar": "1.7.0",
-				"graceful-fs": "4.1.11"
+				"chokidar": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"neo-async": "^2.5.0"
 			}
 		},
 		"web3": {
-			"version": "0.18.4",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-			"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+			"version": "1.0.0-beta.26",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
+			"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
 			"requires": {
-				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-				"crypto-js": "3.1.8",
-				"utf8": "2.1.2",
-				"xhr2": "0.1.4",
-				"xmlhttprequest": "1.8.0"
+				"web3-bzz": "^1.0.0-beta.26",
+				"web3-core": "^1.0.0-beta.26",
+				"web3-eth": "^1.0.0-beta.26",
+				"web3-eth-personal": "^1.0.0-beta.26",
+				"web3-net": "^1.0.0-beta.26",
+				"web3-shh": "^1.0.0-beta.26",
+				"web3-utils": "^1.0.0-beta.26"
 			}
 		},
 		"web3-bzz": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.31.tgz",
-			"integrity": "sha1-rrp8lVhhqZupLdHKj3x6EngyhZ0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+			"integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
 			"requires": {
 				"got": "7.1.0",
 				"swarm-js": "0.1.37",
 				"underscore": "1.8.3"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.31.tgz",
-			"integrity": "sha1-q9FJzEEshTZb9NEZfHSeP1Dj6qE=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+			"integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
 			"requires": {
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-requestmanager": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-requestmanager": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-core-helpers": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.31.tgz",
-			"integrity": "sha1-cETI89P3NRWLoeZrhPbECQiCFlw=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+			"integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-eth-iban": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-eth-iban": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-method": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.31.tgz",
-			"integrity": "sha1-IRkLm4zxUDUT6Diw9O73Jg/uCTs=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+			"integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-promievent": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-promievent": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-promievent": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.31.tgz",
-			"integrity": "sha1-3alb5l7NeSTjAKXphHfBuwpX6PM=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+			"integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
 			"requires": {
 				"any-promise": "1.3.0",
 				"eventemitter3": "1.1.1"
 			}
 		},
 		"web3-core-requestmanager": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.31.tgz",
-			"integrity": "sha1-S/ZntBTUbgZtmTCZTzT0b7QI++c=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+			"integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-providers-http": "1.0.0-beta.31",
-				"web3-providers-ipc": "1.0.0-beta.31",
-				"web3-providers-ws": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-providers-http": "1.0.0-beta.34",
+				"web3-providers-ipc": "1.0.0-beta.34",
+				"web3-providers-ws": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-core-subscriptions": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.31.tgz",
-			"integrity": "sha1-fpAG3iCosEB6wTZO9WuHz8TQ8ks=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+			"integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
 			"requires": {
 				"eventemitter3": "1.1.1",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.31.tgz",
-			"integrity": "sha1-t7SwdVNLOjsKtbVpe9UIXXnrYcY=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+			"integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-eth-abi": "1.0.0-beta.31",
-				"web3-eth-accounts": "1.0.0-beta.31",
-				"web3-eth-contract": "1.0.0-beta.31",
-				"web3-eth-iban": "1.0.0-beta.31",
-				"web3-eth-personal": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-eth-abi": "1.0.0-beta.34",
+				"web3-eth-accounts": "1.0.0-beta.34",
+				"web3-eth-contract": "1.0.0-beta.34",
+				"web3-eth-iban": "1.0.0-beta.34",
+				"web3-eth-personal": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth-abi": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.31.tgz",
-			"integrity": "sha1-xQ457cINFrTDWQKegpuEE5THL8E=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+			"integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
 			"requires": {
 				"bn.js": "4.11.6",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			},
 			"dependencies": {
 				"bn.js": {
 					"version": "4.11.6",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				}
 			}
 		},
 		"web3-eth-accounts": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.31.tgz",
-			"integrity": "sha1-Mnm9BpbYK8ThUswddWx74i0xkq0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+			"integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
 			"requires": {
 				"any-promise": "1.3.0",
 				"crypto-browserify": "3.12.0",
@@ -10785,10 +11139,10 @@
 				"scrypt.js": "0.2.0",
 				"underscore": "1.8.3",
 				"uuid": "2.0.1",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			},
 			"dependencies": {
 				"eth-lib": {
@@ -10796,10 +11150,15 @@
 					"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
 					"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"elliptic": "6.4.0",
-						"xhr-request-promise": "0.1.2"
+						"bn.js": "^4.11.6",
+						"elliptic": "^6.4.0",
+						"xhr-request-promise": "^0.1.2"
 					}
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				},
 				"uuid": {
 					"version": "2.0.1",
@@ -10809,200 +11168,97 @@
 			}
 		},
 		"web3-eth-contract": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.31.tgz",
-			"integrity": "sha1-J5RkM/kdiVMBPi2X/Yt4qe1rbtw=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+			"integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-promievent": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-eth-abi": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-promievent": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-eth-abi": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-eth-iban": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.31.tgz",
-			"integrity": "sha1-7WS+0zO7BApvKU+06dGOrdvr/8o=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+			"integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"web3-utils": "1.0.0-beta.31"
+				"bn.js": "4.11.6",
+				"web3-utils": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
 			}
 		},
 		"web3-eth-personal": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.31.tgz",
-			"integrity": "sha1-Kw1ghZIOndzfu63yCnFfDMN3HYA=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+			"integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-helpers": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-net": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.31.tgz",
-			"integrity": "sha1-0mv8oOoXUvX9XXITTgDlE60efhk=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+			"integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-utils": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-utils": "1.0.0-beta.34"
 			}
 		},
 		"web3-provider-engine": {
-			"version": "8.6.1",
-			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
-			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
+			"version": "8.1.19",
+			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
+			"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
 			"requires": {
-				"async": "2.6.0",
-				"clone": "2.1.1",
-				"ethereumjs-block": "1.7.0",
-				"ethereumjs-tx": "1.3.3",
-				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.2",
-				"isomorphic-fetch": "2.2.1",
-				"request": "2.83.0",
-				"semaphore": "1.1.0",
-				"solc": "0.4.23",
-				"tape": "4.8.0",
-				"web3": "0.16.0",
-				"xhr": "2.4.0",
-				"xtend": "4.0.1"
+				"async": "^2.1.2",
+				"clone": "^2.0.0",
+				"ethereumjs-block": "^1.2.2",
+				"ethereumjs-tx": "^1.2.0",
+				"ethereumjs-util": "^5.0.1",
+				"ethereumjs-vm": "^2.0.2",
+				"isomorphic-fetch": "^2.2.0",
+				"request": "^2.67.0",
+				"semaphore": "^1.0.3",
+				"solc": "^0.4.2",
+				"tape": "^4.4.0",
+				"web3": "^0.16.0",
+				"xhr": "^2.2.0",
+				"xtend": "^4.0.1"
 			},
 			"dependencies": {
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
 				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
-					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
-					"requires": {
-						"babel-preset-es2015": "6.24.1",
-						"babelify": "7.3.0",
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "1.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"solc": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
-					"integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
-					"requires": {
-						"fs-extra": "0.30.0",
-						"memorystream": "0.3.1",
-						"require-from-string": "1.2.1",
-						"semver": "5.4.1",
-						"yargs": "4.8.1"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+					"from": "git+https://github.com/debris/bignumber.js.git#master"
 				},
 				"web3": {
 					"version": "0.16.0",
@@ -11010,113 +11266,71 @@
 					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
 					"requires": {
 						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xmlhttprequest": "1.8.0"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-						}
-					}
-				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"window-size": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-				},
-				"yargs": {
-					"version": "4.8.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xmlhttprequest": "*"
 					}
 				}
 			}
 		},
 		"web3-providers-http": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.31.tgz",
-			"integrity": "sha1-E0Ce9ErhYjzVxNzT20sI1vu6RTI=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+			"integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
 			"requires": {
-				"web3-core-helpers": "1.0.0-beta.31",
+				"web3-core-helpers": "1.0.0-beta.34",
 				"xhr2": "0.1.4"
 			}
 		},
 		"web3-providers-ipc": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.31.tgz",
-			"integrity": "sha1-zm2mcPqhlFjmIt/tm+QAWE/DNyQ=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+			"integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
 			"requires": {
 				"oboe": "2.1.3",
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31"
+				"web3-core-helpers": "1.0.0-beta.34"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				}
 			}
 		},
 		"web3-providers-ws": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.31.tgz",
-			"integrity": "sha1-zHG3Do2LUyAaUzdDcHww6MCZ4o0=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+			"integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
 			"requires": {
 				"underscore": "1.8.3",
-				"web3-core-helpers": "1.0.0-beta.31",
-				"websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
+				"web3-core-helpers": "1.0.0-beta.34",
+				"websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
 			},
 			"dependencies": {
-				"websocket": {
-					"version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
-					"requires": {
-						"debug": "2.6.9",
-						"nan": "2.7.0",
-						"typedarray-to-buffer": "3.1.5",
-						"yaeti": "0.0.6"
-					}
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 				}
 			}
 		},
 		"web3-shh": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.31.tgz",
-			"integrity": "sha1-AW0gS+K7obfzs5FQJyGdJ07+XlI=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+			"integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
 			"requires": {
-				"web3-core": "1.0.0-beta.31",
-				"web3-core-method": "1.0.0-beta.31",
-				"web3-core-subscriptions": "1.0.0-beta.31",
-				"web3-net": "1.0.0-beta.31"
+				"web3-core": "1.0.0-beta.34",
+				"web3-core-method": "1.0.0-beta.34",
+				"web3-core-subscriptions": "1.0.0-beta.34",
+				"web3-net": "1.0.0-beta.34"
 			}
 		},
 		"web3-utils": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.31.tgz",
-			"integrity": "sha1-DxgSXT6WmK6Cy/b6Ka3B4WFvKTY=",
+			"version": "1.0.0-beta.34",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+			"integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
 			"requires": {
 				"bn.js": "4.11.6",
 				"eth-lib": "0.1.27",
@@ -11132,6 +11346,11 @@
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
 				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+				},
 				"utf8": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
@@ -11139,41 +11358,94 @@
 				}
 			}
 		},
+		"webcrypto-shim": {
+			"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+			"from": "github:dignifiedquire/webcrypto-shim#master"
+		},
 		"webpack": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-			"integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+			"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
 			"requires": {
-				"acorn": "5.2.1",
-				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.3.0",
-				"ajv-keywords": "2.1.1",
-				"async": "2.6.0",
-				"enhanced-resolve": "3.4.1",
-				"escope": "3.6.0",
-				"interpret": "1.0.4",
-				"json-loader": "0.5.7",
-				"json5": "0.5.1",
-				"loader-runner": "2.3.0",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"mkdirp": "0.5.1",
-				"node-libs-browser": "2.0.0",
-				"source-map": "0.5.7",
-				"supports-color": "4.5.0",
-				"tapable": "0.2.8",
-				"uglifyjs-webpack-plugin": "0.4.6",
-				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.2",
-				"yargs": "8.0.2"
+				"acorn": "^5.0.0",
+				"acorn-dynamic-import": "^2.0.0",
+				"ajv": "^4.7.0",
+				"ajv-keywords": "^1.1.1",
+				"async": "^2.1.2",
+				"enhanced-resolve": "^3.3.0",
+				"interpret": "^1.0.0",
+				"json-loader": "^0.5.4",
+				"json5": "^0.5.1",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^0.2.16",
+				"memory-fs": "~0.4.1",
+				"mkdirp": "~0.5.0",
+				"node-libs-browser": "^2.0.0",
+				"source-map": "^0.5.3",
+				"supports-color": "^3.1.0",
+				"tapable": "~0.2.5",
+				"uglify-js": "^2.8.27",
+				"watchpack": "^1.3.1",
+				"webpack-sources": "^1.0.1",
+				"yargs": "^6.0.0"
 			},
 			"dependencies": {
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"requires": {
-						"has-flag": "2.0.0"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
+					}
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -11183,44 +11455,106 @@
 			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
 			"requires": {
-				"jscodeshift": "0.4.1"
+				"jscodeshift": "^0.4.0"
 			},
 			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+				},
 				"ast-types": {
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
 					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
 				},
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				"braces": {
+					"version": "1.8.5",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"requires": {
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
+					}
 				},
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				"expand-brackets": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"requires": {
+						"is-posix-bracket": "^0.1.0"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
 				},
 				"jscodeshift": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
 					"requires": {
-						"async": "1.5.2",
-						"babel-plugin-transform-flow-strip-types": "6.22.0",
-						"babel-preset-es2015": "6.24.1",
-						"babel-preset-stage-1": "6.24.1",
-						"babel-register": "6.26.0",
-						"babylon": "6.18.0",
-						"colors": "1.1.2",
-						"flow-parser": "0.70.0",
-						"lodash": "4.17.4",
-						"micromatch": "2.3.11",
+						"async": "^1.5.0",
+						"babel-plugin-transform-flow-strip-types": "^6.8.0",
+						"babel-preset-es2015": "^6.9.0",
+						"babel-preset-stage-1": "^6.5.0",
+						"babel-register": "^6.9.0",
+						"babylon": "^6.17.3",
+						"colors": "^1.1.2",
+						"flow-parser": "^0.*",
+						"lodash": "^4.13.1",
+						"micromatch": "^2.3.7",
 						"node-dir": "0.1.8",
-						"nomnom": "1.8.1",
-						"recast": "0.12.9",
-						"temp": "0.8.3",
-						"write-file-atomic": "1.3.4"
+						"nomnom": "^1.8.1",
+						"recast": "^0.12.5",
+						"temp": "^0.8.1",
+						"write-file-atomic": "^1.2.0"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"requires": {
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				},
 				"recast": {
@@ -11229,10 +11563,10 @@
 					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
 					"requires": {
 						"ast-types": "0.10.1",
-						"core-js": "2.5.1",
-						"esprima": "4.0.0",
-						"private": "0.1.8",
-						"source-map": "0.6.1"
+						"core-js": "^2.4.1",
+						"esprima": "~4.0.0",
+						"private": "~0.1.5",
+						"source-map": "~0.6.1"
 					}
 				},
 				"source-map": {
@@ -11243,36 +11577,36 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.15.tgz",
-			"integrity": "sha512-bjNeIUO51D4OsmZ5ufzcpzVoacjxfWNfeBZKYL3jc+EMfCME3TyfdCPSUoKiOnebQChfupQuIRpAnx7L4l3Hew==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.3.tgz",
+			"integrity": "sha512-5AsKoL/Ccn8iTrwk3uErdyhetGH+c7VRQ7Itim2GL0IhBRq5rtojVDk00buMRmFmBpw1RvHXq97Gup965LbozA==",
 			"requires": {
-				"chalk": "2.4.0",
-				"cross-spawn": "6.0.5",
-				"diff": "3.5.0",
-				"enhanced-resolve": "4.0.0",
-				"envinfo": "4.4.2",
-				"glob-all": "3.1.0",
-				"global-modules": "1.0.0",
-				"got": "8.3.0",
-				"import-local": "1.0.0",
-				"inquirer": "5.2.0",
-				"interpret": "1.0.4",
-				"jscodeshift": "0.5.0",
-				"listr": "0.13.0",
-				"loader-utils": "1.1.0",
-				"lodash": "4.17.10",
-				"log-symbols": "2.2.0",
-				"mkdirp": "0.5.1",
-				"p-each-series": "1.0.0",
-				"p-lazy": "1.0.0",
-				"prettier": "1.12.1",
-				"supports-color": "5.4.0",
-				"v8-compile-cache": "1.1.2",
-				"webpack-addons": "1.1.5",
-				"yargs": "11.1.0",
-				"yeoman-environment": "2.0.6",
-				"yeoman-generator": "2.0.4"
+				"chalk": "^2.3.2",
+				"cross-spawn": "^6.0.5",
+				"diff": "^3.5.0",
+				"enhanced-resolve": "^4.0.0",
+				"envinfo": "^4.4.2",
+				"glob-all": "^3.1.0",
+				"global-modules": "^1.0.0",
+				"got": "^8.2.0",
+				"import-local": "^1.0.0",
+				"inquirer": "^5.1.0",
+				"interpret": "^1.0.4",
+				"jscodeshift": "^0.5.0",
+				"listr": "^0.13.0",
+				"loader-utils": "^1.1.0",
+				"lodash": "^4.17.5",
+				"log-symbols": "^2.2.0",
+				"mkdirp": "^0.5.1",
+				"p-each-series": "^1.0.0",
+				"p-lazy": "^1.0.0",
+				"prettier": "^1.5.3",
+				"supports-color": "^5.3.0",
+				"v8-compile-cache": "^1.1.2",
+				"webpack-addons": "^1.1.5",
+				"yargs": "^11.1.0",
+				"yeoman-environment": "^2.0.0",
+				"yeoman-generator": "^2.0.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11280,37 +11614,19 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "1.9.1"
-					}
-				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
-					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
-					}
 				},
 				"cliui": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -11318,11 +11634,11 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"nice-try": "1.0.4",
-						"path-key": "2.0.1",
-						"semver": "5.5.0",
-						"shebang-command": "1.2.0",
-						"which": "1.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"diff": {
@@ -11335,44 +11651,59 @@
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
 					"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"memory-fs": "0.4.1",
-						"tapable": "1.0.0"
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.4.0",
+						"tapable": "^1.0.0"
 					}
 				},
 				"got": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-					"integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+					"integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
 					"requires": {
-						"@sindresorhus/is": "0.7.0",
-						"cacheable-request": "2.1.4",
-						"decompress-response": "3.3.0",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"into-stream": "3.1.0",
-						"is-retry-allowed": "1.1.0",
-						"isurl": "1.0.0",
-						"lowercase-keys": "1.0.0",
-						"mimic-response": "1.0.0",
-						"p-cancelable": "0.4.1",
-						"p-timeout": "2.0.1",
-						"pify": "3.0.0",
-						"safe-buffer": "5.1.1",
-						"timed-out": "4.0.1",
-						"url-parse-lax": "3.0.0",
-						"url-to-options": "1.0.1"
+						"@sindresorhus/is": "^0.7.0",
+						"cacheable-request": "^2.1.1",
+						"decompress-response": "^3.3.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"into-stream": "^3.1.0",
+						"is-retry-allowed": "^1.1.0",
+						"isurl": "^1.0.0-alpha5",
+						"lowercase-keys": "^1.0.0",
+						"mimic-response": "^1.0.0",
+						"p-cancelable": "^0.4.0",
+						"p-timeout": "^2.0.1",
+						"pify": "^3.0.0",
+						"safe-buffer": "^5.1.1",
+						"timed-out": "^4.0.1",
+						"url-parse-lax": "^3.0.0",
+						"url-to-options": "^1.0.1"
 					}
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
 				},
 				"p-cancelable": {
 					"version": "0.4.1",
@@ -11384,7 +11715,7 @@
 					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
 					"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
 					"requires": {
-						"p-finally": "1.0.0"
+						"p-finally": "^1.0.0"
 					}
 				},
 				"pify": {
@@ -11397,25 +11728,21 @@
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
 					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 				},
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"tapable": {
@@ -11428,26 +11755,31 @@
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 					"requires": {
-						"prepend-http": "2.0.0"
+						"prepend-http": "^2.0.0"
 					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
@@ -11455,18 +11787,18 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
 		"webpack-sources": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
-			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"requires": {
-				"source-list-map": "2.0.0",
-				"source-map": "0.6.1"
+				"source-list-map": "^2.0.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -11476,48 +11808,38 @@
 				}
 			}
 		},
+		"websocket": {
+			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+			"requires": {
+				"debug": "^2.2.0",
+				"nan": "^2.3.3",
+				"typedarray-to-buffer": "^3.1.2",
+				"yaeti": "^0.0.6"
+			}
+		},
 		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"wide-align": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"requires": {
-				"string-width": "1.0.2"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				}
-			}
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
 		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -11529,20 +11851,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				}
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"wrappy": {
@@ -11555,9 +11865,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"slide": "^1.1.5"
 			}
 		},
 		"ws": {
@@ -11565,20 +11875,20 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
 			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"ultron": "1.1.1"
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0",
+				"ultron": "~1.1.0"
 			}
 		},
 		"xhr": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-			"integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
 			"requires": {
-				"global": "4.3.2",
-				"is-function": "1.0.1",
-				"parse-headers": "2.0.1",
-				"xtend": "4.0.1"
+				"global": "~4.3.0",
+				"is-function": "^1.0.1",
+				"parse-headers": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"xhr-request": {
@@ -11586,25 +11896,13 @@
 			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
 			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
 			"requires": {
-				"buffer-to-arraybuffer": "0.0.5",
-				"object-assign": "4.1.1",
-				"query-string": "5.1.1",
-				"simple-get": "2.7.0",
-				"timed-out": "4.0.1",
-				"url-set-query": "1.0.0",
-				"xhr": "2.4.0"
-			},
-			"dependencies": {
-				"simple-get": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-					"integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
-					"requires": {
-						"decompress-response": "3.3.0",
-						"once": "1.4.0",
-						"simple-concat": "1.0.0"
-					}
-				}
+				"buffer-to-arraybuffer": "^0.0.5",
+				"object-assign": "^4.1.1",
+				"query-string": "^5.0.1",
+				"simple-get": "^2.7.0",
+				"timed-out": "^4.0.1",
+				"url-set-query": "^1.0.0",
+				"xhr": "^2.0.4"
 			}
 		},
 		"xhr-request-promise": {
@@ -11612,7 +11910,7 @@
 			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
 			"integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
 			"requires": {
-				"xhr-request": "1.1.0"
+				"xhr-request": "^1.0.1"
 			}
 		},
 		"xhr2": {
@@ -11646,96 +11944,22 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"requires": {
-				"camelcase": "4.1.0",
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"read-pkg-up": "2.0.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "7.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
-							}
-						}
-					}
-				}
-			}
-		},
-		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-			"requires": {
-				"camelcase": "4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				}
-			}
-		},
-		"yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
-			"requires": {
-				"buffer-crc32": "0.2.13",
-				"fd-slicer": "1.0.1"
-			}
-		},
-		"yeoman-environment": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-			"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
-			"requires": {
-				"chalk": "2.4.0",
-				"debug": "3.1.0",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"globby": "6.1.0",
-				"grouped-queue": "0.3.3",
-				"inquirer": "3.3.0",
-				"is-scoped": "1.0.0",
-				"lodash": "4.17.4",
-				"log-symbols": "2.2.0",
-				"mem-fs": "1.1.3",
-				"text-table": "0.2.0",
-				"untildify": "3.0.2"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^8.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11743,22 +11967,123 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+			"requires": {
+				"camelcase": "^3.0.0",
+				"lodash.assign": "^4.0.6"
+			}
+		},
+		"yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+			"requires": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.0.1"
+			}
+		},
+		"yeoman-environment": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+			"integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
+			"requires": {
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^3.1.0",
+				"diff": "^3.3.1",
+				"escape-string-regexp": "^1.0.2",
+				"globby": "^8.0.1",
+				"grouped-queue": "^0.3.3",
+				"inquirer": "^5.2.0",
+				"is-scoped": "^1.0.0",
+				"lodash": "^4.17.10",
+				"log-symbols": "^2.1.0",
+				"mem-fs": "^1.1.0",
+				"strip-ansi": "^4.0.0",
+				"text-table": "^0.2.0",
+				"untildify": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -11774,98 +12099,71 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.0",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "2.2.0",
-						"figures": "2.0.0",
-						"lodash": "4.17.4",
-						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rx-lite": "4.0.8",
-						"rx-lite-aggregates": "4.0.8",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
-					}
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
 		},
 		"yeoman-generator": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
-			"integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
 			"requires": {
-				"async": "2.6.0",
-				"chalk": "2.4.0",
-				"cli-table": "0.3.1",
-				"cross-spawn": "5.1.0",
-				"dargs": "5.1.0",
-				"dateformat": "3.0.3",
-				"debug": "3.1.0",
-				"detect-conflict": "1.0.1",
-				"error": "7.0.2",
-				"find-up": "2.1.0",
-				"github-username": "4.1.0",
-				"istextorbinary": "2.2.1",
-				"lodash": "4.17.4",
-				"make-dir": "1.2.0",
-				"mem-fs-editor": "3.0.2",
-				"minimist": "1.2.0",
-				"pretty-bytes": "4.0.2",
-				"read-chunk": "2.1.0",
-				"read-pkg-up": "3.0.0",
-				"rimraf": "2.6.2",
-				"run-async": "2.3.0",
-				"shelljs": "0.8.1",
-				"text-table": "0.2.0",
-				"through2": "2.0.3",
-				"yeoman-environment": "2.0.6"
+				"async": "^2.6.0",
+				"chalk": "^2.3.0",
+				"cli-table": "^0.3.1",
+				"cross-spawn": "^6.0.5",
+				"dargs": "^5.1.0",
+				"dateformat": "^3.0.3",
+				"debug": "^3.1.0",
+				"detect-conflict": "^1.0.0",
+				"error": "^7.0.2",
+				"find-up": "^2.1.0",
+				"github-username": "^4.0.0",
+				"istextorbinary": "^2.2.1",
+				"lodash": "^4.17.10",
+				"make-dir": "^1.1.0",
+				"mem-fs-editor": "^4.0.0",
+				"minimist": "^1.2.0",
+				"pretty-bytes": "^4.0.2",
+				"read-chunk": "^2.1.0",
+				"read-pkg-up": "^3.0.0",
+				"rimraf": "^2.6.2",
+				"run-async": "^2.0.0",
+				"shelljs": "^0.8.0",
+				"text-table": "^0.2.0",
+				"through2": "^2.0.0",
+				"yeoman-environment": "^2.0.5"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"lodash": "^4.17.10"
 					}
 				},
-				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
@@ -11876,33 +12174,15 @@
 						"ms": "2.0.0"
 					}
 				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"minimist": {
@@ -11910,13 +12190,18 @@
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -11924,7 +12209,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -11937,9 +12222,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -11947,27 +12232,24 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"shelljs": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-					"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+					"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
 					"requires": {
-						"glob": "7.1.2",
-						"interpret": "1.0.4",
-						"rechoir": "0.6.2"
+						"glob": "^7.0.0",
+						"interpret": "^1.0.0",
+						"rechoir": "^0.6.2"
 					}
 				},
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"requires": {
-						"has-flag": "3.0.0"
-					}
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				}
 			}
 		}

--- a/apps/voting/package-lock.json
+++ b/apps/voting/package-lock.json
@@ -7,23 +7,23 @@
 			"resolved": "https://registry.npmjs.org/@aragon/cli/-/cli-2.0.6.tgz",
 			"integrity": "sha512-MvmLlN2o2+ixax/xPpp4ZRY5XAOyhIDXaqax/lqRQq3nIQBxWV4KxAWQS2sM0B6ZncFRDvKsWAU+4mqmk606Dg==",
 			"requires": {
-				"chalk": "2.3.2",
-				"eth-ens-namehash": "2.0.8",
+				"chalk": "^2.1.0",
+				"eth-ens-namehash": "^2.0.0",
 				"ethereum-ens": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
-				"find-up": "2.1.0",
-				"fs-extra": "4.0.3",
-				"ganache-core": "2.0.2",
-				"git-clone": "0.1.0",
-				"homedir": "0.6.0",
-				"ipfs-api": "14.3.7",
-				"js-sha3": "0.7.0",
-				"multimatch": "2.1.0",
-				"rimraf": "2.6.2",
-				"semver": "5.4.1",
-				"stream-to-string": "1.1.0",
-				"tmp-promise": "1.0.4",
+				"find-up": "^2.1.0",
+				"fs-extra": "^4.0.2",
+				"ganache-core": "~2.0.2",
+				"git-clone": "^0.1.0",
+				"homedir": "^0.6.0",
+				"ipfs-api": "^14.3.7",
+				"js-sha3": "^0.7.0",
+				"multimatch": "^2.1.0",
+				"rimraf": "^2.6.2",
+				"semver": "^5.4.1",
+				"stream-to-string": "^1.1.0",
+				"tmp-promise": "^1.0.4",
 				"web3": "1.0.0-beta.26",
-				"yargs": "10.1.2"
+				"yargs": "^10.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -36,7 +36,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"bignumber.js": {
@@ -54,9 +54,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
@@ -64,21 +64,22 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
 					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"ethereum-ens": {
 					"version": "git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
+					"from": "ethereum-ens@git+https://github.com/Arachnid/ensjs.git#03c7f5946b2a1064bfef80b7f844bfb966e762da",
 					"requires": {
-						"bluebird": "3.5.1",
-						"eth-ens-namehash": "2.0.8",
-						"js-sha3": "0.5.7",
-						"pako": "1.0.6",
-						"text-encoding": "0.6.4",
-						"underscore": "1.8.3",
-						"web3": "0.19.1"
+						"bluebird": "^3.4.7",
+						"eth-ens-namehash": "^2.0.0",
+						"js-sha3": "^0.5.7",
+						"pako": "^1.0.4",
+						"text-encoding": "^0.6.4",
+						"underscore": "^1.8.3",
+						"web3": "^0.19.1"
 					},
 					"dependencies": {
 						"js-sha3": {
@@ -96,11 +97,11 @@
 							"resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
 							"integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
 							"requires": {
-								"bignumber.js": "4.1.0",
-								"crypto-js": "3.1.8",
-								"utf8": "2.1.2",
-								"xhr2": "0.1.4",
-								"xmlhttprequest": "1.8.0"
+								"bignumber.js": "^4.0.2",
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xhr2": "*",
+								"xmlhttprequest": "*"
 							}
 						}
 					}
@@ -110,9 +111,9 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"has-flag": {
@@ -130,7 +131,7 @@
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"pako": {
@@ -143,7 +144,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -151,7 +152,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"web3": {
@@ -159,13 +160,13 @@
 					"resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
 					"integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
 					"requires": {
-						"web3-bzz": "1.0.0-beta.30",
-						"web3-core": "1.0.0-beta.30",
-						"web3-eth": "1.0.0-beta.30",
-						"web3-eth-personal": "1.0.0-beta.30",
-						"web3-net": "1.0.0-beta.30",
-						"web3-shh": "1.0.0-beta.30",
-						"web3-utils": "1.0.0-beta.30"
+						"web3-bzz": "^1.0.0-beta.26",
+						"web3-core": "^1.0.0-beta.26",
+						"web3-eth": "^1.0.0-beta.26",
+						"web3-eth-personal": "^1.0.0-beta.26",
+						"web3-net": "^1.0.0-beta.26",
+						"web3-shh": "^1.0.0-beta.26",
+						"web3-utils": "^1.0.0-beta.26"
 					}
 				},
 				"yargs": {
@@ -173,18 +174,18 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -192,7 +193,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
 					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -202,7 +203,7 @@
 			"resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.4.tgz",
 			"integrity": "sha512-Uvzsrw1+Qc1i7WeyRSBRD9C0gGTnlS4O8nwTieG9pqbuThfevpoCHeR7MqPzhWDo5PLQ4wl6WForRyI/vyvXHw==",
 			"requires": {
-				"homedir": "0.6.0",
+				"homedir": "^0.6.0",
 				"truffle-privatekey-provider": "0.0.5"
 			}
 		},
@@ -211,24 +212,51 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
 		},
+		"@types/concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/form-data": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "9.6.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
+			"integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig=="
+		},
+		"@types/qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q=="
+		},
 		"abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
 		},
 		"abi-decoder": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.0.9.tgz",
-			"integrity": "sha1-a8/Yb39j++yFc9l3izpPkruS4B8=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-1.1.0.tgz",
+			"integrity": "sha512-nvLArBx0XOJufWyaghMKtIofZDBwEMdVZoqcetQOIe1qYeKZk4+kRYGPEJ5lt7dD3MLulw//amUzOJLM8eW5RA==",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-loader": "6.4.1",
-				"babel-plugin-add-module-exports": "0.2.1",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-preset-es2015": "6.24.1",
-				"chai": "3.5.0",
-				"web3": "0.18.4",
-				"webpack": "2.7.0"
+				"babel-core": "^6.23.1",
+				"babel-loader": "^6.3.2",
+				"babel-plugin-add-module-exports": "^0.2.1",
+				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+				"babel-plugin-transform-runtime": "^6.23.0",
+				"babel-preset-es2015": "^6.22.0",
+				"chai": "^3.5.0",
+				"web3": "^0.18.4",
+				"webpack": "^2.7.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -236,8 +264,8 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
 					}
 				},
 				"ajv-keywords": {
@@ -255,9 +283,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -265,8 +293,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -279,11 +307,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"loader-utils": {
@@ -291,10 +319,10 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
 					}
 				},
 				"os-locale": {
@@ -302,7 +330,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
@@ -310,7 +338,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -318,9 +346,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -328,9 +356,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -338,8 +366,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -347,9 +375,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -357,7 +385,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"supports-color": {
@@ -365,7 +393,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				},
 				"webpack": {
@@ -373,27 +401,27 @@
 					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
 					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
 					"requires": {
-						"acorn": "5.2.1",
-						"acorn-dynamic-import": "2.0.2",
-						"ajv": "4.11.8",
-						"ajv-keywords": "1.5.1",
-						"async": "2.6.0",
-						"enhanced-resolve": "3.4.1",
-						"interpret": "1.0.4",
-						"json-loader": "0.5.7",
-						"json5": "0.5.1",
-						"loader-runner": "2.3.0",
-						"loader-utils": "0.2.17",
-						"memory-fs": "0.4.1",
-						"mkdirp": "0.5.1",
-						"node-libs-browser": "2.0.0",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3",
-						"tapable": "0.2.8",
-						"uglify-js": "2.8.29",
-						"watchpack": "1.4.0",
-						"webpack-sources": "1.0.2",
-						"yargs": "6.6.0"
+						"acorn": "^5.0.0",
+						"acorn-dynamic-import": "^2.0.0",
+						"ajv": "^4.7.0",
+						"ajv-keywords": "^1.1.1",
+						"async": "^2.1.2",
+						"enhanced-resolve": "^3.3.0",
+						"interpret": "^1.0.0",
+						"json-loader": "^0.5.4",
+						"json5": "^0.5.1",
+						"loader-runner": "^2.3.0",
+						"loader-utils": "^0.2.16",
+						"memory-fs": "~0.4.1",
+						"mkdirp": "~0.5.0",
+						"node-libs-browser": "^2.0.0",
+						"source-map": "^0.5.3",
+						"supports-color": "^3.1.0",
+						"tapable": "~0.2.5",
+						"uglify-js": "^2.8.27",
+						"watchpack": "^1.3.1",
+						"webpack-sources": "^1.0.1",
+						"yargs": "^6.0.0"
 					}
 				},
 				"which-module": {
@@ -406,19 +434,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
 					}
 				},
 				"yargs-parser": {
@@ -426,7 +454,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -436,7 +464,7 @@
 			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
 			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
 			"requires": {
-				"xtend": "4.0.1"
+				"xtend": "~4.0.0"
 			}
 		},
 		"accepts": {
@@ -444,7 +472,7 @@
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"requires": {
-				"mime-types": "2.1.18",
+				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
 			},
 			"dependencies": {
@@ -458,7 +486,7 @@
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": "~1.33.0"
 					}
 				}
 			}
@@ -473,7 +501,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.3"
 			},
 			"dependencies": {
 				"acorn": {
@@ -493,10 +521,10 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
 			"integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -509,9 +537,9 @@
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"amdefine": {
@@ -549,8 +577,8 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
 			}
 		},
 		"aproba": {
@@ -563,8 +591,8 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.3"
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -572,7 +600,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"argsarray": {
@@ -585,7 +613,7 @@
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -608,7 +636,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -626,6 +654,11 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -636,9 +669,9 @@
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
 			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -669,7 +702,7 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.14.0"
 			}
 		},
 		"async-each": {
@@ -682,7 +715,7 @@
 			"resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
 			"integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
 			"requires": {
-				"async": "2.6.0"
+				"async": "^2.4.0"
 			}
 		},
 		"async-limiter": {
@@ -715,21 +748,21 @@
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-polyfill": "6.26.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"chokidar": "1.7.0",
-				"commander": "2.11.0",
-				"convert-source-map": "1.5.0",
-				"fs-readdir-recursive": "1.1.0",
-				"glob": "7.1.2",
-				"lodash": "4.17.4",
-				"output-file-sync": "1.1.2",
-				"path-is-absolute": "1.0.1",
-				"slash": "1.0.0",
-				"source-map": "0.5.7",
-				"v8flags": "2.1.1"
+				"babel-core": "^6.26.0",
+				"babel-polyfill": "^6.26.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"chokidar": "^1.6.1",
+				"commander": "^2.11.0",
+				"convert-source-map": "^1.5.0",
+				"fs-readdir-recursive": "^1.0.0",
+				"glob": "^7.1.2",
+				"lodash": "^4.17.4",
+				"output-file-sync": "^1.1.2",
+				"path-is-absolute": "^1.0.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.6",
+				"v8flags": "^2.1.1"
 			},
 			"dependencies": {
 				"commander": {
@@ -742,12 +775,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -757,9 +790,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			}
 		},
 		"babel-core": {
@@ -767,25 +800,25 @@
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.0",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.0",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.4",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"debug": "^2.6.8",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.7",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.6"
 			}
 		},
 		"babel-generator": {
@@ -793,14 +826,14 @@
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
 			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.4",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.6",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -815,9 +848,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -825,9 +858,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -835,10 +868,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -846,10 +879,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -857,9 +890,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -867,10 +900,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"requires": {
-				"babel-helper-bindify-decorators": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-bindify-decorators": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -878,11 +911,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -890,8 +923,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -899,8 +932,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -908,8 +941,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -917,9 +950,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -927,11 +960,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -939,12 +972,12 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -952,8 +985,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-loader": {
@@ -961,10 +994,10 @@
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
 			"integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
 			"requires": {
-				"find-cache-dir": "0.1.1",
-				"loader-utils": "0.2.17",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
+				"find-cache-dir": "^0.1.1",
+				"loader-utils": "^0.2.16",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -972,10 +1005,10 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
 					}
 				}
 			}
@@ -985,7 +1018,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-add-module-exports": {
@@ -998,7 +1031,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1061,9 +1094,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-generators": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-generators": "^6.5.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1071,9 +1104,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1081,9 +1114,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "6.18.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1091,10 +1124,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1102,11 +1135,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"requires": {
-				"babel-helper-explode-class": "6.24.1",
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-class": "^6.24.1",
+				"babel-plugin-syntax-decorators": "^6.13.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1114,7 +1147,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1122,7 +1155,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1130,11 +1163,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1142,15 +1175,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1158,8 +1191,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1167,7 +1200,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1175,8 +1208,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1184,7 +1217,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1192,9 +1225,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1202,7 +1235,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1210,9 +1243,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1220,10 +1253,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1231,9 +1264,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1241,9 +1274,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1251,8 +1284,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1260,12 +1293,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1273,8 +1306,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1282,7 +1315,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1290,9 +1323,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1300,7 +1333,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1308,7 +1341,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1316,9 +1349,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1326,9 +1359,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1336,8 +1369,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-export-extensions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1345,8 +1378,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1354,8 +1387,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1363,7 +1396,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "0.10.1"
+				"regenerator-transform": "^0.10.0"
+			}
+		},
+		"babel-plugin-transform-runtime": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+			"requires": {
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1371,8 +1412,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-polyfill": {
@@ -1380,9 +1421,9 @@
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.10.5"
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"regenerator-runtime": "^0.10.5"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
@@ -1397,30 +1438,30 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+				"babel-plugin-transform-es2015-for-of": "^6.22.0",
+				"babel-plugin-transform-es2015-function-name": "^6.24.1",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+				"babel-plugin-transform-es2015-object-super": "^6.24.1",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+				"babel-plugin-transform-regenerator": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1428,9 +1469,9 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "6.24.1",
-				"babel-plugin-transform-export-extensions": "6.22.0",
-				"babel-preset-stage-2": "6.24.1"
+				"babel-plugin-transform-class-constructor-call": "^6.24.1",
+				"babel-plugin-transform-export-extensions": "^6.22.0",
+				"babel-preset-stage-2": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1438,10 +1479,10 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-decorators": "6.24.1",
-				"babel-preset-stage-3": "6.24.1"
+				"babel-plugin-syntax-dynamic-import": "^6.18.0",
+				"babel-plugin-transform-class-properties": "^6.24.1",
+				"babel-plugin-transform-decorators": "^6.24.1",
+				"babel-preset-stage-3": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1449,11 +1490,11 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-generator-functions": "6.24.1",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-object-rest-spread": "6.26.0"
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-generator-functions": "^6.24.1",
+				"babel-plugin-transform-async-to-generator": "^6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
+				"babel-plugin-transform-object-rest-spread": "^6.22.0"
 			}
 		},
 		"babel-register": {
@@ -1461,13 +1502,13 @@
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			}
 		},
 		"babel-runtime": {
@@ -1475,8 +1516,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.11.0"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -1484,11 +1525,11 @@
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1496,15 +1537,15 @@
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-types": {
@@ -1512,10 +1553,10 @@
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babelify": {
@@ -1523,8 +1564,8 @@
 			"resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
 			"integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"object-assign": "4.1.1"
+				"babel-core": "^6.0.14",
+				"object-assign": "^4.0.0"
 			}
 		},
 		"babylon": {
@@ -1553,7 +1594,7 @@
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big.js": {
@@ -1562,7 +1603,8 @@
 			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"bignumber.js": {
-			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+			"version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+			"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
 		},
 		"binary-extensions": {
 			"version": "1.10.0",
@@ -1584,11 +1626,11 @@
 			"resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
 			"integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
 			"requires": {
-				"create-hash": "1.1.3",
-				"pbkdf2": "3.0.14",
-				"randombytes": "2.0.5",
-				"safe-buffer": "5.1.1",
-				"unorm": "1.4.1"
+				"create-hash": "^1.1.0",
+				"pbkdf2": "^3.0.9",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"unorm": "^1.3.3"
 			}
 		},
 		"bip66": {
@@ -1596,7 +1638,7 @@
 			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
 			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"bl": {
@@ -1604,7 +1646,7 @@
 			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
 			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.5"
 			}
 		},
 		"blakejs": {
@@ -1617,7 +1659,7 @@
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"bluebird": {
@@ -1636,15 +1678,15 @@
 			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
 			"requires": {
 				"bytes": "3.0.0",
-				"content-type": "1.0.4",
+				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"http-errors": "1.6.2",
+				"depd": "~1.1.1",
+				"http-errors": "~1.6.2",
 				"iconv-lite": "0.4.19",
-				"on-finished": "2.3.0",
+				"on-finished": "~2.3.0",
 				"qs": "6.5.1",
 				"raw-body": "2.3.2",
-				"type-is": "1.6.16"
+				"type-is": "~1.6.15"
 			}
 		},
 		"boom": {
@@ -1652,7 +1694,7 @@
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"brace-expansion": {
@@ -1660,7 +1702,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1669,9 +1711,9 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"brorand": {
@@ -1689,12 +1731,12 @@
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
 			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"browserify-cipher": {
@@ -1702,9 +1744,9 @@
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
 			"requires": {
-				"browserify-aes": "1.1.1",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.3"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
@@ -1712,9 +1754,9 @@
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-rsa": {
@@ -1722,8 +1764,8 @@
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sha3": {
@@ -1731,7 +1773,7 @@
 			"resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
 			"integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
 			"requires": {
-				"js-sha3": "0.3.1"
+				"js-sha3": "^0.3.1"
 			}
 		},
 		"browserify-sign": {
@@ -1739,13 +1781,13 @@
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
@@ -1753,7 +1795,7 @@
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
 			"requires": {
-				"pako": "0.2.9"
+				"pako": "~0.2.0"
 			}
 		},
 		"bs58": {
@@ -1761,7 +1803,7 @@
 			"resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
 			"integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
 			"requires": {
-				"base-x": "1.1.0"
+				"base-x": "^1.1.0"
 			}
 		},
 		"bs58check": {
@@ -1769,8 +1811,8 @@
 			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
 			"integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
 			"requires": {
-				"bs58": "3.1.0",
-				"create-hash": "1.1.3"
+				"bs58": "^3.1.0",
+				"create-hash": "^1.1.0"
 			}
 		},
 		"buffer": {
@@ -1778,9 +1820,9 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8",
-				"isarray": "1.0.0"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
 			}
 		},
 		"buffer-crc32": {
@@ -1793,7 +1835,7 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
 			"integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
 			"requires": {
-				"is-array-buffer-x": "1.7.0"
+				"is-array-buffer-x": "^1.0.13"
 			}
 		},
 		"buffer-loader": {
@@ -1831,8 +1873,8 @@
 			"resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
 			"integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
 			"requires": {
-				"bytewise-core": "1.2.3",
-				"typewise": "1.0.3"
+				"bytewise-core": "^1.2.2",
+				"typewise": "^1.0.3"
 			}
 		},
 		"bytewise-core": {
@@ -1840,7 +1882,7 @@
 			"resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
 			"integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
 			"requires": {
-				"typewise-core": "1.2.0"
+				"typewise-core": "^1.2"
 			}
 		},
 		"cacheable-request": {
@@ -1867,8 +1909,8 @@
 			"resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
 			"integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
 			"requires": {
-				"abstract-leveldown": "2.6.3",
-				"lru-cache": "3.2.0"
+				"abstract-leveldown": "^2.4.1",
+				"lru-cache": "^3.2.0"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -1876,7 +1918,7 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
 					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
 					"requires": {
-						"pseudomap": "1.0.2"
+						"pseudomap": "^1.0.1"
 					}
 				}
 			}
@@ -1896,8 +1938,8 @@
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chai": {
@@ -1905,9 +1947,9 @@
 			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
 			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
 			"requires": {
-				"assertion-error": "1.1.0",
-				"deep-eql": "0.1.3",
-				"type-detect": "1.0.0"
+				"assertion-error": "^1.0.1",
+				"deep-eql": "^0.1.3",
+				"type-detect": "^1.0.0"
 			}
 		},
 		"chalk": {
@@ -1915,11 +1957,11 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"chardet": {
@@ -1932,7 +1974,7 @@
 			"resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
 			"integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
 			"requires": {
-				"functional-red-black-tree": "1.0.1"
+				"functional-red-black-tree": "^1.0.1"
 			}
 		},
 		"chokidar": {
@@ -1940,15 +1982,15 @@
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.1.3",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^1.3.0",
+				"async-each": "^1.0.0",
+				"fsevents": "^1.0.0",
+				"glob-parent": "^2.0.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^2.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0"
 			}
 		},
 		"chownr": {
@@ -1961,9 +2003,9 @@
 			"resolved": "https://registry.npmjs.org/cids/-/cids-0.5.2.tgz",
 			"integrity": "sha512-ymyC9kV8iKgvn+MU44glekHKMDbfx7hUh1YRNDJ4ZzBQspFamRvmDlbH5jjHp9LwwH1vvJuV/rcy1gWJeSVcIw==",
 			"requires": {
-				"multibase": "0.3.4",
-				"multicodec": "0.2.6",
-				"multihashes": "0.4.13"
+				"multibase": "~0.3.4",
+				"multicodec": "~0.2.3",
+				"multihashes": "~0.4.9"
 			}
 		},
 		"cipher-base": {
@@ -1971,8 +2013,8 @@
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"cli-cursor": {
@@ -1980,7 +2022,7 @@
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -2008,9 +2050,9 @@
 			"resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
 			"integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
 			"requires": {
-				"colors": "1.1.2",
-				"lodash": "3.10.1",
-				"string-width": "1.0.2"
+				"colors": "^1.1.2",
+				"lodash": "^3.10.1",
+				"string-width": "^1.0.1"
 			},
 			"dependencies": {
 				"lodash": {
@@ -2023,9 +2065,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -2036,7 +2078,7 @@
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "1.0.2"
+				"string-width": "^1.0.1"
 			},
 			"dependencies": {
 				"string-width": {
@@ -2044,9 +2086,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -2061,8 +2103,8 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
 				"wordwrap": "0.0.2"
 			}
 		},
@@ -2081,7 +2123,7 @@
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"requires": {
-				"mimic-response": "1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"clone-stats": {
@@ -2094,9 +2136,9 @@
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"requires": {
-				"inherits": "2.0.3",
-				"process-nextick-args": "2.0.0",
-				"readable-stream": "2.3.6"
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
 			},
 			"dependencies": {
 				"process-nextick-args": {
@@ -2109,13 +2151,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"string_decoder": {
@@ -2123,7 +2165,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -2143,8 +2185,8 @@
 			"resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
 			"integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
 			"requires": {
-				"bs58": "2.0.1",
-				"create-hash": "1.1.3"
+				"bs58": "^2.0.1",
+				"create-hash": "^1.1.1"
 			},
 			"dependencies": {
 				"bs58": {
@@ -2159,7 +2201,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -2177,7 +2219,7 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -2200,9 +2242,9 @@
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"console-browserify": {
@@ -2210,7 +2252,7 @@
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -2263,8 +2305,8 @@
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
 			"integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
 			"requires": {
-				"object-assign": "4.1.1",
-				"vary": "1.1.2"
+				"object-assign": "^4",
+				"vary": "^1"
 			}
 		},
 		"create-ecdh": {
@@ -2272,8 +2314,8 @@
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
@@ -2281,10 +2323,10 @@
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.9"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
@@ -2292,12 +2334,12 @@
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-spawn": {
@@ -2305,9 +2347,9 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cryptiles": {
@@ -2315,7 +2357,7 @@
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -2323,7 +2365,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -2333,17 +2375,17 @@
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
-				"browserify-cipher": "1.0.0",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.0",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"diffie-hellman": "5.0.2",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.14",
-				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5",
-				"randomfill": "1.0.3"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"crypto-js": {
@@ -2356,7 +2398,7 @@
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"requires": {
-				"es5-ext": "0.10.35"
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"d64": {
@@ -2374,7 +2416,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-fns": {
@@ -2420,14 +2462,14 @@
 			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
 			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
 			"requires": {
-				"decompress-tar": "4.1.1",
-				"decompress-tarbz2": "4.1.1",
-				"decompress-targz": "4.1.1",
-				"decompress-unzip": "4.0.1",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.2.0",
-				"pify": "2.3.0",
-				"strip-dirs": "2.1.0"
+				"decompress-tar": "^4.0.0",
+				"decompress-tarbz2": "^4.0.0",
+				"decompress-targz": "^4.0.0",
+				"decompress-unzip": "^4.0.1",
+				"graceful-fs": "^4.1.10",
+				"make-dir": "^1.0.0",
+				"pify": "^2.3.0",
+				"strip-dirs": "^2.0.0"
 			}
 		},
 		"decompress-response": {
@@ -2435,7 +2477,7 @@
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"requires": {
-				"mimic-response": "1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"decompress-tar": {
@@ -2443,9 +2485,9 @@
 			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
 			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
 			"requires": {
-				"file-type": "5.2.0",
-				"is-stream": "1.1.0",
-				"tar-stream": "1.5.5"
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0",
+				"tar-stream": "^1.5.2"
 			}
 		},
 		"decompress-tarbz2": {
@@ -2453,11 +2495,11 @@
 			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
 			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
 			"requires": {
-				"decompress-tar": "4.1.1",
-				"file-type": "6.2.0",
-				"is-stream": "1.1.0",
-				"seek-bzip": "1.0.5",
-				"unbzip2-stream": "1.2.5"
+				"decompress-tar": "^4.1.0",
+				"file-type": "^6.1.0",
+				"is-stream": "^1.1.0",
+				"seek-bzip": "^1.0.5",
+				"unbzip2-stream": "^1.0.9"
 			},
 			"dependencies": {
 				"file-type": {
@@ -2472,9 +2514,9 @@
 			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
 			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
 			"requires": {
-				"decompress-tar": "4.1.1",
-				"file-type": "5.2.0",
-				"is-stream": "1.1.0"
+				"decompress-tar": "^4.1.1",
+				"file-type": "^5.2.0",
+				"is-stream": "^1.1.0"
 			}
 		},
 		"decompress-unzip": {
@@ -2482,10 +2524,10 @@
 			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
 			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
 			"requires": {
-				"file-type": "3.9.0",
-				"get-stream": "2.3.1",
-				"pify": "2.3.0",
-				"yauzl": "2.9.1"
+				"file-type": "^3.8.0",
+				"get-stream": "^2.2.0",
+				"pify": "^2.3.0",
+				"yauzl": "^2.4.2"
 			},
 			"dependencies": {
 				"file-type": {
@@ -2498,8 +2540,8 @@
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
 					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 					"requires": {
-						"object-assign": "4.1.1",
-						"pinkie-promise": "2.0.1"
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -2539,7 +2581,7 @@
 			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
 			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
 			"requires": {
-				"abstract-leveldown": "2.6.3"
+				"abstract-leveldown": "~2.6.0"
 			}
 		},
 		"define-properties": {
@@ -2547,8 +2589,8 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			},
 			"dependencies": {
 				"object-keys": {
@@ -2583,8 +2625,8 @@
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"destroy": {
@@ -2602,7 +2644,7 @@
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"detect-node": {
@@ -2620,9 +2662,9 @@
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"dom-walk": {
@@ -2640,9 +2682,9 @@
 			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
 			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
 			"requires": {
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6"
+				"browserify-aes": "^1.0.6",
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4"
 			}
 		},
 		"duplexer3": {
@@ -2656,7 +2698,7 @@
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"editions": {
@@ -2684,13 +2726,13 @@
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emojis-list": {
@@ -2708,7 +2750,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"end-of-stream": {
@@ -2716,7 +2758,7 @@
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
 			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -2724,10 +2766,10 @@
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.4.1",
-				"object-assign": "4.1.1",
-				"tapable": "0.2.8"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.4.0",
+				"object-assign": "^4.0.1",
+				"tapable": "^0.2.7"
 			}
 		},
 		"envinfo": {
@@ -2740,7 +2782,7 @@
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 			"requires": {
-				"prr": "0.0.0"
+				"prr": "~0.0.0"
 			}
 		},
 		"error": {
@@ -2748,8 +2790,8 @@
 			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
 			"requires": {
-				"string-template": "0.2.1",
-				"xtend": "4.0.1"
+				"string-template": "~0.2.1",
+				"xtend": "~4.0.0"
 			}
 		},
 		"error-ex": {
@@ -2757,7 +2799,7 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -2765,11 +2807,11 @@
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
 			"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -2777,9 +2819,9 @@
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"es5-ext": {
@@ -2787,8 +2829,8 @@
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
 			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
 			"requires": {
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"es6-iterator": "~2.0.1",
+				"es6-symbol": "~3.1.1"
 			}
 		},
 		"es6-iterator": {
@@ -2796,9 +2838,9 @@
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"es6-map": {
@@ -2806,12 +2848,12 @@
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-set": "0.1.5",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-set": {
@@ -2819,11 +2861,11 @@
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -2831,8 +2873,8 @@
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"es6-weak-map": {
@@ -2840,10 +2882,10 @@
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"escape-html": {
@@ -2861,11 +2903,11 @@
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
 			"requires": {
-				"esprima": "2.7.3",
-				"estraverse": "1.9.3",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.2.0"
+				"esprima": "^2.7.1",
+				"estraverse": "^1.9.1",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.2.0"
 			},
 			"dependencies": {
 				"estraverse": {
@@ -2879,7 +2921,7 @@
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
 					"optional": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -2889,10 +2931,10 @@
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"requires": {
-				"es6-map": "0.1.5",
-				"es6-weak-map": "2.0.2",
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"es6-map": "^0.1.3",
+				"es6-weak-map": "^2.0.1",
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"esprima": {
@@ -2905,8 +2947,8 @@
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
 			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
+				"estraverse": "^4.1.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"estraverse": {
@@ -2929,8 +2971,8 @@
 			"resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
 			"integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
 			"requires": {
-				"idna-uts46-hx": "2.3.1",
-				"js-sha3": "0.5.7"
+				"idna-uts46-hx": "^2.3.1",
+				"js-sha3": "^0.5.7"
 			},
 			"dependencies": {
 				"js-sha3": {
@@ -2941,26 +2983,87 @@
 			}
 		},
 		"eth-gas-reporter": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.1.tgz",
-			"integrity": "sha512-ky5P27RRaDxD5EAzRL+xEBTq6uyfFj1Dyan2Epq5rfV66wEDtDkGTCYBefRaQpuXJ5C/U6Jsv5TR12qn7Mb83g==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.1.5.tgz",
+			"integrity": "sha512-SO3XePkWnl3d5HuIE+0jv6as03RJKRVeZ4/IQc+ukLeo6Vm5aez2/d1yfnxd2zE+MmoFGwvYuN6erk3CUxiHWg==",
 			"requires": {
-				"abi-decoder": "1.0.9",
-				"cli-table2": "0.2.0",
-				"colors": "1.1.2",
-				"lodash": "4.17.4",
-				"req-cwd": "2.0.0",
-				"request": "2.83.0",
-				"request-promise-native": "1.0.5",
-				"shelljs": "0.7.8"
+				"abi-decoder": "^1.0.8",
+				"cli-table2": "^0.2.0",
+				"colors": "^1.1.2",
+				"lodash": "^4.17.4",
+				"mocha": "^3.5.3",
+				"req-cwd": "^2.0.0",
+				"request": "^2.83.0",
+				"request-promise-native": "^1.0.5",
+				"shelljs": "^0.7.8",
+				"solidity-parser-antlr": "^0.2.10",
+				"sync-request": "^6.0.0"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+					"requires": {
+						"graceful-readlink": ">= 1.0.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+				},
+				"glob": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.2",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"mocha": {
+					"version": "3.5.3",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+					"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+					"requires": {
+						"browser-stdout": "1.3.0",
+						"commander": "2.9.0",
+						"debug": "2.6.8",
+						"diff": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.1",
+						"growl": "1.9.2",
+						"he": "1.1.1",
+						"json3": "3.3.2",
+						"lodash.create": "3.1.1",
+						"mkdirp": "0.5.1",
+						"supports-color": "3.1.2"
+					}
+				},
 				"req-cwd": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
 					"integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
 					"requires": {
-						"req-from": "2.0.0"
+						"req-from": "^2.0.0"
 					}
 				},
 				"req-from": {
@@ -2968,13 +3071,21 @@
 					"resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
 					"integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
 					"requires": {
-						"resolve-from": "3.0.0"
+						"resolve-from": "^3.0.0"
 					}
 				},
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
 					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
 				}
 			}
 		},
@@ -2983,13 +3094,13 @@
 			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
 			"integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0",
-				"keccakjs": "0.2.1",
-				"nano-json-stream-parser": "0.1.2",
-				"servify": "0.1.12",
-				"ws": "3.3.3",
-				"xhr-request-promise": "0.1.2"
+				"bn.js": "^4.11.6",
+				"elliptic": "^6.4.0",
+				"keccakjs": "^0.2.1",
+				"nano-json-stream-parser": "^0.1.2",
+				"servify": "^0.1.12",
+				"ws": "^3.0.0",
+				"xhr-request-promise": "^0.1.2"
 			}
 		},
 		"ethereum-common": {
@@ -3002,8 +3113,8 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
 			"integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
 			"requires": {
-				"ethereumjs-util": "4.5.0",
-				"rlp": "2.0.0"
+				"ethereumjs-util": "^4.0.1",
+				"rlp": "^2.0.0"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
@@ -3011,11 +3122,11 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
 					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"keccakjs": "0.2.1",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				}
 			}
@@ -3025,11 +3136,11 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.0.tgz",
 			"integrity": "sha512-4s4Hh7mWa1xr+Bggh3T3jsq9lmje5aYpJRFky00bo/xNgNe+RC8V2ulWYSR4YTEKqLbnLEsLNytjDe5hpblkZQ==",
 			"requires": {
-				"async": "2.6.0",
+				"async": "^2.0.1",
 				"ethereum-common": "0.2.0",
-				"ethereumjs-tx": "1.3.3",
-				"ethereumjs-util": "5.1.2",
-				"merkle-patricia-tree": "2.2.0"
+				"ethereumjs-tx": "^1.2.2",
+				"ethereumjs-util": "^5.0.0",
+				"merkle-patricia-tree": "^2.1.2"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
@@ -3037,14 +3148,14 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
 					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
 					"requires": {
-						"babel-preset-es2015": "6.24.1",
-						"babelify": "7.3.0",
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"babel-preset-es2015": "^6.24.0",
+						"babelify": "^7.3.0",
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"ethjs-util": "^0.1.3",
+						"keccak": "^1.0.2",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				}
 			}
@@ -3054,7 +3165,7 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
 			"integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
 			"requires": {
-				"webpack": "3.10.0"
+				"webpack": "^3.0.0"
 			}
 		},
 		"ethereumjs-tx": {
@@ -3062,8 +3173,8 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.3.tgz",
 			"integrity": "sha1-7OBR0+/b53GtKlGNYWMsoqt17Ls=",
 			"requires": {
-				"ethereum-common": "0.0.18",
-				"ethereumjs-util": "5.1.2"
+				"ethereum-common": "^0.0.18",
+				"ethereumjs-util": "^5.0.0"
 			},
 			"dependencies": {
 				"ethereum-common": {
@@ -3076,14 +3187,14 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
 					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
 					"requires": {
-						"babel-preset-es2015": "6.24.1",
-						"babelify": "7.3.0",
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"babel-preset-es2015": "^6.24.0",
+						"babelify": "^7.3.0",
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"ethjs-util": "^0.1.3",
+						"keccak": "^1.0.2",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				}
 			}
@@ -3093,11 +3204,11 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
 			"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"create-hash": "1.1.3",
-				"keccakjs": "0.2.1",
-				"rlp": "2.0.0",
-				"secp256k1": "3.3.1"
+				"bn.js": "^4.8.0",
+				"create-hash": "^1.1.2",
+				"keccakjs": "^0.2.0",
+				"rlp": "^2.0.0",
+				"secp256k1": "^3.0.1"
 			}
 		},
 		"ethereumjs-vm": {
@@ -3105,17 +3216,17 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.2.tgz",
 			"integrity": "sha512-uREIQ4juS3nnZc9I1khWvw5fjpN4heaI/IDWdbc89x6YuXkmt/QrI/X3QDQI+S4ojFEoigBh9p1eezyitFmMKA==",
 			"requires": {
-				"async": "2.6.0",
-				"async-eventemitter": "0.2.4",
+				"async": "^2.1.2",
+				"async-eventemitter": "^0.2.2",
 				"ethereum-common": "0.2.0",
-				"ethereumjs-account": "2.0.4",
-				"ethereumjs-block": "1.7.0",
+				"ethereumjs-account": "^2.0.3",
+				"ethereumjs-block": "~1.7.0",
 				"ethereumjs-util": "4.5.0",
-				"fake-merkle-patricia-tree": "1.0.1",
-				"functional-red-black-tree": "1.0.1",
-				"merkle-patricia-tree": "2.2.0",
-				"rustbn.js": "0.1.1",
-				"safe-buffer": "5.1.1"
+				"fake-merkle-patricia-tree": "^1.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"merkle-patricia-tree": "^2.1.2",
+				"rustbn.js": "~0.1.1",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"ethereumjs-wallet": {
@@ -3123,13 +3234,13 @@
 			"resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
 			"integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
 			"requires": {
-				"aes-js": "0.2.4",
-				"bs58check": "1.3.4",
-				"ethereumjs-util": "4.5.0",
-				"hdkey": "0.7.1",
-				"scrypt.js": "0.2.0",
-				"utf8": "2.1.2",
-				"uuid": "2.0.3"
+				"aes-js": "^0.2.3",
+				"bs58check": "^1.0.8",
+				"ethereumjs-util": "^4.4.0",
+				"hdkey": "^0.7.0",
+				"scrypt.js": "^0.2.0",
+				"utf8": "^2.1.1",
+				"uuid": "^2.0.1"
 			},
 			"dependencies": {
 				"ethereumjs-util": {
@@ -3137,11 +3248,11 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
 					"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"keccakjs": "0.2.1",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"keccakjs": "^0.2.0",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				}
 			}
@@ -3176,8 +3287,8 @@
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"eventemitter3": {
@@ -3195,8 +3306,8 @@
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"requires": {
-				"md5.js": "1.3.4",
-				"safe-buffer": "5.1.1"
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"execa": {
@@ -3204,13 +3315,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit-hook": {
@@ -3223,7 +3334,7 @@
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -3231,7 +3342,7 @@
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expand-template": {
@@ -3244,7 +3355,7 @@
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"requires": {
-				"homedir-polyfill": "1.0.1"
+				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"express": {
@@ -3252,36 +3363,36 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
 			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
 			"requires": {
-				"accepts": "1.3.5",
+				"accepts": "~1.3.4",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.2",
 				"content-disposition": "0.5.2",
-				"content-type": "1.0.4",
+				"content-type": "~1.0.4",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
+				"depd": "~1.1.1",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
 				"finalhandler": "1.1.0",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
-				"methods": "1.1.2",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "2.0.3",
+				"proxy-addr": "~2.0.2",
 				"qs": "6.5.1",
-				"range-parser": "1.2.0",
+				"range-parser": "~1.2.0",
 				"safe-buffer": "5.1.1",
 				"send": "0.16.1",
 				"serve-static": "1.13.1",
 				"setprototypeof": "1.1.0",
-				"statuses": "1.3.1",
-				"type-is": "1.6.16",
+				"statuses": "~1.3.1",
+				"type-is": "~1.6.15",
 				"utils-merge": "1.0.1",
-				"vary": "1.1.2"
+				"vary": "~1.1.2"
 			},
 			"dependencies": {
 				"setprototypeof": {
@@ -3306,9 +3417,9 @@
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.19",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			},
 			"dependencies": {
 				"tmp": {
@@ -3316,7 +3427,7 @@
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
@@ -3326,7 +3437,7 @@
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -3339,7 +3450,7 @@
 			"resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
 			"integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
 			"requires": {
-				"checkpoint-store": "1.1.0"
+				"checkpoint-store": "^1.1.0"
 			}
 		},
 		"fast-deep-equal": {
@@ -3362,7 +3473,7 @@
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"figures": {
@@ -3370,7 +3481,7 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-type": {
@@ -3388,11 +3499,11 @@
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"finalhandler": {
@@ -3401,12 +3512,12 @@
 			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
-				"statuses": "1.3.1",
-				"unpipe": "1.0.0"
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.3.1",
+				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
 				"statuses": {
@@ -3421,9 +3532,9 @@
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
 			"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
 			"requires": {
-				"commondir": "1.0.1",
-				"mkdirp": "0.5.1",
-				"pkg-dir": "1.0.0"
+				"commondir": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pkg-dir": "^1.0.0"
 			}
 		},
 		"find-up": {
@@ -3431,7 +3542,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"first-chunk-stream": {
@@ -3439,7 +3550,7 @@
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"flatmap": {
@@ -3457,7 +3568,7 @@
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
 			"integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
 			"requires": {
-				"is-function": "1.0.1"
+				"is-function": "~1.0.0"
 			}
 		},
 		"for-in": {
@@ -3470,7 +3581,7 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -3488,9 +3599,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
 			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"forwarded": {
@@ -3508,8 +3619,8 @@
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
 			}
 		},
 		"fs-extra": {
@@ -3517,11 +3628,11 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
 			"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "2.4.0",
-				"klaw": "1.3.1",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^2.1.0",
+				"klaw": "^1.0.0",
+				"path-is-absolute": "^1.0.0",
+				"rimraf": "^2.2.8"
 			}
 		},
 		"fs-promise": {
@@ -3529,10 +3640,10 @@
 			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
 			"integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
 			"requires": {
-				"any-promise": "1.3.0",
-				"fs-extra": "2.1.2",
-				"mz": "2.7.0",
-				"thenify-all": "1.6.0"
+				"any-promise": "^1.3.0",
+				"fs-extra": "^2.0.0",
+				"mz": "^2.6.0",
+				"thenify-all": "^1.6.0"
 			},
 			"dependencies": {
 				"fs-extra": {
@@ -3540,8 +3651,8 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
 					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0"
 					}
 				}
 			}
@@ -3562,8 +3673,8 @@
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
-				"nan": "2.7.0",
-				"node-pre-gyp": "0.6.39"
+				"nan": "^2.3.0",
+				"node-pre-gyp": "^0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3578,8 +3689,8 @@
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"optional": true,
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
 					}
 				},
 				"ansi-regex": {
@@ -3599,8 +3710,8 @@
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"asn1": {
@@ -3644,7 +3755,7 @@
 					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 					"optional": true,
 					"requires": {
-						"tweetnacl": "0.14.5"
+						"tweetnacl": "^0.14.3"
 					}
 				},
 				"block-stream": {
@@ -3652,7 +3763,7 @@
 					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"requires": {
-						"inherits": "2.0.3"
+						"inherits": "~2.0.0"
 					}
 				},
 				"boom": {
@@ -3660,7 +3771,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"brace-expansion": {
@@ -3668,7 +3779,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"requires": {
-						"balanced-match": "0.4.2",
+						"balanced-match": "^0.4.1",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3699,7 +3810,7 @@
 					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"requires": {
-						"delayed-stream": "1.0.0"
+						"delayed-stream": "~1.0.0"
 					}
 				},
 				"concat-map": {
@@ -3722,7 +3833,7 @@
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"requires": {
-						"boom": "2.10.1"
+						"boom": "2.x.x"
 					}
 				},
 				"dashdash": {
@@ -3731,7 +3842,7 @@
 					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"optional": true,
 					"requires": {
-						"assert-plus": "1.0.0"
+						"assert-plus": "^1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3780,7 +3891,7 @@
 					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
+						"jsbn": "~0.1.0"
 					}
 				},
 				"extend": {
@@ -3806,9 +3917,9 @@
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"optional": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"fs.realpath": {
@@ -3821,10 +3932,10 @@
 					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
+						"graceful-fs": "^4.1.2",
+						"inherits": "~2.0.0",
+						"mkdirp": ">=0.5 0",
+						"rimraf": "2"
 					}
 				},
 				"fstream-ignore": {
@@ -3833,9 +3944,9 @@
 					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
 					"optional": true,
 					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
+						"fstream": "^1.0.0",
+						"inherits": "2",
+						"minimatch": "^3.0.0"
 					}
 				},
 				"gauge": {
@@ -3844,14 +3955,14 @@
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"optional": true,
 					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"getpass": {
@@ -3860,7 +3971,7 @@
 					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"optional": true,
 					"requires": {
-						"assert-plus": "1.0.0"
+						"assert-plus": "^1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3876,12 +3987,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -3901,8 +4012,8 @@
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
 					"optional": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"ajv": "^4.9.1",
+						"har-schema": "^1.0.5"
 					}
 				},
 				"has-unicode": {
@@ -3916,10 +4027,10 @@
 					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
+						"boom": "2.x.x",
+						"cryptiles": "2.x.x",
+						"hoek": "2.x.x",
+						"sntp": "1.x.x"
 					}
 				},
 				"hoek": {
@@ -3933,9 +4044,9 @@
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"optional": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"inflight": {
@@ -3943,8 +4054,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -3963,7 +4074,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-typedarray": {
@@ -3989,7 +4100,7 @@
 					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
+						"jsbn": "~0.1.0"
 					}
 				},
 				"jsbn": {
@@ -4010,7 +4121,7 @@
 					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"optional": true,
 					"requires": {
-						"jsonify": "0.0.0"
+						"jsonify": "~0.0.0"
 					}
 				},
 				"json-stringify-safe": {
@@ -4055,7 +4166,7 @@
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"requires": {
-						"mime-db": "1.27.0"
+						"mime-db": "~1.27.0"
 					}
 				},
 				"minimatch": {
@@ -4063,7 +4174,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.7"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -4091,17 +4202,17 @@
 					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.2",
+						"detect-libc": "^1.0.2",
 						"hawk": "3.1.3",
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
+						"mkdirp": "^0.5.1",
+						"nopt": "^4.0.1",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
 						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^2.2.1",
+						"tar-pack": "^3.4.0"
 					}
 				},
 				"nopt": {
@@ -4110,8 +4221,8 @@
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npmlog": {
@@ -4120,10 +4231,10 @@
 					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -4148,7 +4259,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -4169,8 +4280,8 @@
 					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -4207,10 +4318,10 @@
 					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "~0.4.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -4226,13 +4337,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
+						"buffer-shims": "~1.0.0",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~1.0.6",
+						"string_decoder": "~1.0.0",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"request": {
@@ -4241,28 +4352,28 @@
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"optional": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~4.2.1",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"performance-now": "^0.2.0",
+						"qs": "~6.4.0",
+						"safe-buffer": "^5.0.1",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.0.0"
 					}
 				},
 				"rimraf": {
@@ -4270,7 +4381,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -4301,7 +4412,7 @@
 					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"sshpk": {
@@ -4310,15 +4421,15 @@
 					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
 					"optional": true,
 					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jodid25519": "^1.0.0",
+						"jsbn": "~0.1.0",
+						"tweetnacl": "~0.14.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -4334,9 +4445,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -4344,7 +4455,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"stringstream": {
@@ -4358,7 +4469,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -4372,9 +4483,9 @@
 					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
+						"block-stream": "*",
+						"fstream": "^1.0.2",
+						"inherits": "2"
 					}
 				},
 				"tar-pack": {
@@ -4383,14 +4494,14 @@
 					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
 					"optional": true,
 					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
+						"debug": "^2.2.0",
+						"fstream": "^1.0.10",
+						"fstream-ignore": "^1.0.5",
+						"once": "^1.3.3",
+						"readable-stream": "^2.1.4",
+						"rimraf": "^2.5.1",
+						"tar": "^2.2.1",
+						"uid-number": "^0.0.6"
 					}
 				},
 				"tough-cookie": {
@@ -4399,7 +4510,7 @@
 					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
 					"optional": true,
 					"requires": {
-						"punycode": "1.4.1"
+						"punycode": "^1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -4408,7 +4519,7 @@
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"tweetnacl": {
@@ -4449,7 +4560,7 @@
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
@@ -4464,10 +4575,10 @@
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
 			}
 		},
 		"function-bind": {
@@ -4485,8 +4596,8 @@
 			"resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.0.tgz",
 			"integrity": "sha512-FdTeyk4uLRHGeFiMe+Qnh4Hc5KiTVqvRVVvLDFJEVVKC1P1yHhEgZeh9sp1KhuvxSrxToxgJS25UapYQwH4zHw==",
 			"requires": {
-				"source-map-support": "0.5.5",
-				"webpack-cli": "2.0.15"
+				"source-map-support": "^0.5.3",
+				"webpack-cli": "^2.0.9"
 			},
 			"dependencies": {
 				"buffer-from": {
@@ -4504,8 +4615,8 @@
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
 					"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
 					"requires": {
-						"buffer-from": "1.0.0",
-						"source-map": "0.6.1"
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
 					}
 				}
 			}
@@ -4515,36 +4626,36 @@
 			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.0.2.tgz",
 			"integrity": "sha512-hfmfqwWDT7zLPwSmAHXExCP8S97yjqGaT7KS93tKj4DY6beU8na46bkH1GZUb02DKXqHC4deTv85xA1yBwV1Lw==",
 			"requires": {
-				"async": "1.5.2",
-				"bip39": "2.4.0",
-				"cachedown": "1.0.0",
-				"chai": "3.5.0",
-				"clone": "2.1.1",
-				"ethereumjs-account": "2.0.4",
-				"ethereumjs-block": "1.2.2",
-				"ethereumjs-tx": "1.3.3",
-				"ethereumjs-util": "5.1.5",
+				"async": "~1.5.0",
+				"bip39": "~2.4.0",
+				"cachedown": "^1.0.0",
+				"chai": "^3.5.0",
+				"clone": "^2.1.1",
+				"ethereumjs-account": "~2.0.4",
+				"ethereumjs-block": "~1.2.2",
+				"ethereumjs-tx": "^1.3.0",
+				"ethereumjs-util": "~5.1.0",
 				"ethereumjs-vm": "2.3.2",
-				"ethereumjs-wallet": "0.6.0",
-				"fake-merkle-patricia-tree": "1.0.1",
-				"heap": "0.2.6",
-				"js-scrypt": "0.2.0",
-				"level-sublevel": "6.6.1",
-				"levelup": "1.3.9",
-				"localstorage-down": "0.6.7",
-				"merkle-patricia-tree": "2.2.0",
-				"mocha": "3.3.0",
-				"on-build-webpack": "0.1.0",
-				"prepend-file": "1.3.1",
-				"seedrandom": "2.4.3",
+				"ethereumjs-wallet": "~0.6.0",
+				"fake-merkle-patricia-tree": "~1.0.1",
+				"heap": "~0.2.6",
+				"js-scrypt": "^0.2.0",
+				"level-sublevel": "^6.6.1",
+				"levelup": "^1.1.0",
+				"localstorage-down": "^0.6.7",
+				"merkle-patricia-tree": "^2.2.0",
+				"mocha": "~3.3.0",
+				"on-build-webpack": "^0.1.0",
+				"prepend-file": "^1.3.1",
+				"seedrandom": "~2.4.2",
 				"shebang-loader": "0.0.1",
 				"solc": "0.4.18",
-				"temp": "0.8.3",
+				"temp": "^0.8.3",
 				"tmp": "0.0.31",
-				"web3": "0.19.1",
-				"web3-provider-engine": "8.1.19",
-				"webpack": "2.7.0",
-				"yargs": "7.1.0"
+				"web3": "^0.19.1",
+				"web3-provider-engine": "~8.1.0",
+				"webpack": "^2.2.1",
+				"yargs": "^7.0.2"
 			},
 			"dependencies": {
 				"ajv": {
@@ -4552,8 +4663,8 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
 					}
 				},
 				"ajv-keywords": {
@@ -4581,9 +4692,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"commander": {
@@ -4591,7 +4702,7 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
 					"requires": {
-						"graceful-readlink": "1.0.1"
+						"graceful-readlink": ">= 1.0.0"
 					}
 				},
 				"debug": {
@@ -4617,11 +4728,11 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
 					"integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
 					"requires": {
-						"async": "1.5.2",
+						"async": "^1.5.2",
 						"ethereum-common": "0.0.16",
-						"ethereumjs-tx": "1.3.3",
-						"ethereumjs-util": "4.5.0",
-						"merkle-patricia-tree": "2.2.0"
+						"ethereumjs-tx": "^1.0.0",
+						"ethereumjs-util": "^4.0.1",
+						"merkle-patricia-tree": "^2.1.2"
 					},
 					"dependencies": {
 						"ethereumjs-util": {
@@ -4629,11 +4740,11 @@
 							"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
 							"integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
 							"requires": {
-								"bn.js": "4.11.8",
-								"create-hash": "1.1.3",
-								"keccakjs": "0.2.1",
-								"rlp": "2.0.0",
-								"secp256k1": "3.3.1"
+								"bn.js": "^4.8.0",
+								"create-hash": "^1.1.2",
+								"keccakjs": "^0.2.0",
+								"rlp": "^2.0.0",
+								"secp256k1": "^3.0.1"
 							}
 						}
 					}
@@ -4643,13 +4754,13 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
 					"integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"secp256k1": "3.3.1"
+						"bn.js": "^4.11.0",
+						"create-hash": "^1.1.2",
+						"ethjs-util": "^0.1.3",
+						"keccak": "^1.0.2",
+						"rlp": "^2.0.0",
+						"safe-buffer": "^5.1.1",
+						"secp256k1": "^3.0.1"
 					}
 				},
 				"find-up": {
@@ -4657,8 +4768,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"glob": {
@@ -4666,12 +4777,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.2",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -4684,11 +4795,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"loader-utils": {
@@ -4696,10 +4807,10 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
 					}
 				},
 				"mocha": {
@@ -4730,7 +4841,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
@@ -4738,7 +4849,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -4746,9 +4857,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -4756,9 +4867,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -4766,8 +4877,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -4775,9 +4886,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4785,7 +4896,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"supports-color": {
@@ -4793,7 +4904,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				},
 				"web3": {
@@ -4801,11 +4912,11 @@
 					"resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
 					"integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
 					"requires": {
-						"bignumber.js": "4.1.0",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
+						"bignumber.js": "^4.0.2",
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
 					}
 				},
 				"web3-provider-engine": {
@@ -4813,20 +4924,20 @@
 					"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
 					"integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
 					"requires": {
-						"async": "2.6.0",
-						"clone": "2.1.1",
-						"ethereumjs-block": "1.2.2",
-						"ethereumjs-tx": "1.3.3",
-						"ethereumjs-util": "5.1.5",
-						"ethereumjs-vm": "2.3.2",
-						"isomorphic-fetch": "2.2.1",
-						"request": "2.83.0",
-						"semaphore": "1.1.0",
-						"solc": "0.4.18",
-						"tape": "4.8.0",
-						"web3": "0.16.0",
-						"xhr": "2.4.0",
-						"xtend": "4.0.1"
+						"async": "^2.1.2",
+						"clone": "^2.0.0",
+						"ethereumjs-block": "^1.2.2",
+						"ethereumjs-tx": "^1.2.0",
+						"ethereumjs-util": "^5.0.1",
+						"ethereumjs-vm": "^2.0.2",
+						"isomorphic-fetch": "^2.2.0",
+						"request": "^2.67.0",
+						"semaphore": "^1.0.3",
+						"solc": "^0.4.2",
+						"tape": "^4.4.0",
+						"web3": "^0.16.0",
+						"xhr": "^2.2.0",
+						"xtend": "^4.0.1"
 					},
 					"dependencies": {
 						"async": {
@@ -4834,11 +4945,12 @@
 							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 							"requires": {
-								"lodash": "4.17.4"
+								"lodash": "^4.14.0"
 							}
 						},
 						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 						},
 						"web3": {
 							"version": "0.16.0",
@@ -4846,13 +4958,14 @@
 							"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
 							"requires": {
 								"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-								"crypto-js": "3.1.8",
-								"utf8": "2.1.2",
-								"xmlhttprequest": "1.8.0"
+								"crypto-js": "^3.1.4",
+								"utf8": "^2.1.1",
+								"xmlhttprequest": "*"
 							},
 							"dependencies": {
 								"bignumber.js": {
-									"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+									"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+									"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 								}
 							}
 						}
@@ -4863,27 +4976,27 @@
 					"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
 					"integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
 					"requires": {
-						"acorn": "5.2.1",
-						"acorn-dynamic-import": "2.0.2",
-						"ajv": "4.11.8",
-						"ajv-keywords": "1.5.1",
-						"async": "2.6.0",
-						"enhanced-resolve": "3.4.1",
-						"interpret": "1.0.4",
-						"json-loader": "0.5.7",
-						"json5": "0.5.1",
-						"loader-runner": "2.3.0",
-						"loader-utils": "0.2.17",
-						"memory-fs": "0.4.1",
-						"mkdirp": "0.5.1",
-						"node-libs-browser": "2.0.0",
-						"source-map": "0.5.7",
-						"supports-color": "3.1.2",
-						"tapable": "0.2.8",
-						"uglify-js": "2.8.29",
-						"watchpack": "1.4.0",
-						"webpack-sources": "1.0.2",
-						"yargs": "6.6.0"
+						"acorn": "^5.0.0",
+						"acorn-dynamic-import": "^2.0.0",
+						"ajv": "^4.7.0",
+						"ajv-keywords": "^1.1.1",
+						"async": "^2.1.2",
+						"enhanced-resolve": "^3.3.0",
+						"interpret": "^1.0.0",
+						"json-loader": "^0.5.4",
+						"json5": "^0.5.1",
+						"loader-runner": "^2.3.0",
+						"loader-utils": "^0.2.16",
+						"memory-fs": "~0.4.1",
+						"mkdirp": "~0.5.0",
+						"node-libs-browser": "^2.0.0",
+						"source-map": "^0.5.3",
+						"supports-color": "^3.1.0",
+						"tapable": "~0.2.5",
+						"uglify-js": "^2.8.27",
+						"watchpack": "^1.3.1",
+						"webpack-sources": "^1.0.1",
+						"yargs": "^6.0.0"
 					},
 					"dependencies": {
 						"async": {
@@ -4891,7 +5004,7 @@
 							"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 							"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 							"requires": {
-								"lodash": "4.17.4"
+								"lodash": "^4.14.0"
 							}
 						},
 						"yargs": {
@@ -4899,19 +5012,19 @@
 							"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 							"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 							"requires": {
-								"camelcase": "3.0.0",
-								"cliui": "3.2.0",
-								"decamelize": "1.2.0",
-								"get-caller-file": "1.0.2",
-								"os-locale": "1.4.0",
-								"read-pkg-up": "1.0.1",
-								"require-directory": "2.1.1",
-								"require-main-filename": "1.0.1",
-								"set-blocking": "2.0.0",
-								"string-width": "1.0.2",
-								"which-module": "1.0.0",
-								"y18n": "3.2.1",
-								"yargs-parser": "4.2.1"
+								"camelcase": "^3.0.0",
+								"cliui": "^3.2.0",
+								"decamelize": "^1.1.1",
+								"get-caller-file": "^1.0.1",
+								"os-locale": "^1.4.0",
+								"read-pkg-up": "^1.0.1",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^1.0.1",
+								"set-blocking": "^2.0.0",
+								"string-width": "^1.0.2",
+								"which-module": "^1.0.0",
+								"y18n": "^3.2.1",
+								"yargs-parser": "^4.2.0"
 							}
 						}
 					}
@@ -4926,19 +5039,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
 					},
 					"dependencies": {
 						"yargs-parser": {
@@ -4946,7 +5059,7 @@
 							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 							"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 							"requires": {
-								"camelcase": "3.0.0"
+								"camelcase": "^3.0.0"
 							}
 						}
 					}
@@ -4956,7 +5069,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -4966,14 +5079,14 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.2"
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
 			},
 			"dependencies": {
 				"string-width": {
@@ -4981,9 +5094,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -4998,6 +5111,11 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -5008,7 +5126,7 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"gh-got": {
@@ -5016,8 +5134,8 @@
 			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
 			"requires": {
-				"got": "7.1.0",
-				"is-plain-obj": "1.1.0"
+				"got": "^7.0.0",
+				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"git-clone": {
@@ -5035,7 +5153,7 @@
 			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
 			"requires": {
-				"gh-got": "6.0.0"
+				"gh-got": "^6.0.0"
 			}
 		},
 		"glob": {
@@ -5043,11 +5161,11 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "2 || 3",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-all": {
@@ -5055,8 +5173,8 @@
 			"resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
 			"requires": {
-				"glob": "7.1.2",
-				"yargs": "1.2.6"
+				"glob": "^7.0.5",
+				"yargs": "~1.2.6"
 			},
 			"dependencies": {
 				"glob": {
@@ -5064,12 +5182,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"minimist": {
@@ -5082,7 +5200,7 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
 					"requires": {
-						"minimist": "0.1.0"
+						"minimist": "^0.1.0"
 					}
 				}
 			}
@@ -5092,8 +5210,8 @@
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-escape": {
@@ -5106,7 +5224,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"global": {
@@ -5114,8 +5232,8 @@
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"requires": {
-				"min-document": "2.19.0",
-				"process": "0.5.2"
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
 			},
 			"dependencies": {
 				"process": {
@@ -5130,9 +5248,9 @@
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 			"requires": {
-				"global-prefix": "1.0.2",
-				"is-windows": "1.0.2",
-				"resolve-dir": "1.0.1"
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
 			}
 		},
 		"global-prefix": {
@@ -5140,11 +5258,11 @@
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"requires": {
-				"expand-tilde": "2.0.2",
-				"homedir-polyfill": "1.0.1",
-				"ini": "1.3.4",
-				"is-windows": "1.0.2",
-				"which": "1.3.0"
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
 			}
 		},
 		"globals": {
@@ -5157,11 +5275,11 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"requires": {
-				"array-union": "1.0.2",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -5169,12 +5287,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -5184,20 +5302,20 @@
 			"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
 			"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
 			"requires": {
-				"decompress-response": "3.3.0",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-plain-obj": "1.1.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"isurl": "1.0.0",
-				"lowercase-keys": "1.0.0",
-				"p-cancelable": "0.3.0",
-				"p-timeout": "1.2.1",
-				"safe-buffer": "5.1.1",
-				"timed-out": "4.0.1",
-				"url-parse-lax": "1.0.0",
-				"url-to-options": "1.0.1"
+				"decompress-response": "^3.2.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"isurl": "^1.0.0-alpha5",
+				"lowercase-keys": "^1.0.0",
+				"p-cancelable": "^0.3.0",
+				"p-timeout": "^1.1.1",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"url-parse-lax": "^1.0.0",
+				"url-to-options": "^1.0.1"
 			}
 		},
 		"graceful-fs": {
@@ -5215,7 +5333,7 @@
 			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.17.2"
 			}
 		},
 		"growl": {
@@ -5228,10 +5346,10 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			},
 			"dependencies": {
 				"async": {
@@ -5244,7 +5362,7 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -5259,8 +5377,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.3.0",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -5268,7 +5386,7 @@
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -5276,7 +5394,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-color": {
@@ -5299,9 +5417,9 @@
 			"resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
 			"integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"to-object-x": "1.5.0",
-				"to-property-key-x": "2.0.2"
+				"cached-constructors-x": "^1.0.0",
+				"to-object-x": "^1.5.0",
+				"to-property-key-x": "^2.0.2"
 			}
 		},
 		"has-symbol-support-x": {
@@ -5314,7 +5432,7 @@
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"requires": {
-				"has-symbol-support-x": "1.4.2"
+				"has-symbol-support-x": "^1.4.1"
 			}
 		},
 		"has-unicode": {
@@ -5327,7 +5445,7 @@
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1"
 			}
 		},
 		"hash.js": {
@@ -5335,8 +5453,8 @@
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"hawk": {
@@ -5344,10 +5462,10 @@
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"hdkey": {
@@ -5355,8 +5473,8 @@
 			"resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
 			"integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
 			"requires": {
-				"coinstring": "2.3.0",
-				"secp256k1": "3.3.1"
+				"coinstring": "^2.0.0",
+				"secp256k1": "^3.0.1"
 			}
 		},
 		"he": {
@@ -5374,9 +5492,9 @@
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"hoek": {
@@ -5389,8 +5507,8 @@
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"homedir": {
@@ -5403,13 +5521,26 @@
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
 			"requires": {
-				"parse-passwd": "1.0.0"
+				"parse-passwd": "^1.0.0"
 			}
 		},
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
 			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"http-basic": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/http-basic/-/http-basic-7.0.0.tgz",
+			"integrity": "sha1-gvClBr6UJzLsje6+6A50bvVzbbo=",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/node": "^9.4.1",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.4.6",
+				"http-response-object": "^3.0.1",
+				"parse-cache-control": "^1.0.1"
+			}
 		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
@@ -5424,7 +5555,7 @@
 				"depd": "1.1.1",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.0.3",
-				"statuses": "1.4.0"
+				"statuses": ">= 1.3.1 < 2"
 			},
 			"dependencies": {
 				"depd": {
@@ -5439,14 +5570,22 @@
 			"resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
 			"integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
 		},
+		"http-response-object": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.1.tgz",
+			"integrity": "sha512-6L0Fkd6TozA8kFSfh9Widst0wfza3U1Ex2RjJ6zNDK0vR1U1auUR6jY4Nn2Xl7CCy0ikFmxW1XcspVpb9RvwTg==",
+			"requires": {
+				"@types/node": "^9.3.0"
+			}
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"https-browserify": {
@@ -5459,8 +5598,8 @@
 			"resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
 			"integrity": "sha1-0Fqw1SbE7b3b98amDfb/WAUoNGk=",
 			"requires": {
-				"has-localstorage": "1.0.1",
-				"localstorage-memory": "1.0.2"
+				"has-localstorage": "^1.0.1",
+				"localstorage-memory": "^1.0.1"
 			}
 		},
 		"iconv-lite": {
@@ -5498,8 +5637,8 @@
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			},
 			"dependencies": {
 				"pkg-dir": {
@@ -5507,7 +5646,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				}
 			}
@@ -5522,7 +5661,7 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"indexof": {
@@ -5540,8 +5679,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -5559,19 +5698,19 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
 			"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.0",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.4",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.1.0",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rxjs": "5.5.10",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rxjs": "^5.5.2",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5584,7 +5723,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -5592,9 +5731,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
 					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -5607,7 +5746,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -5615,7 +5754,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -5630,8 +5769,8 @@
 			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"requires": {
-				"from2": "2.3.0",
-				"p-is-promise": "1.1.0"
+				"from2": "^2.1.1",
+				"p-is-promise": "^1.1.0"
 			}
 		},
 		"invariant": {
@@ -5639,7 +5778,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -5662,34 +5801,34 @@
 			"resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-14.3.7.tgz",
 			"integrity": "sha512-SeCKT6KwMuu/qDEMDd5CRj2KhSa1+Dyx63jJgadU2tD6QINyxCy/ooPFBhZRwlGuAhb61IVSV8pfZ0nHNQEINQ==",
 			"requires": {
-				"async": "2.6.0",
-				"bs58": "4.0.1",
-				"cids": "0.5.2",
-				"concat-stream": "1.6.1",
-				"detect-node": "2.0.3",
+				"async": "^2.5.0",
+				"bs58": "^4.0.1",
+				"cids": "~0.5.2",
+				"concat-stream": "^1.6.0",
+				"detect-node": "^2.0.3",
 				"flatmap": "0.0.3",
-				"glob": "7.1.2",
+				"glob": "^7.1.2",
 				"glob-escape": "0.0.2",
-				"ipfs-block": "0.6.1",
-				"ipfs-unixfs": "0.1.14",
-				"ipld-dag-pb": "0.11.4",
-				"is-ipfs": "0.3.2",
-				"is-stream": "1.1.0",
-				"lru-cache": "4.1.1",
-				"multiaddr": "3.0.2",
-				"multihashes": "0.4.13",
-				"multipart-stream": "2.0.1",
-				"ndjson": "1.5.0",
-				"once": "1.4.0",
-				"peer-id": "0.10.6",
-				"peer-info": "0.11.6",
-				"promisify-es6": "1.0.3",
-				"pump": "1.0.2",
-				"qs": "6.5.1",
-				"readable-stream": "2.3.3",
-				"stream-http": "2.7.2",
-				"streamifier": "0.1.1",
-				"tar-stream": "1.5.5"
+				"ipfs-block": "~0.6.0",
+				"ipfs-unixfs": "~0.1.13",
+				"ipld-dag-pb": "~0.11.2",
+				"is-ipfs": "^0.3.2",
+				"is-stream": "^1.1.0",
+				"lru-cache": "^4.1.1",
+				"multiaddr": "^3.0.1",
+				"multihashes": "~0.4.10",
+				"multipart-stream": "^2.0.1",
+				"ndjson": "^1.5.0",
+				"once": "^1.4.0",
+				"peer-id": "~0.10.2",
+				"peer-info": "~0.11.0",
+				"promisify-es6": "^1.0.3",
+				"pump": "^1.0.2",
+				"qs": "^6.5.1",
+				"readable-stream": "^2.3.3",
+				"stream-http": "^2.7.2",
+				"streamifier": "^0.1.1",
+				"tar-stream": "^1.5.4"
 			},
 			"dependencies": {
 				"base-x": {
@@ -5697,7 +5836,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -5705,7 +5844,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				},
 				"glob": {
@@ -5713,12 +5852,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -5728,7 +5867,7 @@
 			"resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
 			"integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
 			"requires": {
-				"cids": "0.5.2"
+				"cids": "^0.5.2"
 			}
 		},
 		"ipfs-unixfs": {
@@ -5736,7 +5875,7 @@
 			"resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.14.tgz",
 			"integrity": "sha512-s1tEnwKhdd17MmyC/EUMNVMDYzKhCiHDI11TF8tSBeWkEQp+0WUxkYuqvz0R5TSi2lNDJ/oVnEmwWhki2spUiQ==",
 			"requires": {
-				"protons": "1.0.1"
+				"protons": "^1.0.0"
 			}
 		},
 		"ipld-dag-pb": {
@@ -5744,18 +5883,18 @@
 			"resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.11.4.tgz",
 			"integrity": "sha512-A514Bt4z44bxhPQVzmBFMJsV3res92eBaDX0snzVsLLasBPNh4Z7He8N2mwSeAX9bJNywRBlJbHMQPwC45rqXw==",
 			"requires": {
-				"async": "2.6.0",
-				"bs58": "4.0.1",
+				"async": "^2.6.0",
+				"bs58": "^4.0.1",
 				"buffer-loader": "0.0.1",
-				"cids": "0.5.2",
-				"ipfs-block": "0.6.1",
-				"is-ipfs": "0.3.2",
-				"multihashes": "0.4.13",
-				"multihashing-async": "0.4.8",
-				"protons": "1.0.1",
-				"pull-stream": "3.6.2",
-				"pull-traverse": "1.0.3",
-				"stable": "0.1.6"
+				"cids": "~0.5.2",
+				"ipfs-block": "~0.6.1",
+				"is-ipfs": "~0.3.2",
+				"multihashes": "~0.4.12",
+				"multihashing-async": "~0.4.7",
+				"protons": "^1.0.0",
+				"pull-stream": "^3.6.1",
+				"pull-traverse": "^1.0.3",
+				"stable": "^0.1.6"
 			},
 			"dependencies": {
 				"base-x": {
@@ -5763,7 +5902,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -5771,7 +5910,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -5781,11 +5920,11 @@
 			"resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
 			"integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
 			"requires": {
-				"attempt-x": "1.1.3",
-				"has-to-string-tag-x": "1.4.1",
-				"is-object-like-x": "1.7.1",
-				"object-get-own-property-descriptor-x": "3.2.0",
-				"to-string-tag-x": "1.4.3"
+				"attempt-x": "^1.1.0",
+				"has-to-string-tag-x": "^1.4.1",
+				"is-object-like-x": "^1.5.1",
+				"object-get-own-property-descriptor-x": "^3.2.0",
+				"to-string-tag-x": "^1.4.1"
 			}
 		},
 		"is-arrayish": {
@@ -5798,7 +5937,7 @@
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"requires": {
-				"binary-extensions": "1.10.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -5811,7 +5950,7 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -5834,7 +5973,7 @@
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -5852,7 +5991,7 @@
 			"resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.3.tgz",
 			"integrity": "sha512-RWjusR6LXAhGa0Vus7aD1rwJuJwdJsvG3daAVMDvOAgvGuGm4eilNgoSuXhpv2/2qpLDvioAKTNb3t3XYidCNg==",
 			"requires": {
-				"to-boolean-x": "1.0.3"
+				"to-boolean-x": "^1.0.2"
 			}
 		},
 		"is-finite": {
@@ -5860,7 +5999,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-finite-x": {
@@ -5868,8 +6007,8 @@
 			"resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.4.tgz",
 			"integrity": "sha512-wdSI5zk/Pl21HzGcLWFoFzuDa8gsgcqhwZGAZryL2eU7RKf7+g+q4jL2gGItrBs/YtspkjOrJ4JxXNZqquoAWA==",
 			"requires": {
-				"infinity-x": "1.0.2",
-				"is-nan-x": "1.0.3"
+				"infinity-x": "^1.0.1",
+				"is-nan-x": "^1.0.2"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -5877,7 +6016,7 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-function": {
@@ -5890,14 +6029,14 @@
 			"resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
 			"integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
 			"requires": {
-				"attempt-x": "1.1.3",
-				"has-to-string-tag-x": "1.4.1",
-				"is-falsey-x": "1.0.3",
-				"is-primitive": "2.0.0",
-				"normalize-space-x": "3.0.0",
-				"replace-comments-x": "2.0.0",
-				"to-boolean-x": "1.0.3",
-				"to-string-tag-x": "1.4.3"
+				"attempt-x": "^1.1.1",
+				"has-to-string-tag-x": "^1.4.1",
+				"is-falsey-x": "^1.0.1",
+				"is-primitive": "^2.0.0",
+				"normalize-space-x": "^3.0.0",
+				"replace-comments-x": "^2.0.0",
+				"to-boolean-x": "^1.0.1",
+				"to-string-tag-x": "^1.4.2"
 			}
 		},
 		"is-glob": {
@@ -5905,7 +6044,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-hex-prefixed": {
@@ -5918,11 +6057,11 @@
 			"resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
 			"integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
 			"requires": {
-				"math-clamp-x": "1.2.0",
-				"max-safe-integer": "1.0.1",
-				"to-integer-x": "3.0.0",
-				"to-number-x": "2.0.0",
-				"to-string-symbols-supported-x": "1.0.2"
+				"math-clamp-x": "^1.2.0",
+				"max-safe-integer": "^1.0.1",
+				"to-integer-x": "^3.0.0",
+				"to-number-x": "^2.0.0",
+				"to-string-symbols-supported-x": "^1.0.0"
 			}
 		},
 		"is-ipfs": {
@@ -5930,9 +6069,9 @@
 			"resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.3.2.tgz",
 			"integrity": "sha512-82V1j4LMkYy7H4seQQzOWqo7FiW3I64/1/ryo3dhtWKfOvm7ZolLMRQQfGKs4OXWauh5rAkPnamVcRISHwhmpQ==",
 			"requires": {
-				"bs58": "4.0.1",
-				"cids": "0.5.2",
-				"multihashes": "0.4.13"
+				"bs58": "^4.0.1",
+				"cids": "~0.5.1",
+				"multihashes": "~0.4.9"
 			},
 			"dependencies": {
 				"base-x": {
@@ -5940,7 +6079,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -5948,7 +6087,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -5968,8 +6107,8 @@
 			"resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
 			"integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
 			"requires": {
-				"lodash.isnull": "3.0.0",
-				"validate.io-undefined": "1.0.3"
+				"lodash.isnull": "^3.0.0",
+				"validate.io-undefined": "^1.0.3"
 			}
 		},
 		"is-number": {
@@ -5977,7 +6116,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-object": {
@@ -5990,8 +6129,8 @@
 			"resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.7.1.tgz",
 			"integrity": "sha512-89nz+kESAW2Y7udq+PdRX/dZnRN2WP1b19Gdv4OYE1Xjoekn1xf31l0ZPzT40qdPD7I2nveNFm9rxxI0vmnGHA==",
 			"requires": {
-				"is-function-x": "3.3.0",
-				"is-primitive": "3.0.0"
+				"is-function-x": "^3.3.0",
+				"is-primitive": "^3.0.0"
 			},
 			"dependencies": {
 				"is-primitive": {
@@ -6006,7 +6145,7 @@
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 			"requires": {
-				"symbol-observable": "0.2.4"
+				"symbol-observable": "^0.2.2"
 			},
 			"dependencies": {
 				"symbol-observable": {
@@ -6041,7 +6180,7 @@
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-retry-allowed": {
@@ -6054,7 +6193,7 @@
 			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
 			"requires": {
-				"scoped-regex": "1.0.0"
+				"scoped-regex": "^1.0.0"
 			}
 		},
 		"is-stream": {
@@ -6110,8 +6249,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -6124,20 +6263,20 @@
 			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
 			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
 			"requires": {
-				"abbrev": "1.0.9",
-				"async": "1.5.2",
-				"escodegen": "1.8.1",
-				"esprima": "2.7.3",
-				"glob": "5.0.15",
-				"handlebars": "4.0.11",
-				"js-yaml": "3.11.0",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"once": "1.4.0",
-				"resolve": "1.1.7",
-				"supports-color": "3.2.3",
-				"which": "1.3.0",
-				"wordwrap": "1.0.0"
+				"abbrev": "1.0.x",
+				"async": "1.x",
+				"escodegen": "1.8.x",
+				"esprima": "2.7.x",
+				"glob": "^5.0.15",
+				"handlebars": "^4.0.1",
+				"js-yaml": "3.x",
+				"mkdirp": "0.5.x",
+				"nopt": "3.x",
+				"once": "1.x",
+				"resolve": "1.1.x",
+				"supports-color": "^3.1.0",
+				"which": "^1.1.1",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
 				"async": {
@@ -6155,7 +6294,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				},
 				"wordwrap": {
@@ -6170,9 +6309,9 @@
 			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
 			"requires": {
-				"binaryextensions": "2.1.1",
-				"editions": "1.3.4",
-				"textextensions": "2.2.0"
+				"binaryextensions": "2",
+				"editions": "^1.3.3",
+				"textextensions": "2"
 			}
 		},
 		"isurl": {
@@ -6180,8 +6319,8 @@
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"requires": {
-				"has-to-string-tag-x": "1.4.1",
-				"is-object": "1.0.1"
+				"has-to-string-tag-x": "^1.2.0",
+				"is-object": "^1.0.1"
 			}
 		},
 		"jade": {
@@ -6210,7 +6349,7 @@
 			"resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
 			"integrity": "sha1-emK3AbRhbnCtDN5URiequ5nX/jk=",
 			"requires": {
-				"generic-pool": "2.0.4"
+				"generic-pool": "~2.0.4"
 			}
 		},
 		"js-sha3": {
@@ -6233,8 +6372,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -6255,21 +6394,21 @@
 			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.0.tgz",
 			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-preset-es2015": "6.24.1",
-				"babel-preset-stage-1": "6.24.1",
-				"babel-register": "6.26.0",
-				"babylon": "7.0.0-beta.46",
-				"colors": "1.1.2",
-				"flow-parser": "0.70.0",
-				"lodash": "4.17.4",
-				"micromatch": "2.3.11",
-				"neo-async": "2.5.1",
+				"babel-plugin-transform-flow-strip-types": "^6.8.0",
+				"babel-preset-es2015": "^6.9.0",
+				"babel-preset-stage-1": "^6.5.0",
+				"babel-register": "^6.9.0",
+				"babylon": "^7.0.0-beta.30",
+				"colors": "^1.1.2",
+				"flow-parser": "^0.*",
+				"lodash": "^4.13.1",
+				"micromatch": "^2.3.7",
+				"neo-async": "^2.5.0",
 				"node-dir": "0.1.8",
-				"nomnom": "1.8.1",
-				"recast": "0.14.7",
-				"temp": "0.8.3",
-				"write-file-atomic": "1.3.4"
+				"nomnom": "^1.8.1",
+				"recast": "^0.14.1",
+				"temp": "^0.8.1",
+				"write-file-atomic": "^1.2.0"
 			},
 			"dependencies": {
 				"babylon": {
@@ -6314,7 +6453,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -6337,7 +6476,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsonify": {
@@ -6361,11 +6500,11 @@
 			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
 			"integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
 			"requires": {
-				"bindings": "1.3.0",
-				"inherits": "2.0.3",
-				"nan": "2.7.0",
-				"prebuild-install": "2.3.0",
-				"safe-buffer": "5.1.1"
+				"bindings": "^1.2.1",
+				"inherits": "^2.0.3",
+				"nan": "^2.2.1",
+				"prebuild-install": "^2.0.0",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"keccakjs": {
@@ -6373,8 +6512,8 @@
 			"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
 			"integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
 			"requires": {
-				"browserify-sha3": "0.0.1",
-				"sha3": "1.2.0"
+				"browserify-sha3": "^0.0.1",
+				"sha3": "^1.1.0"
 			}
 		},
 		"keypair": {
@@ -6395,7 +6534,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"klaw": {
@@ -6403,7 +6542,7 @@
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.9"
 			}
 		},
 		"lazy-cache": {
@@ -6416,7 +6555,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"left-pad": {
@@ -6434,7 +6573,7 @@
 			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
 			"integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
 			"requires": {
-				"errno": "0.1.4"
+				"errno": "~0.1.1"
 			}
 		},
 		"level-iterator-stream": {
@@ -6442,10 +6581,10 @@
 			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
 			"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
 			"requires": {
-				"inherits": "2.0.3",
-				"level-errors": "1.1.2",
-				"readable-stream": "1.1.14",
-				"xtend": "4.0.1"
+				"inherits": "^2.0.1",
+				"level-errors": "^1.0.3",
+				"readable-stream": "^1.0.33",
+				"xtend": "^4.0.0"
 			},
 			"dependencies": {
 				"isarray": {
@@ -6458,7 +6597,7 @@
 					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
 					"integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
 					"requires": {
-						"errno": "0.1.4"
+						"errno": "~0.1.1"
 					}
 				},
 				"readable-stream": {
@@ -6466,10 +6605,10 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -6484,7 +6623,7 @@
 			"resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
 			"integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
 			"requires": {
-				"ltgt": "2.2.0"
+				"ltgt": "^2.1.2"
 			}
 		},
 		"level-sublevel": {
@@ -6492,13 +6631,13 @@
 			"resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
 			"integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
 			"requires": {
-				"bytewise": "1.1.0",
-				"levelup": "0.19.1",
-				"ltgt": "2.1.3",
-				"pull-level": "2.0.4",
-				"pull-stream": "3.6.2",
-				"typewiselite": "1.0.0",
-				"xtend": "4.0.1"
+				"bytewise": "~1.1.0",
+				"levelup": "~0.19.0",
+				"ltgt": "~2.1.1",
+				"pull-level": "^2.0.3",
+				"pull-stream": "^3.4.5",
+				"typewiselite": "~1.0.0",
+				"xtend": "~4.0.0"
 			},
 			"dependencies": {
 				"abstract-leveldown": {
@@ -6506,7 +6645,7 @@
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
 					"integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
 					"requires": {
-						"xtend": "3.0.0"
+						"xtend": "~3.0.0"
 					},
 					"dependencies": {
 						"xtend": {
@@ -6521,7 +6660,7 @@
 					"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
 					"integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
 					"requires": {
-						"readable-stream": "1.0.34"
+						"readable-stream": "~1.0.26"
 					}
 				},
 				"deferred-leveldown": {
@@ -6529,7 +6668,7 @@
 					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
 					"integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
 					"requires": {
-						"abstract-leveldown": "0.12.4"
+						"abstract-leveldown": "~0.12.1"
 					}
 				},
 				"isarray": {
@@ -6542,13 +6681,13 @@
 					"resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
 					"integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
 					"requires": {
-						"bl": "0.8.2",
-						"deferred-leveldown": "0.2.0",
-						"errno": "0.1.4",
-						"prr": "0.0.0",
-						"readable-stream": "1.0.34",
-						"semver": "5.1.1",
-						"xtend": "3.0.0"
+						"bl": "~0.8.1",
+						"deferred-leveldown": "~0.2.0",
+						"errno": "~0.1.1",
+						"prr": "~0.0.0",
+						"readable-stream": "~1.0.26",
+						"semver": "~5.1.0",
+						"xtend": "~3.0.0"
 					},
 					"dependencies": {
 						"xtend": {
@@ -6568,10 +6707,10 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"semver": {
@@ -6591,8 +6730,8 @@
 			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
 			"integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
 			"requires": {
-				"readable-stream": "1.0.34",
-				"xtend": "2.1.2"
+				"readable-stream": "~1.0.15",
+				"xtend": "~2.1.1"
 			},
 			"dependencies": {
 				"isarray": {
@@ -6605,10 +6744,10 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -6621,7 +6760,7 @@
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
 					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
 					"requires": {
-						"object-keys": "0.4.0"
+						"object-keys": "~0.4.0"
 					}
 				}
 			}
@@ -6631,13 +6770,13 @@
 			"resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
 			"integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
 			"requires": {
-				"deferred-leveldown": "1.2.2",
-				"level-codec": "7.0.1",
-				"level-errors": "1.0.5",
-				"level-iterator-stream": "1.3.1",
-				"prr": "1.0.1",
-				"semver": "5.4.1",
-				"xtend": "4.0.1"
+				"deferred-leveldown": "~1.2.1",
+				"level-codec": "~7.0.0",
+				"level-errors": "~1.0.3",
+				"level-iterator-stream": "~1.3.0",
+				"prr": "~1.0.1",
+				"semver": "~5.4.1",
+				"xtend": "~4.0.0"
 			},
 			"dependencies": {
 				"prr": {
@@ -6652,8 +6791,8 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"libp2p-crypto": {
@@ -6661,18 +6800,18 @@
 			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
 			"integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
 			"requires": {
-				"asn1.js": "5.0.0",
-				"async": "2.6.0",
-				"browserify-aes": "1.1.1",
-				"bs58": "4.0.1",
-				"keypair": "1.0.1",
-				"libp2p-crypto-secp256k1": "0.2.2",
-				"multihashing-async": "0.4.8",
-				"node-forge": "0.7.3",
-				"pem-jwk": "1.5.1",
-				"protons": "1.0.1",
-				"rsa-pem-to-jwk": "1.1.3",
-				"tweetnacl": "1.0.0",
+				"asn1.js": "^5.0.0",
+				"async": "^2.6.0",
+				"browserify-aes": "^1.1.1",
+				"bs58": "^4.0.1",
+				"keypair": "^1.0.1",
+				"libp2p-crypto-secp256k1": "~0.2.2",
+				"multihashing-async": "~0.4.7",
+				"node-forge": "^0.7.1",
+				"pem-jwk": "^1.5.1",
+				"protons": "^1.0.1",
+				"rsa-pem-to-jwk": "^1.1.3",
+				"tweetnacl": "^1.0.0",
 				"webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
 			},
 			"dependencies": {
@@ -6681,9 +6820,9 @@
 					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
 					"integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
 					"requires": {
-						"bn.js": "4.11.8",
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.0"
+						"bn.js": "^4.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"base-x": {
@@ -6691,7 +6830,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -6699,7 +6838,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				},
 				"tweetnacl": {
@@ -6708,7 +6847,8 @@
 					"integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
 				},
 				"webcrypto-shim": {
-					"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+					"version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+					"from": "webcrypto-shim@github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
 				}
 			}
 		},
@@ -6717,11 +6857,11 @@
 			"resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
 			"integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
 			"requires": {
-				"async": "2.6.0",
-				"multihashing-async": "0.4.8",
-				"nodeify": "1.0.1",
-				"safe-buffer": "5.1.1",
-				"secp256k1": "3.3.1"
+				"async": "^2.5.0",
+				"multihashing-async": "~0.4.6",
+				"nodeify": "^1.0.1",
+				"safe-buffer": "^5.1.1",
+				"secp256k1": "^3.3.0"
 			}
 		},
 		"listr": {
@@ -6729,23 +6869,23 @@
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
 			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"figures": "1.7.0",
-				"indent-string": "2.1.0",
-				"is-observable": "0.2.0",
-				"is-promise": "2.1.0",
-				"is-stream": "1.1.0",
-				"listr-silent-renderer": "1.1.1",
-				"listr-update-renderer": "0.4.0",
-				"listr-verbose-renderer": "0.4.1",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"ora": "0.2.3",
-				"p-map": "1.2.0",
-				"rxjs": "5.5.10",
-				"stream-to-observable": "0.2.0",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"figures": "^1.7.0",
+				"indent-string": "^2.1.0",
+				"is-observable": "^0.2.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.4.0",
+				"listr-verbose-renderer": "^0.4.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"ora": "^0.2.3",
+				"p-map": "^1.1.1",
+				"rxjs": "^5.4.2",
+				"stream-to-observable": "^0.2.0",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -6753,8 +6893,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"is-promise": {
@@ -6767,7 +6907,7 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				}
 			}
@@ -6782,14 +6922,14 @@
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"elegant-spinner": "1.0.1",
-				"figures": "1.7.0",
-				"indent-string": "3.2.0",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -6797,8 +6937,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"indent-string": {
@@ -6811,7 +6951,7 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				}
 			}
@@ -6821,10 +6961,10 @@
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
+				"chalk": "^1.1.3",
+				"cli-cursor": "^1.0.2",
+				"date-fns": "^1.27.2",
+				"figures": "^1.7.0"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -6832,7 +6972,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -6840,8 +6980,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"onetime": {
@@ -6854,8 +6994,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -6865,10 +7005,10 @@
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"loader-runner": {
@@ -6881,9 +7021,9 @@
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"requires": {
-				"big.js": "3.2.0",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0"
 			}
 		},
 		"localstorage-down": {
@@ -6893,10 +7033,10 @@
 			"requires": {
 				"abstract-leveldown": "0.12.3",
 				"argsarray": "0.0.1",
-				"buffer-from": "0.1.1",
-				"d64": "1.0.0",
-				"humble-localstorage": "1.4.2",
-				"inherits": "2.0.3",
+				"buffer-from": "^0.1.1",
+				"d64": "^1.0.0",
+				"humble-localstorage": "^1.4.2",
+				"inherits": "^2.0.1",
 				"tiny-queue": "0.2.0"
 			},
 			"dependencies": {
@@ -6905,7 +7045,7 @@
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
 					"integrity": "sha1-EWsexcdxDvei1XBnaLvbREC+EHA=",
 					"requires": {
-						"xtend": "3.0.0"
+						"xtend": "~3.0.0"
 					}
 				},
 				"xtend": {
@@ -6925,8 +7065,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -6939,8 +7079,8 @@
 			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._basecopy": {
@@ -6973,9 +7113,9 @@
 			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
 			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._basecreate": "3.0.3",
-				"lodash._isiterateecall": "3.0.9"
+				"lodash._baseassign": "^3.0.0",
+				"lodash._basecreate": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0"
 			}
 		},
 		"lodash.filter": {
@@ -7003,9 +7143,9 @@
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lodash.map": {
@@ -7023,7 +7163,7 @@
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"requires": {
-				"chalk": "2.4.0"
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7031,7 +7171,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7039,9 +7179,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
 					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -7054,7 +7194,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -7064,8 +7204,8 @@
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
+				"ansi-escapes": "^1.0.0",
+				"cli-cursor": "^1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -7078,7 +7218,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -7091,8 +7231,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -7112,7 +7252,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -7125,8 +7265,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"ltgt": {
@@ -7139,7 +7279,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -7154,7 +7294,7 @@
 			"resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
 			"integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
 			"requires": {
-				"to-number-x": "2.0.0"
+				"to-number-x": "^2.0.0"
 			}
 		},
 		"math-sign-x": {
@@ -7162,8 +7302,8 @@
 			"resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
 			"integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
 			"requires": {
-				"is-nan-x": "1.0.3",
-				"to-number-x": "2.0.0"
+				"is-nan-x": "^1.0.1",
+				"to-number-x": "^2.0.0"
 			}
 		},
 		"max-safe-integer": {
@@ -7176,8 +7316,8 @@
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			},
 			"dependencies": {
 				"hash-base": {
@@ -7185,8 +7325,8 @@
 					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.1"
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				}
 			}
@@ -7201,7 +7341,7 @@
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"mem-fs": {
@@ -7209,9 +7349,9 @@
 			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
 			"requires": {
-				"through2": "2.0.3",
-				"vinyl": "1.2.0",
-				"vinyl-file": "2.0.0"
+				"through2": "^2.0.0",
+				"vinyl": "^1.1.0",
+				"vinyl-file": "^2.0.0"
 			}
 		},
 		"mem-fs-editor": {
@@ -7219,16 +7359,16 @@
 			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
 			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
 			"requires": {
-				"commondir": "1.0.1",
-				"deep-extend": "0.4.2",
-				"ejs": "2.5.9",
-				"glob": "7.1.2",
-				"globby": "6.1.0",
-				"mkdirp": "0.5.1",
-				"multimatch": "2.1.0",
-				"rimraf": "2.6.2",
-				"through2": "2.0.3",
-				"vinyl": "2.1.0"
+				"commondir": "^1.0.1",
+				"deep-extend": "^0.4.0",
+				"ejs": "^2.3.1",
+				"glob": "^7.0.3",
+				"globby": "^6.1.0",
+				"mkdirp": "^0.5.0",
+				"multimatch": "^2.0.0",
+				"rimraf": "^2.2.8",
+				"through2": "^2.0.0",
+				"vinyl": "^2.0.1"
 			},
 			"dependencies": {
 				"clone-stats": {
@@ -7241,12 +7381,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"replace-ext": {
@@ -7259,12 +7399,12 @@
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
 					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
 					"requires": {
-						"clone": "2.1.1",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -7274,12 +7414,12 @@
 			"resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
 			"integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
 			"requires": {
-				"abstract-leveldown": "2.7.2",
-				"functional-red-black-tree": "1.0.1",
-				"immediate": "3.2.3",
-				"inherits": "2.0.3",
-				"ltgt": "2.2.0",
-				"safe-buffer": "5.1.1"
+				"abstract-leveldown": "~2.7.1",
+				"functional-red-black-tree": "^1.0.1",
+				"immediate": "^3.2.3",
+				"inherits": "~2.0.1",
+				"ltgt": "~2.2.0",
+				"safe-buffer": "~5.1.1"
 			},
 			"dependencies": {
 				"abstract-leveldown": {
@@ -7287,7 +7427,7 @@
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
 					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
 					"requires": {
-						"xtend": "4.0.1"
+						"xtend": "~4.0.0"
 					}
 				}
 			}
@@ -7297,8 +7437,8 @@
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"requires": {
-				"errno": "0.1.4",
-				"readable-stream": "2.3.3"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"memorystream": {
@@ -7316,14 +7456,14 @@
 			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.2.0.tgz",
 			"integrity": "sha1-ekeHsSYqsA/psgSrRxsAUzIwbvo=",
 			"requires": {
-				"async": "1.5.2",
-				"ethereumjs-util": "4.5.0",
+				"async": "^1.4.2",
+				"ethereumjs-util": "^4.0.0",
 				"level-ws": "0.0.0",
-				"levelup": "1.3.9",
-				"memdown": "1.4.1",
-				"readable-stream": "2.3.3",
-				"rlp": "2.0.0",
-				"semaphore": "1.1.0"
+				"levelup": "^1.2.1",
+				"memdown": "^1.0.0",
+				"readable-stream": "^2.0.0",
+				"rlp": "^2.0.0",
+				"semaphore": ">=1.0.1"
 			},
 			"dependencies": {
 				"async": {
@@ -7343,19 +7483,19 @@
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"miller-rabin": {
@@ -7363,8 +7503,8 @@
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"mime": {
@@ -7382,7 +7522,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.30.0"
 			}
 		},
 		"mimic-fn": {
@@ -7400,7 +7540,7 @@
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"requires": {
-				"dom-walk": "0.1.1"
+				"dom-walk": "^0.1.0"
 			}
 		},
 		"minimalistic-assert": {
@@ -7418,7 +7558,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -7439,7 +7579,7 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
 			"integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "*"
 			}
 		},
 		"mocha": {
@@ -7477,8 +7617,8 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
 					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
 					"requires": {
-						"inherits": "2.0.3",
-						"minimatch": "0.3.0"
+						"inherits": "2",
+						"minimatch": "0.3"
 					}
 				},
 				"lru-cache": {
@@ -7491,8 +7631,8 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
 					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
 					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
+						"lru-cache": "2",
+						"sigmund": "~1.0.0"
 					}
 				},
 				"ms": {
@@ -7527,12 +7667,12 @@
 			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.0.2.tgz",
 			"integrity": "sha512-TLEujk9VD1SR8HgV00rr1I3MWOk4t0GSDvxzzOO1m1hfxdv4DkFHmKKUHngUCiWHDeClHKSSV23Ig5/Mav3MQw==",
 			"requires": {
-				"bs58": "4.0.1",
-				"ip": "1.1.5",
-				"lodash.filter": "4.6.0",
-				"lodash.map": "4.6.0",
-				"varint": "5.0.0",
-				"xtend": "4.0.1"
+				"bs58": "^4.0.1",
+				"ip": "^1.1.5",
+				"lodash.filter": "^4.6.0",
+				"lodash.map": "^4.6.0",
+				"varint": "^5.0.0",
+				"xtend": "^4.0.1"
 			},
 			"dependencies": {
 				"base-x": {
@@ -7540,7 +7680,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -7548,7 +7688,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -7573,7 +7713,7 @@
 			"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.6.tgz",
 			"integrity": "sha512-VGyRUDkxdJzWnj9x3C49MzI3+TtKKDYNfIBOaWBCNuPk6CE5CwwkL15gJtsLDfLay0fL4xTh4Af3kBbJSxSppw==",
 			"requires": {
-				"varint": "5.0.0"
+				"varint": "^5.0.0"
 			}
 		},
 		"multihashes": {
@@ -7581,8 +7721,8 @@
 			"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
 			"integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
 			"requires": {
-				"bs58": "4.0.1",
-				"varint": "5.0.0"
+				"bs58": "^4.0.1",
+				"varint": "^5.0.0"
 			},
 			"dependencies": {
 				"base-x": {
@@ -7590,7 +7730,7 @@
 					"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
 					"integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"bs58": {
@@ -7598,7 +7738,7 @@
 					"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
 					"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
 					"requires": {
-						"base-x": "3.0.4"
+						"base-x": "^3.0.2"
 					}
 				}
 			}
@@ -7608,12 +7748,12 @@
 			"resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
 			"integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
 			"requires": {
-				"async": "2.6.0",
-				"blakejs": "1.1.0",
-				"js-sha3": "0.7.0",
-				"multihashes": "0.4.13",
-				"murmurhash3js": "3.0.1",
-				"nodeify": "1.0.1"
+				"async": "^2.6.0",
+				"blakejs": "^1.1.0",
+				"js-sha3": "^0.7.0",
+				"multihashes": "~0.4.13",
+				"murmurhash3js": "^3.0.1",
+				"nodeify": "^1.0.1"
 			},
 			"dependencies": {
 				"js-sha3": {
@@ -7628,10 +7768,10 @@
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"multipart-stream": {
@@ -7639,9 +7779,9 @@
 			"resolved": "https://registry.npmjs.org/multipart-stream/-/multipart-stream-2.0.1.tgz",
 			"integrity": "sha1-GVyctLLEHnjHKh6POMfQ66HNC6A=",
 			"requires": {
-				"inherits": "2.0.3",
-				"is-stream": "1.1.0",
-				"sandwich-stream": "1.0.0"
+				"inherits": "^2.0.1",
+				"is-stream": "^1.0.1",
+				"sandwich-stream": "^1.0.0"
 			}
 		},
 		"murmurhash3js": {
@@ -7659,9 +7799,9 @@
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
 			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
 			"requires": {
-				"any-promise": "1.3.0",
-				"object-assign": "4.1.1",
-				"thenify-all": "1.6.0"
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
 			}
 		},
 		"nan": {
@@ -7684,10 +7824,10 @@
 			"resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
 			"integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
 			"requires": {
-				"json-stringify-safe": "5.0.1",
-				"minimist": "1.2.0",
-				"split2": "2.2.0",
-				"through2": "2.0.3"
+				"json-stringify-safe": "^5.0.1",
+				"minimist": "^1.2.0",
+				"split2": "^2.1.0",
+				"through2": "^2.0.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -7717,7 +7857,7 @@
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
 			"integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
 			"requires": {
-				"semver": "5.4.1"
+				"semver": "^5.4.1"
 			}
 		},
 		"node-dir": {
@@ -7730,8 +7870,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-forge": {
@@ -7744,28 +7884,28 @@
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
 			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.12.0",
-				"domain-browser": "1.1.7",
-				"events": "1.1.1",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.1.4",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
 				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
+				"os-browserify": "^0.2.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.3",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
-				"timers-browserify": "2.0.4",
+				"process": "^0.11.0",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.0.5",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.3.1",
+				"string_decoder": "^0.10.25",
+				"timers-browserify": "^2.0.2",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -7781,8 +7921,8 @@
 			"resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
 			"integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
 			"requires": {
-				"is-promise": "1.0.1",
-				"promise": "1.3.0"
+				"is-promise": "~1.0.0",
+				"promise": "~1.3.0"
 			}
 		},
 		"nomnom": {
@@ -7790,8 +7930,8 @@
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 			"requires": {
-				"chalk": "0.4.0",
-				"underscore": "1.6.0"
+				"chalk": "~0.4.0",
+				"underscore": "~1.6.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7804,9 +7944,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -7831,7 +7971,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1.0.9"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -7839,10 +7979,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -7850,7 +7990,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"normalize-space-x": {
@@ -7858,9 +7998,9 @@
 			"resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
 			"integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"trim-x": "3.0.0",
-				"white-space-x": "3.0.1"
+				"cached-constructors-x": "^1.0.0",
+				"trim-x": "^3.0.0",
+				"white-space-x": "^3.0.0"
 			}
 		},
 		"normalize-url": {
@@ -7868,9 +8008,9 @@
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
 			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
 			"requires": {
-				"prepend-http": "2.0.0",
-				"query-string": "5.1.0",
-				"sort-keys": "2.0.0"
+				"prepend-http": "^2.0.0",
+				"query-string": "^5.0.1",
+				"sort-keys": "^2.0.0"
 			},
 			"dependencies": {
 				"prepend-http": {
@@ -7885,7 +8025,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"npmlog": {
@@ -7893,10 +8033,10 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"requires": {
-				"are-we-there-yet": "1.1.4",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -7935,16 +8075,16 @@
 			"resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
 			"integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
 			"requires": {
-				"attempt-x": "1.1.3",
-				"has-own-property-x": "3.2.0",
-				"has-symbol-support-x": "1.4.2",
-				"is-falsey-x": "1.0.3",
-				"is-index-x": "1.1.0",
-				"is-primitive": "2.0.0",
-				"is-string": "1.0.4",
-				"property-is-enumerable-x": "1.1.0",
-				"to-object-x": "1.5.0",
-				"to-property-key-x": "2.0.2"
+				"attempt-x": "^1.1.0",
+				"has-own-property-x": "^3.1.1",
+				"has-symbol-support-x": "^1.4.1",
+				"is-falsey-x": "^1.0.0",
+				"is-index-x": "^1.0.0",
+				"is-primitive": "^2.0.0",
+				"is-string": "^1.0.4",
+				"property-is-enumerable-x": "^1.1.0",
+				"to-object-x": "^1.4.1",
+				"to-property-key-x": "^2.0.1"
 			}
 		},
 		"object-inspect": {
@@ -7962,8 +8102,8 @@
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"oboe": {
@@ -7971,7 +8111,7 @@
 			"resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
 			"integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
 			"requires": {
-				"http-https": "1.0.0"
+				"http-https": "^1.0.0"
 			}
 		},
 		"on-build-webpack": {
@@ -7992,7 +8132,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -8000,7 +8140,7 @@
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optimist": {
@@ -8008,8 +8148,8 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.2"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
@@ -8017,12 +8157,12 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -8037,10 +8177,10 @@
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-spinners": "0.1.2",
-				"object-assign": "4.1.1"
+				"chalk": "^1.1.1",
+				"cli-cursor": "^1.0.2",
+				"cli-spinners": "^0.1.2",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -8048,7 +8188,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -8061,8 +8201,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -8087,9 +8227,9 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -8102,9 +8242,9 @@
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
+				"graceful-fs": "^4.1.4",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"p-cancelable": {
@@ -8117,7 +8257,7 @@
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"requires": {
-				"p-reduce": "1.0.0"
+				"p-reduce": "^1.0.0"
 			}
 		},
 		"p-finally": {
@@ -8145,7 +8285,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -8163,7 +8303,7 @@
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 			"requires": {
-				"p-finally": "1.0.0"
+				"p-finally": "^1.0.0"
 			}
 		},
 		"pako": {
@@ -8176,22 +8316,27 @@
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"requires": {
-				"asn1.js": "4.9.2",
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.14"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
+		},
+		"parse-cache-control": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+			"integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-headers": {
@@ -8199,7 +8344,7 @@
 			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
 			"integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
 			"requires": {
-				"for-each": "0.3.2",
+				"for-each": "^0.3.2",
 				"trim": "0.0.1"
 			}
 		},
@@ -8208,10 +8353,10 @@
 			"resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
 			"integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"nan-x": "1.0.2",
-				"to-string-x": "1.4.5",
-				"trim-left-x": "3.0.0"
+				"cached-constructors-x": "^1.0.0",
+				"nan-x": "^1.0.0",
+				"to-string-x": "^1.4.2",
+				"trim-left-x": "^3.0.0"
 			}
 		},
 		"parse-json": {
@@ -8219,7 +8364,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse-passwd": {
@@ -8267,7 +8412,7 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 			"requires": {
-				"pify": "2.3.0"
+				"pify": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
@@ -8275,11 +8420,11 @@
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
 			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
 			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"peer-id": {
@@ -8287,10 +8432,10 @@
 			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.6.tgz",
 			"integrity": "sha512-NyJgPRy108amQClcuBI/VZtyFJLDaTsPC3nVhZ87mpY5JVFmI2Er4atMap6/ToRJxm/RBX1Nh8CMxzlXCpfKKw==",
 			"requires": {
-				"async": "2.6.0",
-				"libp2p-crypto": "0.12.1",
-				"lodash": "4.17.5",
-				"multihashes": "0.4.13"
+				"async": "^2.6.0",
+				"libp2p-crypto": "~0.12.1",
+				"lodash": "^4.17.5",
+				"multihashes": "~0.4.13"
 			},
 			"dependencies": {
 				"lodash": {
@@ -8305,9 +8450,9 @@
 			"resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
 			"integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
 			"requires": {
-				"lodash.uniqby": "4.7.0",
-				"multiaddr": "3.0.2",
-				"peer-id": "0.10.6"
+				"lodash.uniqby": "^4.7.0",
+				"multiaddr": "^3.0.2",
+				"peer-id": "~0.10.5"
 			}
 		},
 		"pegjs": {
@@ -8328,9 +8473,9 @@
 					"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
 					"integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
 					"requires": {
-						"bn.js": "1.3.0",
-						"inherits": "2.0.3",
-						"minimalistic-assert": "1.0.0"
+						"bn.js": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"bn.js": {
@@ -8366,7 +8511,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -8374,7 +8519,7 @@
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 			"requires": {
-				"find-up": "1.1.2"
+				"find-up": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -8382,8 +8527,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -8391,7 +8536,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -8401,19 +8546,19 @@
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
 			"integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
 			"requires": {
-				"expand-template": "1.1.0",
+				"expand-template": "^1.0.2",
 				"github-from-package": "0.0.0",
-				"minimist": "1.2.0",
-				"mkdirp": "0.5.1",
-				"node-abi": "2.1.2",
-				"noop-logger": "0.1.1",
-				"npmlog": "4.1.2",
-				"os-homedir": "1.0.2",
-				"pump": "1.0.2",
-				"rc": "1.2.2",
-				"simple-get": "1.4.3",
-				"tar-fs": "1.16.0",
-				"tunnel-agent": "0.6.0",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"node-abi": "^2.1.1",
+				"noop-logger": "^0.1.1",
+				"npmlog": "^4.0.1",
+				"os-homedir": "^1.0.1",
+				"pump": "^1.0.1",
+				"rc": "^1.1.6",
+				"simple-get": "^1.4.2",
+				"tar-fs": "^1.13.0",
+				"tunnel-agent": "^0.6.0",
 				"xtend": "4.0.1"
 			},
 			"dependencies": {
@@ -8477,7 +8622,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
 			"integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
 			"requires": {
-				"is-promise": "1.0.1"
+				"is-promise": "~1"
 			}
 		},
 		"promise-polyfill": {
@@ -8495,8 +8640,8 @@
 			"resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
 			"integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
 			"requires": {
-				"to-object-x": "1.5.0",
-				"to-property-key-x": "2.0.2"
+				"to-object-x": "^1.4.1",
+				"to-property-key-x": "^2.0.1"
 			}
 		},
 		"protocol-buffers-schema": {
@@ -8509,10 +8654,10 @@
 			"resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
 			"integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
 			"requires": {
-				"protocol-buffers-schema": "3.3.2",
-				"safe-buffer": "5.1.1",
-				"signed-varint": "2.0.1",
-				"varint": "5.0.0"
+				"protocol-buffers-schema": "^3.3.1",
+				"safe-buffer": "^5.1.1",
+				"signed-varint": "^2.0.1",
+				"varint": "^5.0.0"
 			}
 		},
 		"proxy-addr": {
@@ -8520,7 +8665,7 @@
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
 			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"requires": {
-				"forwarded": "0.1.2",
+				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.6.0"
 			}
 		},
@@ -8539,11 +8684,11 @@
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"pull-cat": {
@@ -8556,13 +8701,13 @@
 			"resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
 			"integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
 			"requires": {
-				"level-post": "1.0.7",
-				"pull-cat": "1.1.11",
-				"pull-live": "1.0.1",
-				"pull-pushable": "2.2.0",
-				"pull-stream": "3.6.2",
-				"pull-window": "2.1.4",
-				"stream-to-pull-stream": "1.7.2"
+				"level-post": "^1.0.7",
+				"pull-cat": "^1.1.9",
+				"pull-live": "^1.0.1",
+				"pull-pushable": "^2.0.0",
+				"pull-stream": "^3.4.0",
+				"pull-window": "^2.1.4",
+				"stream-to-pull-stream": "^1.7.1"
 			}
 		},
 		"pull-live": {
@@ -8570,8 +8715,8 @@
 			"resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
 			"integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
 			"requires": {
-				"pull-cat": "1.1.11",
-				"pull-stream": "3.6.2"
+				"pull-cat": "^1.1.9",
+				"pull-stream": "^3.4.0"
 			}
 		},
 		"pull-pushable": {
@@ -8594,7 +8739,7 @@
 			"resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
 			"integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
 			"requires": {
-				"looper": "2.0.0"
+				"looper": "^2.0.0"
 			}
 		},
 		"pump": {
@@ -8602,8 +8747,8 @@
 			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
 			"integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
 			"requires": {
-				"end-of-stream": "1.4.0",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"punycode": {
@@ -8621,9 +8766,9 @@
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
 			"integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
 			"requires": {
-				"decode-uri-component": "0.2.0",
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"querystring": {
@@ -8641,8 +8786,8 @@
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -8650,7 +8795,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -8658,7 +8803,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -8668,7 +8813,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -8678,7 +8823,7 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
@@ -8686,8 +8831,8 @@
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
 			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
 			"requires": {
-				"randombytes": "2.0.5",
-				"safe-buffer": "5.1.1"
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomhex": {
@@ -8716,10 +8861,10 @@
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
 			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
 			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.4",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
+				"deep-extend": "~0.4.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -8734,8 +8879,8 @@
 			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
 			"requires": {
-				"pify": "3.0.0",
-				"safe-buffer": "5.1.1"
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.1.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -8750,9 +8895,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "2.0.0"
+				"load-json-file": "^2.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^2.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -8760,8 +8905,8 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
 			}
 		},
 		"readable-stream": {
@@ -8769,13 +8914,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -8783,10 +8928,10 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"recast": {
@@ -8795,9 +8940,9 @@
 			"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
 			"requires": {
 				"ast-types": "0.11.3",
-				"esprima": "4.0.0",
-				"private": "0.1.8",
-				"source-map": "0.6.1"
+				"esprima": "~4.0.0",
+				"private": "~0.1.5",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -8817,7 +8962,7 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.1.7"
+				"resolve": "^1.1.6"
 			}
 		},
 		"regenerate": {
@@ -8835,9 +8980,9 @@
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -8845,7 +8990,7 @@
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regexpu-core": {
@@ -8853,9 +8998,9 @@
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
@@ -8868,7 +9013,7 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -8891,7 +9036,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"replace-comments-x": {
@@ -8899,8 +9044,8 @@
 			"resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
 			"integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
 			"requires": {
-				"require-coercible-to-string-x": "1.0.2",
-				"to-string-x": "1.4.5"
+				"require-coercible-to-string-x": "^1.0.0",
+				"to-string-x": "^1.4.2"
 			}
 		},
 		"replace-ext": {
@@ -8913,7 +9058,7 @@
 			"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
 			"integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
 			"requires": {
-				"req-from": "1.0.1"
+				"req-from": "^1.0.1"
 			}
 		},
 		"req-from": {
@@ -8921,7 +9066,7 @@
 			"resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
 			"integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
 			"requires": {
-				"resolve-from": "2.0.0"
+				"resolve-from": "^2.0.0"
 			}
 		},
 		"request": {
@@ -8929,28 +9074,28 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"uuid": {
@@ -8965,7 +9110,7 @@
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.13.1"
 			}
 		},
 		"request-promise-native": {
@@ -8974,8 +9119,8 @@
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-coercible-to-string-x": {
@@ -8983,8 +9128,8 @@
 			"resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
 			"integrity": "sha512-GZ3BSCL0n/zhho8ITganW9FGPh0Kxhq71nCjck8Qau/30Wf4Po8a3XpQdzEMFiXCwZ/0m0E3lKSdSG8gkcIofQ==",
 			"requires": {
-				"require-object-coercible-x": "1.4.3",
-				"to-string-x": "1.4.5"
+				"require-object-coercible-x": "^1.4.3",
+				"to-string-x": "^1.4.5"
 			}
 		},
 		"require-directory": {
@@ -9007,7 +9152,7 @@
 			"resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.3.tgz",
 			"integrity": "sha512-5wEaS+NIiU5HLJQTqBQ+6XHtX7yplUS374j/H/nRDlc7rMWfENqp026jnUHWAOCZ+ekixkXuFHEnTF28oqqVLA==",
 			"requires": {
-				"is-nil-x": "1.4.2"
+				"is-nil-x": "^1.4.2"
 			}
 		},
 		"resolve": {
@@ -9020,7 +9165,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -9035,8 +9180,8 @@
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"requires": {
-				"expand-tilde": "2.0.2",
-				"global-modules": "1.0.0"
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
 			}
 		},
 		"resolve-from": {
@@ -9049,7 +9194,7 @@
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 			"requires": {
-				"lowercase-keys": "1.0.0"
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"restore-cursor": {
@@ -9057,8 +9202,8 @@
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"resumer": {
@@ -9066,7 +9211,7 @@
 			"resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
 			"integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
 			"requires": {
-				"through": "2.3.8"
+				"through": "~2.3.4"
 			}
 		},
 		"right-align": {
@@ -9074,7 +9219,7 @@
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -9082,7 +9227,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			},
 			"dependencies": {
 				"glob": {
@@ -9090,12 +9235,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -9105,8 +9250,8 @@
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
 			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
+				"hash-base": "^2.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"rlp": {
@@ -9119,7 +9264,7 @@
 			"resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
 			"integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
 			"requires": {
-				"object-assign": "2.1.1",
+				"object-assign": "^2.0.0",
 				"rsa-unpack": "0.0.6"
 			},
 			"dependencies": {
@@ -9135,7 +9280,7 @@
 			"resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
 			"integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
 			"requires": {
-				"optimist": "0.3.7"
+				"optimist": "~0.3.5"
 			},
 			"dependencies": {
 				"optimist": {
@@ -9143,7 +9288,7 @@
 					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
 					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
 					"requires": {
-						"wordwrap": "0.0.2"
+						"wordwrap": "~0.0.2"
 					}
 				}
 			}
@@ -9153,7 +9298,7 @@
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			},
 			"dependencies": {
 				"is-promise": {
@@ -9178,7 +9323,7 @@
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -9209,7 +9354,7 @@
 			"resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
 			"integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
 			"requires": {
-				"nan": "2.7.0"
+				"nan": "^2.0.8"
 			}
 		},
 		"scrypt.js": {
@@ -9217,8 +9362,8 @@
 			"resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
 			"integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
 			"requires": {
-				"scrypt": "6.0.3",
-				"scryptsy": "1.2.1"
+				"scrypt": "^6.0.2",
+				"scryptsy": "^1.2.1"
 			}
 		},
 		"scryptsy": {
@@ -9226,7 +9371,7 @@
 			"resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
 			"integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
 			"requires": {
-				"pbkdf2": "3.0.14"
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"secp256k1": {
@@ -9234,15 +9379,15 @@
 			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
 			"integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
 			"requires": {
-				"bindings": "1.3.0",
-				"bip66": "1.1.5",
-				"bn.js": "4.11.8",
-				"create-hash": "1.1.3",
-				"drbg.js": "1.0.1",
-				"elliptic": "6.4.0",
-				"nan": "2.7.0",
-				"prebuild-install": "2.3.0",
-				"safe-buffer": "5.1.1"
+				"bindings": "^1.2.1",
+				"bip66": "^1.1.3",
+				"bn.js": "^4.11.3",
+				"create-hash": "^1.1.2",
+				"drbg.js": "^1.0.1",
+				"elliptic": "^6.2.3",
+				"nan": "^2.2.1",
+				"prebuild-install": "^2.0.0",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"seedrandom": {
@@ -9255,7 +9400,7 @@
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
 			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
 			"requires": {
-				"commander": "2.8.1"
+				"commander": "~2.8.1"
 			},
 			"dependencies": {
 				"commander": {
@@ -9263,7 +9408,7 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
 					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
 					"requires": {
-						"graceful-readlink": "1.0.1"
+						"graceful-readlink": ">= 1.0.0"
 					}
 				}
 			}
@@ -9284,18 +9429,18 @@
 			"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
 			"requires": {
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
+				"depd": "~1.1.1",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "1.6.2",
+				"http-errors": "~1.6.2",
 				"mime": "1.4.1",
 				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.3.1"
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.3.1"
 			},
 			"dependencies": {
 				"statuses": {
@@ -9310,9 +9455,9 @@
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
 			"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
 			"requires": {
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.2",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
 				"send": "0.16.1"
 			}
 		},
@@ -9321,11 +9466,11 @@
 			"resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
 			"integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
 			"requires": {
-				"body-parser": "1.18.2",
-				"cors": "2.8.4",
-				"express": "4.16.2",
-				"request": "2.83.0",
-				"xhr": "2.4.0"
+				"body-parser": "^1.16.0",
+				"cors": "^2.8.1",
+				"express": "^4.14.0",
+				"request": "^2.79.0",
+				"xhr": "^2.3.3"
 			}
 		},
 		"set-blocking": {
@@ -9353,8 +9498,8 @@
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
 			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"sha3": {
@@ -9362,7 +9507,7 @@
 			"resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.0.tgz",
 			"integrity": "sha1-aYnxtwpJhwWHajc+LGKs6WqpOZo=",
 			"requires": {
-				"nan": "2.7.0"
+				"nan": "^2.0.5"
 			}
 		},
 		"shebang-command": {
@@ -9370,7 +9515,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-loader": {
@@ -9388,9 +9533,9 @@
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.0.4",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			},
 			"dependencies": {
 				"glob": {
@@ -9398,12 +9543,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -9423,7 +9568,7 @@
 			"resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
 			"integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
 			"requires": {
-				"varint": "5.0.0"
+				"varint": "~5.0.0"
 			}
 		},
 		"simple-concat": {
@@ -9436,9 +9581,9 @@
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
 			"integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
 			"requires": {
-				"once": "1.4.0",
-				"unzip-response": "1.0.2",
-				"xtend": "4.0.1"
+				"once": "^1.3.1",
+				"unzip-response": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"slash": {
@@ -9461,7 +9606,7 @@
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"sol-digger": {
@@ -9479,11 +9624,11 @@
 			"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.18.tgz",
 			"integrity": "sha512-Kq+O3PNF9Pfq7fB+lDYAuoqRdghLmZyfngsg0h1Hj38NKAeVHeGPOGeZasn5KqdPeCzbMFvaGyTySxzGv6aXCg==",
 			"requires": {
-				"fs-extra": "0.30.0",
-				"memorystream": "0.3.1",
-				"require-from-string": "1.2.1",
-				"semver": "5.4.1",
-				"yargs": "4.8.1"
+				"fs-extra": "^0.30.0",
+				"memorystream": "^0.3.1",
+				"require-from-string": "^1.1.0",
+				"semver": "^5.3.0",
+				"yargs": "^4.7.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -9496,9 +9641,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -9506,8 +9651,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -9515,11 +9660,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"os-locale": {
@@ -9527,7 +9672,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
@@ -9535,7 +9680,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -9543,9 +9688,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -9553,9 +9698,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9563,8 +9708,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -9572,9 +9717,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -9582,7 +9727,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"which-module": {
@@ -9600,20 +9745,20 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"lodash.assign": "^4.0.3",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.1",
+						"which-module": "^1.0.0",
+						"window-size": "^0.2.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^2.4.1"
 					}
 				},
 				"yargs-parser": {
@@ -9621,8 +9766,8 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "^3.0.0",
+						"lodash.assign": "^4.0.6"
 					}
 				}
 			}
@@ -9632,25 +9777,30 @@
 			"resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.4.3.tgz",
 			"integrity": "sha512-ARsACPfgUgZahaHIiVmuYxkJczKXPDekdxdGMtq+78zCA62eCVpSzth1gyVkv+pVdQ5XOmQ/eRWLOFgNsfvxqA==",
 			"requires": {
-				"death": "1.1.0",
+				"death": "^1.1.0",
 				"ethereumjs-testrpc-sc": "6.0.7",
-				"istanbul": "0.4.5",
-				"keccakjs": "0.2.1",
-				"req-cwd": "1.0.1",
-				"shelljs": "0.7.8",
-				"sol-explore": "1.6.2",
+				"istanbul": "^0.4.5",
+				"keccakjs": "^0.2.1",
+				"req-cwd": "^1.0.1",
+				"shelljs": "^0.7.4",
+				"sol-explore": "^1.6.2",
 				"solidity-parser-sc": "0.4.1",
-				"web3": "0.18.4"
+				"web3": "^0.18.4"
 			}
+		},
+		"solidity-parser-antlr": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz",
+			"integrity": "sha512-g1RWj6m377CBlUBlyffhv4UOO48ue+gL7GlmE9i77N8bxaKgzWvTl1xzvDadaubJoz2euPpk3A7qTPbqkUof1w=="
 		},
 		"solidity-parser-sc": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
 			"integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
 			"requires": {
-				"mocha": "2.5.3",
-				"pegjs": "0.10.0",
-				"yargs": "4.8.1"
+				"mocha": "^2.4.5",
+				"pegjs": "^0.10.0",
+				"yargs": "^4.6.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -9663,9 +9813,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -9673,8 +9823,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -9682,11 +9832,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"os-locale": {
@@ -9694,7 +9844,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
@@ -9702,7 +9852,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -9710,9 +9860,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -9720,9 +9870,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9730,8 +9880,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -9739,9 +9889,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -9749,7 +9899,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"which-module": {
@@ -9767,20 +9917,20 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"lodash.assign": "^4.0.3",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.1",
+						"which-module": "^1.0.0",
+						"window-size": "^0.2.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^2.4.1"
 					}
 				},
 				"yargs-parser": {
@@ -9788,8 +9938,8 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "^3.0.0",
+						"lodash.assign": "^4.0.6"
 					}
 				}
 			}
@@ -9799,15 +9949,16 @@
 			"resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
 			"integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
 			"requires": {
-				"babel-cli": "6.26.0",
-				"babel-preset-es2015": "6.24.1",
-				"babel-register": "6.26.0",
-				"left-pad": "1.1.3",
-				"web3": "0.16.0"
+				"babel-cli": "*",
+				"babel-preset-es2015": "*",
+				"babel-register": "*",
+				"left-pad": "^1.1.1",
+				"web3": "^0.16.0"
 			},
 			"dependencies": {
 				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+					"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 				},
 				"web3": {
 					"version": "0.16.0",
@@ -9815,13 +9966,14 @@
 					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
 					"requires": {
 						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xmlhttprequest": "1.8.0"
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xmlhttprequest": "*"
 					},
 					"dependencies": {
 						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 						}
 					}
 				}
@@ -9832,14 +9984,14 @@
 			"resolved": "https://registry.npmjs.org/solium/-/solium-1.0.4.tgz",
 			"integrity": "sha512-IiWV5YLSuRplNAOXMhrOH8yi5J4PbNEbZaxhSdxtgEeK9tA6OXcAvwTsq2I8qRzqf6m3Bxr6OhiGboQaLtGC4Q==",
 			"requires": {
-				"ajv": "5.3.0",
-				"chokidar": "1.7.0",
-				"colors": "1.1.2",
-				"commander": "2.11.0",
-				"js-string-escape": "1.0.1",
-				"lodash": "4.17.4",
+				"ajv": "^5.2.2",
+				"chokidar": "^1.6.0",
+				"colors": "^1.1.2",
+				"commander": "^2.9.0",
+				"js-string-escape": "^1.0.1",
+				"lodash": "^4.14.2",
 				"sol-digger": "0.0.2",
-				"sol-explore": "1.6.2",
+				"sol-explore": "^1.6.1",
 				"solium-plugin-security": "0.0.2",
 				"solparse": "1.4.0"
 			},
@@ -9854,9 +10006,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -9864,9 +10016,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -9894,12 +10046,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"growl": {
@@ -9929,9 +10081,9 @@
 					"resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
 					"integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
 					"requires": {
-						"mocha": "4.0.1",
-						"pegjs": "0.10.0",
-						"yargs": "10.0.3"
+						"mocha": "^4.0.1",
+						"pegjs": "^0.10.0",
+						"yargs": "^10.0.3"
 					}
 				},
 				"supports-color": {
@@ -9939,7 +10091,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				},
 				"yargs": {
@@ -9947,18 +10099,18 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
 					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.0.0"
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -9966,7 +10118,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
 					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -9981,7 +10133,7 @@
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-list-map": {
@@ -9999,7 +10151,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "^0.5.6"
 			}
 		},
 		"spdx-correct": {
@@ -10007,7 +10159,7 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -10025,7 +10177,7 @@
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"requires": {
-				"through2": "2.0.3"
+				"through2": "^2.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -10038,14 +10190,14 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stable": {
@@ -10068,8 +10220,8 @@
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-http": {
@@ -10077,11 +10229,11 @@
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
 			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.2.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"stream-to-observable": {
@@ -10089,7 +10241,7 @@
 			"resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
 			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
 			"requires": {
-				"any-observable": "0.2.0"
+				"any-observable": "^0.2.0"
 			}
 		},
 		"stream-to-pull-stream": {
@@ -10097,8 +10249,8 @@
 			"resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
 			"integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
 			"requires": {
-				"looper": "3.0.0",
-				"pull-stream": "3.6.2"
+				"looper": "^3.0.0",
+				"pull-stream": "^3.2.3"
 			},
 			"dependencies": {
 				"looper": {
@@ -10113,7 +10265,7 @@
 			"resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
 			"integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
 			"requires": {
-				"promise-polyfill": "1.1.6"
+				"promise-polyfill": "^1.1.6"
 			}
 		},
 		"streamifier": {
@@ -10136,8 +10288,8 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -10155,7 +10307,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -10165,9 +10317,9 @@
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
 			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.9.0",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.0",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -10175,7 +10327,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringstream": {
@@ -10188,7 +10340,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -10201,8 +10353,8 @@
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
 			"requires": {
-				"first-chunk-stream": "2.0.0",
-				"strip-bom": "2.0.0"
+				"first-chunk-stream": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -10210,7 +10362,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -10220,7 +10372,7 @@
 			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
 			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
 			"requires": {
-				"is-natural-number": "4.0.1"
+				"is-natural-number": "^4.0.1"
 			}
 		},
 		"strip-eof": {
@@ -10251,19 +10403,19 @@
 			"resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
 			"integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
 			"requires": {
-				"bluebird": "3.5.1",
-				"buffer": "5.1.0",
-				"decompress": "4.2.0",
-				"eth-lib": "0.1.27",
-				"fs-extra": "2.1.2",
-				"fs-promise": "2.0.3",
-				"got": "7.1.0",
-				"mime-types": "2.1.17",
-				"mkdirp-promise": "5.0.1",
-				"mock-fs": "4.4.2",
-				"setimmediate": "1.0.5",
-				"tar.gz": "1.0.7",
-				"xhr-request-promise": "0.1.2"
+				"bluebird": "^3.5.0",
+				"buffer": "^5.0.5",
+				"decompress": "^4.0.0",
+				"eth-lib": "^0.1.26",
+				"fs-extra": "^2.1.2",
+				"fs-promise": "^2.0.0",
+				"got": "^7.1.0",
+				"mime-types": "^2.1.16",
+				"mkdirp-promise": "^5.0.1",
+				"mock-fs": "^4.1.0",
+				"setimmediate": "^1.0.5",
+				"tar.gz": "^1.0.5",
+				"xhr-request-promise": "^0.1.2"
 			},
 			"dependencies": {
 				"buffer": {
@@ -10271,8 +10423,8 @@
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
 					"integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
 					"requires": {
-						"base64-js": "1.2.1",
-						"ieee754": "1.1.8"
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
 					}
 				},
 				"fs-extra": {
@@ -10280,8 +10432,8 @@
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
 					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "2.4.0"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0"
 					}
 				}
 			}
@@ -10290,6 +10442,24 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+		},
+		"sync-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.0.0.tgz",
+			"integrity": "sha512-jGNIAlCi9iU4X3Dm4oQnNQshDD3h0/1A7r79LyqjbjUnj69sX6mShAXlhRXgImsfVKtTcnra1jfzabdZvp+Lmw==",
+			"requires": {
+				"http-response-object": "^3.0.1",
+				"sync-rpc": "^1.2.1",
+				"then-request": "^6.0.0"
+			}
+		},
+		"sync-rpc": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
+			"integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+			"requires": {
+				"get-port": "^3.1.0"
+			}
 		},
 		"tapable": {
 			"version": "0.2.8",
@@ -10301,19 +10471,19 @@
 			"resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
 			"integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
 			"requires": {
-				"deep-equal": "1.0.1",
-				"defined": "1.0.0",
-				"for-each": "0.3.2",
-				"function-bind": "1.1.1",
-				"glob": "7.1.2",
-				"has": "1.0.1",
-				"inherits": "2.0.3",
-				"minimist": "1.2.0",
-				"object-inspect": "1.3.0",
-				"resolve": "1.4.0",
-				"resumer": "0.0.0",
-				"string.prototype.trim": "1.1.2",
-				"through": "2.3.8"
+				"deep-equal": "~1.0.1",
+				"defined": "~1.0.0",
+				"for-each": "~0.3.2",
+				"function-bind": "~1.1.0",
+				"glob": "~7.1.2",
+				"has": "~1.0.1",
+				"inherits": "~2.0.3",
+				"minimist": "~1.2.0",
+				"object-inspect": "~1.3.0",
+				"resolve": "~1.4.0",
+				"resumer": "~0.0.0",
+				"string.prototype.trim": "~1.1.2",
+				"through": "~2.3.8"
 			},
 			"dependencies": {
 				"glob": {
@@ -10321,12 +10491,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"minimist": {
@@ -10339,7 +10509,7 @@
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
 					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
 					"requires": {
-						"path-parse": "1.0.5"
+						"path-parse": "^1.0.5"
 					}
 				}
 			}
@@ -10349,9 +10519,9 @@
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
 			}
 		},
 		"tar-fs": {
@@ -10359,10 +10529,10 @@
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
 			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
 			"requires": {
-				"chownr": "1.0.1",
-				"mkdirp": "0.5.1",
-				"pump": "1.0.2",
-				"tar-stream": "1.5.5"
+				"chownr": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pump": "^1.0.0",
+				"tar-stream": "^1.1.2"
 			}
 		},
 		"tar-stream": {
@@ -10370,10 +10540,10 @@
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
 			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
 			"requires": {
-				"bl": "1.2.1",
-				"end-of-stream": "1.4.0",
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"bl": "^1.0.0",
+				"end-of-stream": "^1.0.0",
+				"readable-stream": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"tar.gz": {
@@ -10381,11 +10551,11 @@
 			"resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
 			"integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
 			"requires": {
-				"bluebird": "2.11.0",
-				"commander": "2.14.1",
-				"fstream": "1.0.11",
-				"mout": "0.11.1",
-				"tar": "2.2.1"
+				"bluebird": "^2.9.34",
+				"commander": "^2.8.1",
+				"fstream": "^1.0.8",
+				"mout": "^0.11.0",
+				"tar": "^2.1.1"
 			},
 			"dependencies": {
 				"bluebird": {
@@ -10405,8 +10575,8 @@
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"rimraf": "2.2.8"
+				"os-tmpdir": "^1.0.0",
+				"rimraf": "~2.2.6"
 			},
 			"dependencies": {
 				"rimraf": {
@@ -10426,12 +10596,45 @@
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
 			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
 		},
+		"then-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.0.tgz",
+			"integrity": "sha512-xA+7uEMc+jsQIoyySJ93Ad08Kuqnik7u6jLS5hR91Z3smAoCfL3M8/MqMlobAa9gzBfO9pA88A/AntfepkkMJQ==",
+			"requires": {
+				"@types/concat-stream": "^1.6.0",
+				"@types/form-data": "0.0.33",
+				"@types/node": "^8.0.0",
+				"@types/qs": "^6.2.31",
+				"caseless": "~0.12.0",
+				"concat-stream": "^1.6.0",
+				"form-data": "^2.2.0",
+				"http-basic": "^7.0.0",
+				"http-response-object": "^3.0.1",
+				"promise": "^8.0.0",
+				"qs": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "8.10.17",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
+					"integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg=="
+				},
+				"promise": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+					"integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				}
+			}
+		},
 		"thenify": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
 			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
 			"requires": {
-				"any-promise": "1.3.0"
+				"any-promise": "^1.0.0"
 			}
 		},
 		"thenify-all": {
@@ -10439,7 +10642,7 @@
 			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
 			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
 			"requires": {
-				"thenify": "3.3.0"
+				"thenify": ">= 3.1.0 < 4"
 			}
 		},
 		"through": {
@@ -10452,8 +10655,8 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timed-out": {
@@ -10466,7 +10669,7 @@
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
 			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
 			"requires": {
-				"setimmediate": "1.0.5"
+				"setimmediate": "^1.0.4"
 			}
 		},
 		"tiny-queue": {
@@ -10479,7 +10682,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
 			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.1"
 			}
 		},
 		"tmp-promise": {
@@ -10487,7 +10690,7 @@
 			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
 			"integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
 			"requires": {
-				"bluebird": "3.5.1",
+				"bluebird": "^3.5.0",
 				"tmp": "0.0.33"
 			},
 			"dependencies": {
@@ -10496,7 +10699,7 @@
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.2"
 					}
 				}
 			}
@@ -10521,10 +10724,10 @@
 			"resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
 			"integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
 			"requires": {
-				"is-finite-x": "3.0.4",
-				"is-nan-x": "1.0.3",
-				"math-sign-x": "3.0.0",
-				"to-number-x": "2.0.0"
+				"is-finite-x": "^3.0.2",
+				"is-nan-x": "^1.0.1",
+				"math-sign-x": "^3.0.0",
+				"to-number-x": "^2.0.0"
 			}
 		},
 		"to-iso-string": {
@@ -10537,11 +10740,11 @@
 			"resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
 			"integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"nan-x": "1.0.2",
-				"parse-int-x": "2.0.0",
-				"to-primitive-x": "1.1.0",
-				"trim-x": "3.0.0"
+				"cached-constructors-x": "^1.0.0",
+				"nan-x": "^1.0.0",
+				"parse-int-x": "^2.0.0",
+				"to-primitive-x": "^1.1.0",
+				"trim-x": "^3.0.0"
 			}
 		},
 		"to-object-x": {
@@ -10549,8 +10752,8 @@
 			"resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
 			"integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"require-object-coercible-x": "1.4.3"
+				"cached-constructors-x": "^1.0.0",
+				"require-object-coercible-x": "^1.4.1"
 			}
 		},
 		"to-primitive-x": {
@@ -10558,14 +10761,14 @@
 			"resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
 			"integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
 			"requires": {
-				"has-symbol-support-x": "1.4.2",
-				"is-date-object": "1.0.1",
-				"is-function-x": "3.3.0",
-				"is-nil-x": "1.4.2",
-				"is-primitive": "2.0.0",
-				"is-symbol": "1.0.1",
-				"require-object-coercible-x": "1.4.3",
-				"validate.io-undefined": "1.0.3"
+				"has-symbol-support-x": "^1.4.1",
+				"is-date-object": "^1.0.1",
+				"is-function-x": "^3.2.0",
+				"is-nil-x": "^1.4.1",
+				"is-primitive": "^2.0.0",
+				"is-symbol": "^1.0.1",
+				"require-object-coercible-x": "^1.4.1",
+				"validate.io-undefined": "^1.0.3"
 			}
 		},
 		"to-property-key-x": {
@@ -10573,9 +10776,9 @@
 			"resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
 			"integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
 			"requires": {
-				"has-symbol-support-x": "1.4.2",
-				"to-primitive-x": "1.1.0",
-				"to-string-x": "1.4.5"
+				"has-symbol-support-x": "^1.4.1",
+				"to-primitive-x": "^1.1.0",
+				"to-string-x": "^1.4.2"
 			}
 		},
 		"to-string-symbols-supported-x": {
@@ -10583,9 +10786,9 @@
 			"resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.2.tgz",
 			"integrity": "sha512-3MRqhIhSNVDsVAk4M6WNcuBZrAQe54W13xrXX6RzxXS+pA4nj6DQ96RegQS5z9BSNyYbFsBsPvMVDIpP+a/5RA==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"has-symbol-support-x": "1.4.2",
-				"is-symbol": "1.0.1"
+				"cached-constructors-x": "^1.0.2",
+				"has-symbol-support-x": "^1.4.2",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"to-string-tag-x": {
@@ -10593,8 +10796,8 @@
 			"resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.3.tgz",
 			"integrity": "sha512-5+0EZ6dOVt/XArXmkooxPzWxmOR081HM/uXitUow7h11WYg5pPo15uYqDWuqO7ZY+O3Atn/dG26wcJCK+mFevg==",
 			"requires": {
-				"lodash.isnull": "3.0.0",
-				"validate.io-undefined": "1.0.3"
+				"lodash.isnull": "^3.0.0",
+				"validate.io-undefined": "^1.0.3"
 			}
 		},
 		"to-string-x": {
@@ -10602,8 +10805,8 @@
 			"resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
 			"integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"is-symbol": "1.0.1"
+				"cached-constructors-x": "^1.0.0",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"tough-cookie": {
@@ -10611,7 +10814,7 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"trim": {
@@ -10624,9 +10827,9 @@
 			"resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
 			"integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"require-coercible-to-string-x": "1.0.2",
-				"white-space-x": "3.0.1"
+				"cached-constructors-x": "^1.0.0",
+				"require-coercible-to-string-x": "^1.0.0",
+				"white-space-x": "^3.0.0"
 			}
 		},
 		"trim-right": {
@@ -10639,9 +10842,9 @@
 			"resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
 			"integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
 			"requires": {
-				"cached-constructors-x": "1.0.2",
-				"require-coercible-to-string-x": "1.0.2",
-				"white-space-x": "3.0.1"
+				"cached-constructors-x": "^1.0.0",
+				"require-coercible-to-string-x": "^1.0.0",
+				"white-space-x": "^3.0.0"
 			}
 		},
 		"trim-x": {
@@ -10649,8 +10852,8 @@
 			"resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
 			"integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
 			"requires": {
-				"trim-left-x": "3.0.0",
-				"trim-right-x": "3.0.0"
+				"trim-left-x": "^3.0.0",
+				"trim-right-x": "^3.0.0"
 			}
 		},
 		"truffle": {
@@ -10658,8 +10861,8 @@
 			"resolved": "https://registry.npmjs.org/truffle/-/truffle-4.0.5.tgz",
 			"integrity": "sha512-Hyj4LFRdfgoeb1SVV17hLAlO/szCXuuWS3tq26N5BI+avcEYdZl4KhxKMVgf6O/HeEIEuDYCpfLOWplXMfjeHQ==",
 			"requires": {
-				"mocha": "3.5.3",
-				"original-require": "1.0.1",
+				"mocha": "^3.4.2",
+				"original-require": "^1.0.1",
 				"solc": "0.4.18"
 			},
 			"dependencies": {
@@ -10668,7 +10871,7 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
 					"requires": {
-						"graceful-readlink": "1.0.1"
+						"graceful-readlink": ">= 1.0.0"
 					}
 				},
 				"debug": {
@@ -10689,12 +10892,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.2",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -10726,7 +10929,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -10736,10 +10939,10 @@
 			"resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-0.0.3.tgz",
 			"integrity": "sha1-Dh3gIQS3PTh14c9wkzBbTqii2EM=",
 			"requires": {
-				"bip39": "2.4.0",
-				"ethereumjs-wallet": "0.6.0",
-				"web3": "0.18.4",
-				"web3-provider-engine": "8.6.1"
+				"bip39": "^2.2.0",
+				"ethereumjs-wallet": "^0.6.0",
+				"web3": "^0.18.2",
+				"web3-provider-engine": "^8.4.0"
 			}
 		},
 		"truffle-privatekey-provider": {
@@ -10747,13 +10950,14 @@
 			"resolved": "https://registry.npmjs.org/truffle-privatekey-provider/-/truffle-privatekey-provider-0.0.5.tgz",
 			"integrity": "sha512-I4agR/KbFA+XLLYxN32YeMTm5D9ySMQ5yN/CaRywCYceaZM+cPIXJQoX5R+L6S5i9OSm0aebbOGsdYSVU4YGaQ==",
 			"requires": {
-				"ethereumjs-wallet": "0.6.0",
-				"web3": "0.20.6",
-				"web3-provider-engine": "8.6.1"
+				"ethereumjs-wallet": "^0.6.0",
+				"web3": "^0.20.1",
+				"web3-provider-engine": "^8.4.0"
 			},
 			"dependencies": {
 				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+					"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
 				},
 				"web3": {
 					"version": "0.20.6",
@@ -10761,14 +10965,15 @@
 					"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 					"requires": {
 						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xhr2": "0.1.4",
-						"xmlhttprequest": "1.8.0"
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xhr2": "*",
+						"xmlhttprequest": "*"
 					},
 					"dependencies": {
 						"bignumber.js": {
-							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+							"from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
 						}
 					}
 				}
@@ -10784,7 +10989,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -10798,7 +11003,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-detect": {
@@ -10812,7 +11017,7 @@
 			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.18"
+				"mime-types": "~2.1.18"
 			},
 			"dependencies": {
 				"mime-db": {
@@ -10825,7 +11030,7 @@
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": "~1.33.0"
 					}
 				}
 			}
@@ -10840,7 +11045,7 @@
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.4.tgz",
 			"integrity": "sha512-JTZPwvf+dXFWkljvE3oDjTZ6DFg+bbBhB9yA4Xx3JN4Ol9jfMjXuLn/o2gmgt+BJJwJ4MIzrTBz+UbwVMi9vcA==",
 			"requires": {
-				"is-typedarray": "1.0.0"
+				"is-typedarray": "^1.0.0"
 			}
 		},
 		"typewise": {
@@ -10848,7 +11053,7 @@
 			"resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
 			"integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
 			"requires": {
-				"typewise-core": "1.2.0"
+				"typewise-core": "^1.2.0"
 			}
 		},
 		"typewise-core": {
@@ -10866,9 +11071,9 @@
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"yargs": {
@@ -10876,9 +11081,9 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -10895,9 +11100,9 @@
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
 			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.2"
+				"source-map": "^0.5.6",
+				"uglify-js": "^2.8.29",
+				"webpack-sources": "^1.0.1"
 			}
 		},
 		"ultron": {
@@ -10910,8 +11115,8 @@
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
 			"integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
 			"requires": {
-				"buffer": "3.6.0",
-				"through": "2.3.8"
+				"buffer": "^3.0.1",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"base64-js": {
@@ -10925,8 +11130,8 @@
 					"integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
 					"requires": {
 						"base64-js": "0.0.8",
-						"ieee754": "1.1.8",
-						"isarray": "1.0.0"
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
 					}
 				}
 			}
@@ -10982,7 +11187,7 @@
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"url-set-query": {
@@ -11045,7 +11250,7 @@
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
 			"requires": {
-				"user-home": "1.1.1"
+				"user-home": "^1.1.1"
 			}
 		},
 		"validate-npm-package-license": {
@@ -11053,8 +11258,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"validate.io-undefined": {
@@ -11077,9 +11282,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vinyl": {
@@ -11087,8 +11292,8 @@
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 			"requires": {
-				"clone": "1.0.4",
-				"clone-stats": "0.0.1",
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
 				"replace-ext": "0.0.1"
 			},
 			"dependencies": {
@@ -11104,12 +11309,12 @@
 			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0",
-				"strip-bom-stream": "2.0.0",
-				"vinyl": "1.2.0"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.3.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0",
+				"strip-bom-stream": "^2.0.0",
+				"vinyl": "^1.1.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -11117,7 +11322,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -11135,9 +11340,9 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"requires": {
-				"async": "2.6.0",
-				"chokidar": "1.7.0",
-				"graceful-fs": "4.1.11"
+				"async": "^2.1.2",
+				"chokidar": "^1.7.0",
+				"graceful-fs": "^4.1.2"
 			}
 		},
 		"web3": {
@@ -11146,10 +11351,10 @@
 			"integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
 			"requires": {
 				"bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-				"crypto-js": "3.1.8",
-				"utf8": "2.1.2",
-				"xhr2": "0.1.4",
-				"xmlhttprequest": "1.8.0"
+				"crypto-js": "^3.1.4",
+				"utf8": "^2.1.1",
+				"xhr2": "*",
+				"xmlhttprequest": "*"
 			}
 		},
 		"web3-bzz": {
@@ -11276,7 +11481,7 @@
 			"integrity": "sha1-jwobNCxCg4EjciQqbi3yaIh7O3A=",
 			"requires": {
 				"bluebird": "3.3.1",
-				"crypto-browserify": "3.12.0",
+				"crypto-browserify": "^3.12.0",
 				"eth-lib": "0.2.7",
 				"scrypt.js": "0.2.0",
 				"underscore": "1.8.3",
@@ -11297,9 +11502,9 @@
 					"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
 					"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
 					"requires": {
-						"bn.js": "4.11.8",
-						"elliptic": "6.4.0",
-						"xhr-request-promise": "0.1.2"
+						"bn.js": "^4.11.6",
+						"elliptic": "^6.4.0",
+						"xhr-request-promise": "^0.1.2"
 					}
 				},
 				"uuid": {
@@ -11329,7 +11534,7 @@
 			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.30.tgz",
 			"integrity": "sha1-OwgKXE2h+jdHexfkyQB4G5IVBkU=",
 			"requires": {
-				"bn.js": "4.11.8",
+				"bn.js": "^4.11.6",
 				"web3-utils": "1.0.0-beta.30"
 			}
 		},
@@ -11360,24 +11565,25 @@
 			"resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.6.1.tgz",
 			"integrity": "sha1-TYbhnjDKr5ffNRUR7A9gE25bMOs=",
 			"requires": {
-				"async": "2.6.0",
-				"clone": "2.1.1",
-				"ethereumjs-block": "1.7.0",
-				"ethereumjs-tx": "1.3.3",
-				"ethereumjs-util": "5.1.2",
-				"ethereumjs-vm": "2.3.2",
-				"isomorphic-fetch": "2.2.1",
-				"request": "2.83.0",
-				"semaphore": "1.1.0",
-				"solc": "0.4.23",
-				"tape": "4.8.0",
-				"web3": "0.16.0",
-				"xhr": "2.4.0",
-				"xtend": "4.0.1"
+				"async": "^2.1.2",
+				"clone": "^2.0.0",
+				"ethereumjs-block": "^1.2.2",
+				"ethereumjs-tx": "^1.2.0",
+				"ethereumjs-util": "^5.0.1",
+				"ethereumjs-vm": "^2.0.2",
+				"isomorphic-fetch": "^2.2.0",
+				"request": "^2.67.0",
+				"semaphore": "^1.0.3",
+				"solc": "^0.4.2",
+				"tape": "^4.4.0",
+				"web3": "^0.16.0",
+				"xhr": "^2.2.0",
+				"xtend": "^4.0.1"
 			},
 			"dependencies": {
 				"bignumber.js": {
-					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+					"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+					"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 				},
 				"camelcase": {
 					"version": "3.0.0",
@@ -11389,9 +11595,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"ethereumjs-util": {
@@ -11399,14 +11605,14 @@
 					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.2.tgz",
 					"integrity": "sha1-JboCFcu0wvCxCKb5avKi5i5Fkh8=",
 					"requires": {
-						"babel-preset-es2015": "6.24.1",
-						"babelify": "7.3.0",
-						"bn.js": "4.11.8",
-						"create-hash": "1.1.3",
-						"ethjs-util": "0.1.4",
-						"keccak": "1.3.0",
-						"rlp": "2.0.0",
-						"secp256k1": "3.3.1"
+						"babel-preset-es2015": "^6.24.0",
+						"babelify": "^7.3.0",
+						"bn.js": "^4.8.0",
+						"create-hash": "^1.1.2",
+						"ethjs-util": "^0.1.3",
+						"keccak": "^1.0.2",
+						"rlp": "^2.0.0",
+						"secp256k1": "^3.0.1"
 					}
 				},
 				"find-up": {
@@ -11414,8 +11620,8 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -11423,11 +11629,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"os-locale": {
@@ -11435,7 +11641,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
@@ -11443,7 +11649,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -11451,9 +11657,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -11461,9 +11667,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -11471,8 +11677,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"solc": {
@@ -11480,11 +11686,11 @@
 					"resolved": "https://registry.npmjs.org/solc/-/solc-0.4.23.tgz",
 					"integrity": "sha512-AT7anLHY6uIRg2It6N0UlCHeZ7YeecIkUhnlirrCgCPCUevtnoN48BxvgigN/4jJTRljv5oFhAJtI6gvHzT5DQ==",
 					"requires": {
-						"fs-extra": "0.30.0",
-						"memorystream": "0.3.1",
-						"require-from-string": "1.2.1",
-						"semver": "5.4.1",
-						"yargs": "4.8.1"
+						"fs-extra": "^0.30.0",
+						"memorystream": "^0.3.1",
+						"require-from-string": "^1.1.0",
+						"semver": "^5.3.0",
+						"yargs": "^4.7.1"
 					}
 				},
 				"string-width": {
@@ -11492,9 +11698,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -11502,7 +11708,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"web3": {
@@ -11511,13 +11717,14 @@
 					"integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
 					"requires": {
 						"bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-						"crypto-js": "3.1.8",
-						"utf8": "2.1.2",
-						"xmlhttprequest": "1.8.0"
+						"crypto-js": "^3.1.4",
+						"utf8": "^2.1.1",
+						"xmlhttprequest": "*"
 					},
 					"dependencies": {
 						"bignumber.js": {
-							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+							"version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+							"from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 						}
 					}
 				},
@@ -11536,20 +11743,20 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 					"requires": {
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"lodash.assign": "4.2.0",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "2.4.1"
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"lodash.assign": "^4.0.3",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.1",
+						"which-module": "^1.0.0",
+						"window-size": "^0.2.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^2.4.1"
 					}
 				},
 				"yargs-parser": {
@@ -11557,8 +11764,8 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"lodash.assign": "4.2.0"
+						"camelcase": "^3.0.0",
+						"lodash.assign": "^4.0.6"
 					}
 				}
 			}
@@ -11594,11 +11801,12 @@
 			"dependencies": {
 				"websocket": {
 					"version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
+					"from": "websocket@git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
 					"requires": {
-						"debug": "2.6.9",
-						"nan": "2.7.0",
-						"typedarray-to-buffer": "3.1.4",
-						"yaeti": "0.0.6"
+						"debug": "^2.2.0",
+						"nan": "^2.3.3",
+						"typedarray-to-buffer": "^3.1.2",
+						"yaeti": "^0.0.6"
 					}
 				}
 			}
@@ -11620,7 +11828,7 @@
 			"integrity": "sha1-6uQIzI1tb+zI1Ql8/q1Rdz8jH/k=",
 			"requires": {
 				"bn.js": "4.11.6",
-				"eth-lib": "0.1.27",
+				"eth-lib": "^0.1.27",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
 				"randomhex": "0.1.5",
@@ -11645,28 +11853,28 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
 			"integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
 			"requires": {
-				"acorn": "5.2.1",
-				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.3.0",
-				"ajv-keywords": "2.1.1",
-				"async": "2.6.0",
-				"enhanced-resolve": "3.4.1",
-				"escope": "3.6.0",
-				"interpret": "1.0.4",
-				"json-loader": "0.5.7",
-				"json5": "0.5.1",
-				"loader-runner": "2.3.0",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"mkdirp": "0.5.1",
-				"node-libs-browser": "2.0.0",
-				"source-map": "0.5.7",
-				"supports-color": "4.5.0",
-				"tapable": "0.2.8",
-				"uglifyjs-webpack-plugin": "0.4.6",
-				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.2",
-				"yargs": "8.0.2"
+				"acorn": "^5.0.0",
+				"acorn-dynamic-import": "^2.0.0",
+				"ajv": "^5.1.5",
+				"ajv-keywords": "^2.0.0",
+				"async": "^2.1.2",
+				"enhanced-resolve": "^3.4.0",
+				"escope": "^3.6.0",
+				"interpret": "^1.0.0",
+				"json-loader": "^0.5.4",
+				"json5": "^0.5.1",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "~0.4.1",
+				"mkdirp": "~0.5.0",
+				"node-libs-browser": "^2.0.0",
+				"source-map": "^0.5.3",
+				"supports-color": "^4.2.1",
+				"tapable": "^0.2.7",
+				"uglifyjs-webpack-plugin": "^0.4.6",
+				"watchpack": "^1.4.0",
+				"webpack-sources": "^1.0.1",
+				"yargs": "^8.0.2"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -11674,7 +11882,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -11684,7 +11892,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
 			"requires": {
-				"jscodeshift": "0.4.1"
+				"jscodeshift": "^0.4.0"
 			},
 			"dependencies": {
 				"ast-types": {
@@ -11707,21 +11915,21 @@
 					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
 					"requires": {
-						"async": "1.5.2",
-						"babel-plugin-transform-flow-strip-types": "6.22.0",
-						"babel-preset-es2015": "6.24.1",
-						"babel-preset-stage-1": "6.24.1",
-						"babel-register": "6.26.0",
-						"babylon": "6.18.0",
-						"colors": "1.1.2",
-						"flow-parser": "0.70.0",
-						"lodash": "4.17.4",
-						"micromatch": "2.3.11",
+						"async": "^1.5.0",
+						"babel-plugin-transform-flow-strip-types": "^6.8.0",
+						"babel-preset-es2015": "^6.9.0",
+						"babel-preset-stage-1": "^6.5.0",
+						"babel-register": "^6.9.0",
+						"babylon": "^6.17.3",
+						"colors": "^1.1.2",
+						"flow-parser": "^0.*",
+						"lodash": "^4.13.1",
+						"micromatch": "^2.3.7",
 						"node-dir": "0.1.8",
-						"nomnom": "1.8.1",
-						"recast": "0.12.9",
-						"temp": "0.8.3",
-						"write-file-atomic": "1.3.4"
+						"nomnom": "^1.8.1",
+						"recast": "^0.12.5",
+						"temp": "^0.8.1",
+						"write-file-atomic": "^1.2.0"
 					}
 				},
 				"recast": {
@@ -11730,10 +11938,10 @@
 					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
 					"requires": {
 						"ast-types": "0.10.1",
-						"core-js": "2.5.1",
-						"esprima": "4.0.0",
-						"private": "0.1.8",
-						"source-map": "0.6.1"
+						"core-js": "^2.4.1",
+						"esprima": "~4.0.0",
+						"private": "~0.1.5",
+						"source-map": "~0.6.1"
 					}
 				},
 				"source-map": {
@@ -11748,32 +11956,32 @@
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.15.tgz",
 			"integrity": "sha512-bjNeIUO51D4OsmZ5ufzcpzVoacjxfWNfeBZKYL3jc+EMfCME3TyfdCPSUoKiOnebQChfupQuIRpAnx7L4l3Hew==",
 			"requires": {
-				"chalk": "2.4.0",
-				"cross-spawn": "6.0.5",
-				"diff": "3.5.0",
-				"enhanced-resolve": "4.0.0",
-				"envinfo": "4.4.2",
-				"glob-all": "3.1.0",
-				"global-modules": "1.0.0",
-				"got": "8.3.0",
-				"import-local": "1.0.0",
-				"inquirer": "5.2.0",
-				"interpret": "1.0.4",
-				"jscodeshift": "0.5.0",
-				"listr": "0.13.0",
-				"loader-utils": "1.1.0",
-				"lodash": "4.17.10",
-				"log-symbols": "2.2.0",
-				"mkdirp": "0.5.1",
-				"p-each-series": "1.0.0",
-				"p-lazy": "1.0.0",
-				"prettier": "1.12.1",
-				"supports-color": "5.4.0",
-				"v8-compile-cache": "1.1.2",
-				"webpack-addons": "1.1.5",
-				"yargs": "11.1.0",
-				"yeoman-environment": "2.0.6",
-				"yeoman-generator": "2.0.4"
+				"chalk": "^2.3.2",
+				"cross-spawn": "^6.0.5",
+				"diff": "^3.5.0",
+				"enhanced-resolve": "^4.0.0",
+				"envinfo": "^4.4.2",
+				"glob-all": "^3.1.0",
+				"global-modules": "^1.0.0",
+				"got": "^8.2.0",
+				"import-local": "^1.0.0",
+				"inquirer": "^5.1.0",
+				"interpret": "^1.0.4",
+				"jscodeshift": "^0.5.0",
+				"listr": "^0.13.0",
+				"loader-utils": "^1.1.0",
+				"lodash": "^4.17.5",
+				"log-symbols": "^2.2.0",
+				"mkdirp": "^0.5.1",
+				"p-each-series": "^1.0.0",
+				"p-lazy": "^1.0.0",
+				"prettier": "^1.5.3",
+				"supports-color": "^5.3.0",
+				"v8-compile-cache": "^1.1.2",
+				"webpack-addons": "^1.1.5",
+				"yargs": "^11.1.0",
+				"yeoman-environment": "^2.0.0",
+				"yeoman-generator": "^2.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11786,7 +11994,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"camelcase": {
@@ -11799,9 +12007,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
 					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
@@ -11809,9 +12017,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -11819,11 +12027,11 @@
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"nice-try": "1.0.4",
-						"path-key": "2.0.1",
-						"semver": "5.5.0",
-						"shebang-command": "1.2.0",
-						"which": "1.3.0"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				},
 				"diff": {
@@ -11836,9 +12044,9 @@
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
 					"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"memory-fs": "0.4.1",
-						"tapable": "1.0.0"
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.4.0",
+						"tapable": "^1.0.0"
 					}
 				},
 				"got": {
@@ -11846,23 +12054,23 @@
 					"resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
 					"integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
 					"requires": {
-						"@sindresorhus/is": "0.7.0",
-						"cacheable-request": "2.1.4",
-						"decompress-response": "3.3.0",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"into-stream": "3.1.0",
-						"is-retry-allowed": "1.1.0",
-						"isurl": "1.0.0",
-						"lowercase-keys": "1.0.0",
-						"mimic-response": "1.0.0",
-						"p-cancelable": "0.4.1",
-						"p-timeout": "2.0.1",
-						"pify": "3.0.0",
-						"safe-buffer": "5.1.1",
-						"timed-out": "4.0.1",
-						"url-parse-lax": "3.0.0",
-						"url-to-options": "1.0.1"
+						"@sindresorhus/is": "^0.7.0",
+						"cacheable-request": "^2.1.1",
+						"decompress-response": "^3.3.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"into-stream": "^3.1.0",
+						"is-retry-allowed": "^1.1.0",
+						"isurl": "^1.0.0-alpha5",
+						"lowercase-keys": "^1.0.0",
+						"mimic-response": "^1.0.0",
+						"p-cancelable": "^0.4.0",
+						"p-timeout": "^2.0.1",
+						"pify": "^3.0.0",
+						"safe-buffer": "^5.1.1",
+						"timed-out": "^4.0.1",
+						"url-parse-lax": "^3.0.0",
+						"url-to-options": "^1.0.1"
 					}
 				},
 				"has-flag": {
@@ -11885,7 +12093,7 @@
 					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
 					"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
 					"requires": {
-						"p-finally": "1.0.0"
+						"p-finally": "^1.0.0"
 					}
 				},
 				"pify": {
@@ -11908,7 +12116,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -11916,7 +12124,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"tapable": {
@@ -11929,7 +12137,7 @@
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 					"requires": {
-						"prepend-http": "2.0.0"
+						"prepend-http": "^2.0.0"
 					}
 				},
 				"yargs": {
@@ -11937,18 +12145,18 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
@@ -11956,7 +12164,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -11966,8 +12174,8 @@
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.2.tgz",
 			"integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
 			"requires": {
-				"source-list-map": "2.0.0",
-				"source-map": "0.6.1"
+				"source-list-map": "^2.0.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -11987,7 +12195,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -12005,7 +12213,7 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"requires": {
-				"string-width": "1.0.2"
+				"string-width": "^1.0.2"
 			},
 			"dependencies": {
 				"string-width": {
@@ -12013,9 +12221,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -12035,8 +12243,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"string-width": {
@@ -12044,9 +12252,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -12061,9 +12269,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"slide": "^1.1.5"
 			}
 		},
 		"ws": {
@@ -12071,9 +12279,9 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
 			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"ultron": "1.1.1"
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0",
+				"ultron": "~1.1.0"
 			}
 		},
 		"xhr": {
@@ -12081,10 +12289,10 @@
 			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
 			"integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
 			"requires": {
-				"global": "4.3.2",
-				"is-function": "1.0.1",
-				"parse-headers": "2.0.1",
-				"xtend": "4.0.1"
+				"global": "~4.3.0",
+				"is-function": "^1.0.1",
+				"parse-headers": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"xhr-request": {
@@ -12092,13 +12300,13 @@
 			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
 			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
 			"requires": {
-				"buffer-to-arraybuffer": "0.0.5",
-				"object-assign": "4.1.1",
-				"query-string": "5.1.0",
-				"simple-get": "2.7.0",
-				"timed-out": "4.0.1",
-				"url-set-query": "1.0.0",
-				"xhr": "2.4.0"
+				"buffer-to-arraybuffer": "^0.0.5",
+				"object-assign": "^4.1.1",
+				"query-string": "^5.0.1",
+				"simple-get": "^2.7.0",
+				"timed-out": "^4.0.1",
+				"url-set-query": "^1.0.0",
+				"xhr": "^2.0.4"
 			},
 			"dependencies": {
 				"simple-get": {
@@ -12106,9 +12314,9 @@
 					"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
 					"integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
 					"requires": {
-						"decompress-response": "3.3.0",
-						"once": "1.4.0",
-						"simple-concat": "1.0.0"
+						"decompress-response": "^3.3.0",
+						"once": "^1.3.1",
+						"simple-concat": "^1.0.0"
 					}
 				}
 			}
@@ -12118,7 +12326,7 @@
 			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
 			"integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
 			"requires": {
-				"xhr-request": "1.1.0"
+				"xhr-request": "^1.0.1"
 			}
 		},
 		"xhr2": {
@@ -12156,19 +12364,19 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 			"requires": {
-				"camelcase": "4.1.0",
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"read-pkg-up": "2.0.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "7.0.0"
+				"camelcase": "^4.1.0",
+				"cliui": "^3.2.0",
+				"decamelize": "^1.1.1",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"read-pkg-up": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^7.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -12181,9 +12389,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -12191,9 +12399,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -12205,7 +12413,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -12220,8 +12428,8 @@
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
 			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
 			"requires": {
-				"buffer-crc32": "0.2.13",
-				"fd-slicer": "1.0.1"
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.0.1"
 			}
 		},
 		"yeoman-environment": {
@@ -12229,19 +12437,19 @@
 			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
 			"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
 			"requires": {
-				"chalk": "2.4.0",
-				"debug": "3.1.0",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"globby": "6.1.0",
-				"grouped-queue": "0.3.3",
-				"inquirer": "3.3.0",
-				"is-scoped": "1.0.0",
-				"lodash": "4.17.4",
-				"log-symbols": "2.2.0",
-				"mem-fs": "1.1.3",
-				"text-table": "0.2.0",
-				"untildify": "3.0.2"
+				"chalk": "^2.1.0",
+				"debug": "^3.1.0",
+				"diff": "^3.3.1",
+				"escape-string-regexp": "^1.0.2",
+				"globby": "^6.1.0",
+				"grouped-queue": "^0.3.3",
+				"inquirer": "^3.3.0",
+				"is-scoped": "^1.0.0",
+				"lodash": "^4.17.4",
+				"log-symbols": "^2.1.0",
+				"mem-fs": "^1.1.0",
+				"text-table": "^0.2.0",
+				"untildify": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12254,7 +12462,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -12262,9 +12470,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
 					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -12290,20 +12498,20 @@
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.0",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "2.2.0",
-						"figures": "2.0.0",
-						"lodash": "4.17.4",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rx-lite": "4.0.8",
-						"rx-lite-aggregates": "4.0.8",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					}
 				},
 				"strip-ansi": {
@@ -12311,7 +12519,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -12319,7 +12527,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -12329,31 +12537,31 @@
 			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.4.tgz",
 			"integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
 			"requires": {
-				"async": "2.6.0",
-				"chalk": "2.4.0",
-				"cli-table": "0.3.1",
-				"cross-spawn": "5.1.0",
-				"dargs": "5.1.0",
-				"dateformat": "3.0.3",
-				"debug": "3.1.0",
-				"detect-conflict": "1.0.1",
-				"error": "7.0.2",
-				"find-up": "2.1.0",
-				"github-username": "4.1.0",
-				"istextorbinary": "2.2.1",
-				"lodash": "4.17.4",
-				"make-dir": "1.2.0",
-				"mem-fs-editor": "3.0.2",
-				"minimist": "1.2.0",
-				"pretty-bytes": "4.0.2",
-				"read-chunk": "2.1.0",
-				"read-pkg-up": "3.0.0",
-				"rimraf": "2.6.2",
-				"run-async": "2.3.0",
-				"shelljs": "0.8.1",
-				"text-table": "0.2.0",
-				"through2": "2.0.3",
-				"yeoman-environment": "2.0.6"
+				"async": "^2.6.0",
+				"chalk": "^2.3.0",
+				"cli-table": "^0.3.1",
+				"cross-spawn": "^5.1.0",
+				"dargs": "^5.1.0",
+				"dateformat": "^3.0.2",
+				"debug": "^3.1.0",
+				"detect-conflict": "^1.0.0",
+				"error": "^7.0.2",
+				"find-up": "^2.1.0",
+				"github-username": "^4.0.0",
+				"istextorbinary": "^2.1.0",
+				"lodash": "^4.17.4",
+				"make-dir": "^1.1.0",
+				"mem-fs-editor": "^3.0.2",
+				"minimist": "^1.2.0",
+				"pretty-bytes": "^4.0.2",
+				"read-chunk": "^2.1.0",
+				"read-pkg-up": "^3.0.0",
+				"rimraf": "^2.6.2",
+				"run-async": "^2.0.0",
+				"shelljs": "^0.8.0",
+				"text-table": "^0.2.0",
+				"through2": "^2.0.0",
+				"yeoman-environment": "^2.0.5"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -12361,7 +12569,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -12369,9 +12577,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
 					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -12387,12 +12595,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -12405,10 +12613,10 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"minimist": {
@@ -12421,8 +12629,8 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -12430,7 +12638,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -12443,9 +12651,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -12453,8 +12661,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"shelljs": {
@@ -12462,9 +12670,9 @@
 					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
 					"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
 					"requires": {
-						"glob": "7.1.2",
-						"interpret": "1.0.4",
-						"rechoir": "0.6.2"
+						"glob": "^7.0.0",
+						"interpret": "^1.0.0",
+						"rechoir": "^0.6.2"
 					}
 				},
 				"supports-color": {
@@ -12472,7 +12680,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@aragon/cli": "^2.0.4",
     "@aragon/test-helpers": "^1.0.0",
-    "eth-gas-reporter": "^0.1.1",
+    "eth-gas-reporter": "^0.1.5",
     "ganache-cli": "^6.1.0",
     "solidity-coverage": "0.4.3",
     "solidity-sha3": "^0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@sindresorhus/is": {
@@ -26,8 +26,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "add-stream": {
@@ -36,15 +36,27 @@
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
     },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -89,8 +101,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.5"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -99,7 +111,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -108,7 +120,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -147,7 +159,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -175,9 +187,9 @@
       "dev": true
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
@@ -211,15 +223,15 @@
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "babel-code-frame": {
@@ -228,9 +240,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -239,25 +251,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "babylon": {
@@ -274,14 +286,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "detect-indent": {
@@ -290,7 +302,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "jsesc": {
@@ -307,9 +319,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -318,9 +330,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -329,10 +341,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -341,10 +353,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -353,9 +365,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -364,10 +376,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -376,11 +388,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -389,8 +401,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -399,8 +411,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -409,8 +421,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -419,9 +431,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -430,11 +442,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -443,12 +455,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -457,8 +469,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -467,7 +479,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -476,7 +488,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -551,9 +563,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -562,9 +574,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -573,9 +585,9 @@
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "6.18.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -584,10 +596,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -596,11 +608,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -609,7 +621,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -618,7 +630,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -627,11 +639,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -640,15 +652,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -657,8 +669,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -667,7 +679,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -676,8 +688,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -686,7 +698,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -695,9 +707,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -706,7 +718,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -715,9 +727,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -726,10 +738,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -738,9 +750,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -749,9 +761,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -760,8 +772,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -770,12 +782,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -784,8 +796,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -794,7 +806,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -803,9 +815,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -814,7 +826,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -823,7 +835,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -832,9 +844,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -843,9 +855,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -854,8 +866,8 @@
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-export-extensions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -864,8 +876,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -874,8 +886,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -884,7 +896,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -893,8 +905,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-es2015": {
@@ -903,30 +915,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -935,9 +947,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -946,10 +958,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -958,11 +970,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -971,13 +983,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "source-map-support": {
@@ -986,7 +998,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         }
       }
@@ -997,8 +1009,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1007,11 +1019,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "babylon": {
@@ -1028,15 +1040,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "babylon": {
@@ -1053,10 +1065,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1077,13 +1089,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1092,7 +1104,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1101,7 +1113,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1110,7 +1122,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1119,9 +1131,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -1139,7 +1151,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
@@ -1154,22 +1166,13 @@
       "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
       "dev": true
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1179,9 +1182,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "buffer-from": {
@@ -1208,15 +1211,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cacheable-request": {
@@ -1253,9 +1256,9 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1273,9 +1276,9 @@
       "dev": true
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "center-align": {
@@ -1285,8 +1288,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -1295,11 +1298,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chardet": {
@@ -1320,10 +1323,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1332,7 +1335,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -1343,7 +1346,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -1376,7 +1379,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -1385,9 +1388,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -1405,8 +1408,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -1428,7 +1431,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "clone-stats": {
@@ -1443,9 +1446,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "2.0.0",
-        "readable-stream": "2.3.5"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
       }
     },
     "cmd-shim": {
@@ -1454,9 +1457,15 @@
       "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1"
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "~0.5.0"
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1470,8 +1479,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -1480,7 +1489,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1501,8 +1510,8 @@
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "requires": {
-        "strip-ansi": "3.0.1",
-        "wcwidth": "1.0.1"
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
       }
     },
     "combined-stream": {
@@ -1511,19 +1520,13 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-join": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
       "integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
       "dev": true
     },
     "commondir": {
@@ -1538,8 +1541,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       }
     },
     "component-emitter": {
@@ -1560,9 +1563,9 @@
       "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-control-strings": {
@@ -1577,17 +1580,17 @@
       "integrity": "sha512-swf5bqhm7PsY2cw6zxuPy6+rZiiGwEpQnrWki+L+z2oZI53QSYwU4brpljmmWss821AsiwmVL+7V6hP+ER+TBA==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-atom": "0.2.4",
-        "conventional-changelog-codemirror": "0.3.4",
-        "conventional-changelog-core": "2.0.5",
-        "conventional-changelog-ember": "0.3.6",
-        "conventional-changelog-eslint": "1.0.5",
-        "conventional-changelog-express": "0.3.4",
-        "conventional-changelog-jquery": "0.1.0",
-        "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.3.4",
-        "conventional-changelog-preset-loader": "1.1.6"
+        "conventional-changelog-angular": "^1.6.6",
+        "conventional-changelog-atom": "^0.2.4",
+        "conventional-changelog-codemirror": "^0.3.4",
+        "conventional-changelog-core": "^2.0.5",
+        "conventional-changelog-ember": "^0.3.6",
+        "conventional-changelog-eslint": "^1.0.5",
+        "conventional-changelog-express": "^0.3.4",
+        "conventional-changelog-jquery": "^0.1.0",
+        "conventional-changelog-jscs": "^0.1.0",
+        "conventional-changelog-jshint": "^0.3.4",
+        "conventional-changelog-preset-loader": "^1.1.6"
       }
     },
     "conventional-changelog-angular": {
@@ -1596,8 +1599,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-atom": {
@@ -1606,7 +1609,7 @@
       "integrity": "sha512-4+hmbBwcAwx1XzDZ4aEOxk/ONU0iay10G0u/sld16ksgnRUHN7CxmZollm3FFaptr6VADMq1qxomA+JlpblBlg==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-cli": {
@@ -1615,11 +1618,11 @@
       "integrity": "sha512-zNDG/rNbh29Z+d6zzrHN63dFZ4q9k1Ri0V8lXGw1q2ia6+FaE7AqJKccObbBFRmRISXpFESrqZiXpM4QeA84YA==",
       "dev": true,
       "requires": {
-        "add-stream": "1.0.0",
-        "conventional-changelog": "1.1.18",
-        "lodash": "4.17.5",
-        "meow": "4.0.0",
-        "tempfile": "1.1.1"
+        "add-stream": "^1.0.0",
+        "conventional-changelog": "^1.1.18",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "tempfile": "^1.1.1"
       }
     },
     "conventional-changelog-codemirror": {
@@ -1628,7 +1631,7 @@
       "integrity": "sha512-8M7pGgQVzRU//vG3rFlLYqqBywOLxu9XM0/lc1/1Ll7RuKA79PgK9TDpuPmQDHFnqGS7D1YiZpC3Z0D9AIYExg==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-core": {
@@ -1637,19 +1640,19 @@
       "integrity": "sha512-lP1s7Z3NyEFcG78bWy7GG7nXsq9OpAJgo2xbyAlVBDweLSL5ghvyEZlkEamnAQpIUVK0CAVhs8nPvCiQuXT/VA==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "3.0.4",
-        "conventional-commits-parser": "2.1.5",
-        "dateformat": "3.0.3",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.4",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.4",
-        "lodash": "4.17.5",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
+        "conventional-changelog-writer": "^3.0.4",
+        "conventional-commits-parser": "^2.1.5",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "^1.3.4",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^1.3.4",
+        "lodash": "^4.2.1",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.5.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -1658,8 +1661,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -1668,11 +1671,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "path-exists": {
@@ -1681,7 +1684,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -1690,9 +1693,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -1701,9 +1704,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -1712,8 +1715,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -1722,7 +1725,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -1733,7 +1736,7 @@
       "integrity": "sha512-hBM1xb5IrjNtsjXaGryPF/Wn36cwyjkNeqX/CIDbJv/1kRFBHsWoSPYBiNVEpg8xE5fcK4DbPhGTDN2sVoPeiA==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-eslint": {
@@ -1742,7 +1745,7 @@
       "integrity": "sha512-7NUv+gMOS8Y49uPFRgF7kuLZqpnrKa2bQMZZsc62NzvaJmjUktnV03PYHuXhTDEHt5guvV9gyEFtUpgHCDkojg==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-express": {
@@ -1751,7 +1754,7 @@
       "integrity": "sha512-M+UUb715TXT6l9vyMf4HYvAepnQn0AYTcPi6KHrFsd80E0HErjQnqStBg8i3+Qm7EV9+RyATQEnIhSzHbdQ7+A==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -1760,7 +1763,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -1769,7 +1772,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -1778,8 +1781,8 @@
       "integrity": "sha512-CdrqwDgL56b176FVxHmhuOvnO1dRDQvrMaHyuIVjcFlOXukATz2wVT17g8jQU3LvybVbyXvJRbdD5pboo7/1KQ==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-preset-loader": {
@@ -1794,16 +1797,16 @@
       "integrity": "sha512-EUf/hWiEj3IOa5Jk8XDzM6oS0WgijlYGkUfLc+mDnLH9RwpZqhYIBwgJHWHzEB4My013wx2FhmUu45P6tQrucw==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.5",
-        "dateformat": "3.0.3",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.5",
-        "meow": "4.0.0",
-        "semver": "5.5.0",
-        "split": "1.0.1",
-        "through2": "2.0.3"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.5",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "conventional-commits-filter": {
@@ -1812,8 +1815,8 @@
       "integrity": "sha512-mj3+WLj8UZE72zO9jocZjx8+W4Bwnx/KHoIz1vb4F8XUXj0XSjp8Y3MFkpRyIpsRiCBX+DkDjxGKF/nfeu7BGw==",
       "dev": true,
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.0"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
@@ -1822,13 +1825,13 @@
       "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.5",
-        "meow": "4.0.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       }
     },
     "conventional-recommended-bump": {
@@ -1837,13 +1840,13 @@
       "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.1",
-        "conventional-commits-filter": "1.1.5",
-        "conventional-commits-parser": "2.1.5",
-        "git-raw-commits": "1.3.4",
-        "git-semver-tags": "1.3.4",
-        "meow": "3.7.0",
-        "object-assign": "4.1.1"
+        "concat-stream": "^1.4.10",
+        "conventional-commits-filter": "^1.1.1",
+        "conventional-commits-parser": "^2.1.1",
+        "git-raw-commits": "^1.3.0",
+        "git-semver-tags": "^1.3.0",
+        "meow": "^3.3.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -1858,8 +1861,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -1868,8 +1871,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "indent-string": {
@@ -1878,7 +1881,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -1887,11 +1890,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -1906,16 +1909,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "path-exists": {
@@ -1924,7 +1927,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -1933,9 +1936,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -1944,9 +1947,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -1955,8 +1958,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -1965,8 +1968,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -1975,7 +1978,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -1984,7 +1987,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -2020,16 +2023,16 @@
       "dev": true
     },
     "coveralls": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       }
     },
     "create-error-class": {
@@ -2038,7 +2041,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -2047,18 +2050,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "currently-unhandled": {
@@ -2067,7 +2061,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -2076,7 +2070,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -2085,15 +2079,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
+        "assert-plus": "^1.0.0"
       }
     },
     "date-fns": {
@@ -2129,8 +2115,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
@@ -2153,7 +2139,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "dedent": {
@@ -2174,7 +2160,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3"
+        "clone": "^1.0.2"
       }
     },
     "define-property": {
@@ -2183,8 +2169,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2193,7 +2179,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2202,7 +2188,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2211,9 +2197,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -2260,8 +2246,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -2270,7 +2256,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -2287,7 +2273,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
@@ -2308,10 +2294,10 @@
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -2321,7 +2307,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "editions": {
@@ -2354,7 +2340,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -2363,9 +2349,9 @@
       "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "tapable": "1.0.0"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
       }
     },
     "envinfo": {
@@ -2380,7 +2366,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error": {
@@ -2389,8 +2375,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
     "error-ex": {
@@ -2399,7 +2385,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -2409,9 +2395,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esutils": {
@@ -2426,13 +2412,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit-hook": {
@@ -2447,7 +2433,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2456,7 +2442,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -2465,11 +2451,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -2478,7 +2464,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -2498,7 +2484,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "extend": {
@@ -2513,8 +2499,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2523,7 +2509,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -2534,9 +2520,9 @@
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -2545,7 +2531,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -2562,17 +2548,23 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
     "fast-glob": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
       "integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.2",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.1",
+        "micromatch": "^3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -2593,16 +2585,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -2611,7 +2603,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -2622,13 +2614,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -2637,7 +2629,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -2646,7 +2638,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -2655,7 +2647,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2664,7 +2656,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2675,7 +2667,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -2684,7 +2676,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2695,9 +2687,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -2714,14 +2706,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -2730,7 +2722,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -2739,7 +2731,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -2750,7 +2742,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2759,7 +2751,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2768,9 +2760,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-glob": {
@@ -2779,7 +2771,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "kind-of": {
@@ -2794,22 +2786,28 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "figures": {
       "version": "2.0.0",
@@ -2817,7 +2815,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "filename-regex": {
@@ -2832,10 +2830,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2844,7 +2842,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2855,7 +2853,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "first-chunk-stream": {
@@ -2882,7 +2880,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -2892,14 +2890,14 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -2908,7 +2906,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "from2": {
@@ -2917,8 +2915,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-extra": {
@@ -2927,9 +2925,9 @@
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -2944,8 +2942,8 @@
       "integrity": "sha512-FdTeyk4uLRHGeFiMe+Qnh4Hc5KiTVqvRVVvLDFJEVVKC1P1yHhEgZeh9sp1KhuvxSrxToxgJS25UapYQwH4zHw==",
       "dev": true,
       "requires": {
-        "source-map-support": "0.5.6",
-        "webpack-cli": "2.1.3"
+        "source-map-support": "^0.5.3",
+        "webpack-cli": "^2.0.9"
       }
     },
     "gauge": {
@@ -2954,14 +2952,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "string-width": {
@@ -2970,26 +2968,11 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
       }
     },
     "get-caller-file": {
@@ -3004,11 +2987,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -3023,8 +3006,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "find-up": {
@@ -3033,8 +3016,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "indent-string": {
@@ -3043,7 +3026,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -3052,11 +3035,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -3071,16 +3054,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "path-exists": {
@@ -3089,7 +3072,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -3098,9 +3081,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -3109,9 +3092,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -3120,8 +3103,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -3130,8 +3113,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "strip-bom": {
@@ -3140,7 +3123,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -3149,7 +3132,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -3190,15 +3173,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
+        "assert-plus": "^1.0.0"
       }
     },
     "gh-got": {
@@ -3207,8 +3182,8 @@
       "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
       "dev": true,
       "requires": {
-        "got": "7.1.0",
-        "is-plain-obj": "1.1.0"
+        "got": "^7.0.0",
+        "is-plain-obj": "^1.1.0"
       },
       "dependencies": {
         "got": {
@@ -3217,20 +3192,20 @@
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
           "requires": {
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-plain-obj": "1.1.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.0",
-            "p-cancelable": "0.3.0",
-            "p-timeout": "1.2.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "1.0.0",
-            "url-to-options": "1.0.1"
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
           }
         },
         "p-cancelable": {
@@ -3245,7 +3220,7 @@
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
           "requires": {
-            "p-finally": "1.0.0"
+            "p-finally": "^1.0.0"
           }
         }
       }
@@ -3256,11 +3231,11 @@
       "integrity": "sha512-G3O+41xHbscpgL5nA0DUkbFVgaAz5rd57AMSIMew8p7C8SyFwZDyn08MoXHkTl9zcD0LmxsLFPxbqFY4YPbpPA==",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "4.0.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       }
     },
     "git-remote-origin-url": {
@@ -3269,8 +3244,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
       }
     },
     "git-semver-tags": {
@@ -3279,8 +3254,8 @@
       "integrity": "sha512-Xe2Z74MwXZfAezuaO6e6cA4nsgeCiARPzaBp23gma325c/OXdt//PhrknptIaynNeUp2yWtmikV7k5RIicgGIQ==",
       "dev": true,
       "requires": {
-        "meow": "4.0.0",
-        "semver": "5.5.0"
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
       }
     },
     "gitconfiglocal": {
@@ -3289,7 +3264,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.2"
       }
     },
     "github-username": {
@@ -3298,7 +3273,7 @@
       "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
       "dev": true,
       "requires": {
-        "gh-got": "6.0.0"
+        "gh-got": "^6.0.0"
       }
     },
     "glob": {
@@ -3307,11 +3282,11 @@
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-all": {
@@ -3320,8 +3295,8 @@
       "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "yargs": "1.2.6"
+        "glob": "^7.0.5",
+        "yargs": "~1.2.6"
       },
       "dependencies": {
         "glob": {
@@ -3330,12 +3305,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimist": {
@@ -3350,7 +3325,7 @@
           "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
           "dev": true,
           "requires": {
-            "minimist": "0.1.0"
+            "minimist": "^0.1.0"
           }
         }
       }
@@ -3361,8 +3336,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -3371,7 +3346,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -3386,7 +3361,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -3397,8 +3372,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -3407,7 +3382,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -3418,14 +3393,14 @@
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "glob": "5.0.15",
-        "glob-parent": "3.1.0",
-        "micromatch": "2.3.11",
-        "ordered-read-streams": "0.3.0",
-        "through2": "0.6.5",
-        "to-absolute-glob": "0.1.1",
-        "unique-stream": "2.2.1"
+        "extend": "^3.0.0",
+        "glob": "^5.0.3",
+        "glob-parent": "^3.0.0",
+        "micromatch": "^2.3.7",
+        "ordered-read-streams": "^0.3.0",
+        "through2": "^0.6.0",
+        "to-absolute-glob": "^0.1.1",
+        "unique-stream": "^2.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -3434,7 +3409,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -3449,9 +3424,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "expand-brackets": {
@@ -3460,7 +3435,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -3469,7 +3444,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -3484,7 +3459,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "isarray": {
@@ -3499,19 +3474,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "readable-stream": {
@@ -3520,10 +3495,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3538,8 +3513,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -3556,9 +3531,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -3567,11 +3542,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -3586,11 +3561,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3599,12 +3574,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -3615,17 +3590,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -3640,7 +3615,7 @@
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.17.2"
       }
     },
     "gulp-sourcemaps": {
@@ -3649,11 +3624,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.1",
-        "graceful-fs": "4.1.11",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "convert-source-map": "^1.1.1",
+        "graceful-fs": "^4.1.2",
+        "strip-bom": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -3662,7 +3637,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -3673,10 +3648,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -3691,21 +3666,25 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
     "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.14.1",
-        "is-my-json-valid": "2.17.2",
-        "pinkie-promise": "2.0.1"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -3714,7 +3693,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -3741,7 +3720,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -3756,9 +3735,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -3767,8 +3746,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3777,28 +3756,10 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3806,8 +3767,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -3816,7 +3777,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3832,14 +3793,14 @@
       "dev": true
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -3860,8 +3821,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -3882,8 +3843,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3904,20 +3865,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.2",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3932,7 +3893,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3941,9 +3902,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -3958,7 +3919,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -3967,7 +3928,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -3984,8 +3945,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
       }
     },
     "invariant": {
@@ -3994,7 +3955,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -4009,7 +3970,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -4030,7 +3991,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-ci": {
@@ -4039,7 +4000,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -4048,7 +4009,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-descriptor": {
@@ -4057,9 +4018,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4082,7 +4043,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4103,7 +4064,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4112,7 +4073,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -4121,7 +4082,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -4132,32 +4093,13 @@
         }
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -4178,7 +4120,7 @@
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "0.2.4"
+        "symbol-observable": "^0.2.2"
       },
       "dependencies": {
         "symbol-observable": {
@@ -4195,7 +4137,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4218,7 +4160,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -4239,12 +4181,6 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -4263,7 +4199,7 @@
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "dev": true,
       "requires": {
-        "scoped-regex": "1.0.0"
+        "scoped-regex": "^1.0.0"
       }
     },
     "is-stream": {
@@ -4284,7 +4220,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.7.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -4347,9 +4283,9 @@
       "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
       "dev": true,
       "requires": {
-        "binaryextensions": "2.1.1",
-        "editions": "1.3.4",
-        "textextensions": "2.2.0"
+        "binaryextensions": "2",
+        "editions": "^1.3.3",
+        "textextensions": "2"
       }
     },
     "isurl": {
@@ -4358,8 +4294,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -4369,13 +4305,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4391,21 +4327,21 @@
       "integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-stage-1": "6.24.1",
-        "babel-register": "6.26.0",
-        "babylon": "7.0.0-beta.47",
-        "colors": "1.2.5",
-        "flow-parser": "0.72.0",
-        "lodash": "4.17.5",
-        "micromatch": "2.3.11",
-        "neo-async": "2.5.1",
+        "babel-plugin-transform-flow-strip-types": "^6.8.0",
+        "babel-preset-es2015": "^6.9.0",
+        "babel-preset-stage-1": "^6.5.0",
+        "babel-register": "^6.9.0",
+        "babylon": "^7.0.0-beta.30",
+        "colors": "^1.1.2",
+        "flow-parser": "^0.*",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.7",
+        "neo-async": "^2.5.0",
         "node-dir": "0.1.8",
-        "nomnom": "1.8.1",
-        "recast": "0.14.7",
-        "temp": "0.8.3",
-        "write-file-atomic": "1.3.4"
+        "nomnom": "^1.8.1",
+        "recast": "^0.14.1",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^1.2.0"
       },
       "dependencies": {
         "write-file-atomic": {
@@ -4414,9 +4350,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         }
       }
@@ -4445,13 +4381,19 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4472,7 +4414,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -4487,12 +4429,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4503,14 +4439,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "keyv": {
@@ -4528,7 +4456,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -4544,7 +4472,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5"
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -4553,7 +4481,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -4568,9 +4496,9 @@
       "integrity": "sha1-XeHmQm+IWSm3c1fwFN5f7h2tBVM=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "vinyl-fs": "2.4.4"
+        "through2": "^2.0.1",
+        "vinyl": "^1.1.1",
+        "vinyl-fs": "^2.4.3"
       }
     },
     "lerna": {
@@ -4579,45 +4507,45 @@
       "integrity": "sha512-8KvXqRsnkqkorOlE7tMnaDl8b43t8i6/ZyGthoyIzb7ikeH2XNrQOHuI1FWsuOtP2HY3vLp2zuMvM5Zuw3ulUA==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "chalk": "2.3.2",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "command-join": "2.0.0",
-        "conventional-changelog-cli": "1.3.16",
-        "conventional-recommended-bump": "1.2.1",
-        "dedent": "0.7.0",
-        "execa": "0.8.0",
-        "find-up": "2.1.0",
-        "fs-extra": "4.0.3",
-        "get-port": "3.2.0",
-        "glob": "7.1.2",
-        "glob-parent": "3.1.0",
-        "globby": "6.1.0",
-        "graceful-fs": "4.1.11",
-        "hosted-git-info": "2.5.0",
-        "inquirer": "3.3.0",
-        "is-ci": "1.1.0",
-        "load-json-file": "4.0.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "npmlog": "4.1.2",
-        "p-finally": "1.0.0",
-        "package-json": "4.0.1",
-        "path-exists": "3.0.0",
-        "read-cmd-shim": "1.0.1",
-        "read-pkg": "3.0.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "semver": "5.5.0",
-        "signal-exit": "3.0.2",
-        "slash": "1.0.0",
-        "strong-log-transformer": "1.0.6",
-        "temp-write": "3.4.0",
-        "write-file-atomic": "2.3.0",
-        "write-json-file": "2.3.0",
-        "write-pkg": "3.1.0",
-        "yargs": "8.0.2"
+        "async": "^1.5.0",
+        "chalk": "^2.1.0",
+        "cmd-shim": "^2.0.2",
+        "columnify": "^1.5.4",
+        "command-join": "^2.0.0",
+        "conventional-changelog-cli": "^1.3.13",
+        "conventional-recommended-bump": "^1.2.1",
+        "dedent": "^0.7.0",
+        "execa": "^0.8.0",
+        "find-up": "^2.1.0",
+        "fs-extra": "^4.0.1",
+        "get-port": "^3.2.0",
+        "glob": "^7.1.2",
+        "glob-parent": "^3.1.0",
+        "globby": "^6.1.0",
+        "graceful-fs": "^4.1.11",
+        "hosted-git-info": "^2.5.0",
+        "inquirer": "^3.2.2",
+        "is-ci": "^1.0.10",
+        "load-json-file": "^4.0.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
+        "p-finally": "^1.0.0",
+        "package-json": "^4.0.1",
+        "path-exists": "^3.0.0",
+        "read-cmd-shim": "^1.0.1",
+        "read-pkg": "^3.0.0",
+        "rimraf": "^2.6.1",
+        "safe-buffer": "^5.1.1",
+        "semver": "^5.4.1",
+        "signal-exit": "^3.0.2",
+        "slash": "^1.0.0",
+        "strong-log-transformer": "^1.0.6",
+        "temp-write": "^3.3.0",
+        "write-file-atomic": "^2.3.0",
+        "write-json-file": "^2.2.0",
+        "write-pkg": "^3.1.0",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4626,7 +4554,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "async": {
@@ -4641,9 +4569,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "execa": {
@@ -4652,13 +4580,13 @@
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "glob": {
@@ -4667,12 +4595,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -4687,10 +4615,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -4699,8 +4627,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -4709,7 +4637,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -4724,9 +4652,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4735,7 +4663,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4746,23 +4674,23 @@
       "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "figures": "1.7.0",
-        "indent-string": "2.1.0",
-        "is-observable": "0.2.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.4.0",
-        "listr-verbose-renderer": "0.4.1",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "ora": "0.2.3",
-        "p-map": "1.2.0",
-        "rxjs": "5.5.10",
-        "stream-to-observable": "0.2.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "figures": "^1.7.0",
+        "indent-string": "^2.1.0",
+        "is-observable": "^0.2.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.4.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "ora": "^0.2.3",
+        "p-map": "^1.1.1",
+        "rxjs": "^5.4.2",
+        "stream-to-observable": "^0.2.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "figures": {
@@ -4771,8 +4699,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "indent-string": {
@@ -4781,7 +4709,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "log-symbols": {
@@ -4790,7 +4718,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         }
       }
@@ -4807,14 +4735,14 @@
       "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "figures": {
@@ -4823,8 +4751,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "log-symbols": {
@@ -4833,7 +4761,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         }
       }
@@ -4844,10 +4772,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.29.0",
-        "figures": "1.7.0"
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
       },
       "dependencies": {
         "cli-cursor": {
@@ -4856,7 +4784,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "figures": {
@@ -4865,8 +4793,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "onetime": {
@@ -4881,8 +4809,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         }
       }
@@ -4893,10 +4821,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "loader-utils": {
@@ -4905,9 +4833,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -4916,8 +4844,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -4944,8 +4872,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -4954,13 +4882,13 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
@@ -4969,7 +4897,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4978,7 +4906,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4987,9 +4915,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -4998,7 +4926,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5009,8 +4937,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -5025,7 +4953,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -5040,8 +4968,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         }
       }
@@ -5058,7 +4986,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -5067,8 +4995,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -5083,8 +5011,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -5093,7 +5021,7 @@
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5122,7 +5050,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "mem": {
@@ -5131,7 +5059,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "mem-fs": {
@@ -5140,9 +5068,9 @@
       "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "vinyl-file": "2.0.0"
+        "through2": "^2.0.0",
+        "vinyl": "^1.1.0",
+        "vinyl-file": "^2.0.0"
       }
     },
     "mem-fs-editor": {
@@ -5151,17 +5079,17 @@
       "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "deep-extend": "0.5.1",
-        "ejs": "2.6.1",
-        "glob": "7.1.2",
-        "globby": "8.0.1",
-        "isbinaryfile": "3.0.2",
-        "mkdirp": "0.5.1",
-        "multimatch": "2.1.0",
-        "rimraf": "2.6.2",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "commondir": "^1.0.1",
+        "deep-extend": "^0.5.1",
+        "ejs": "^2.5.9",
+        "glob": "^7.0.3",
+        "globby": "^8.0.0",
+        "isbinaryfile": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "multimatch": "^2.0.0",
+        "rimraf": "^2.2.8",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.1"
       },
       "dependencies": {
         "clone": {
@@ -5188,12 +5116,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -5202,13 +5130,13 @@
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "fast-glob": "2.2.1",
-            "glob": "7.1.2",
-            "ignore": "3.3.8",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         },
         "pify": {
@@ -5229,12 +5157,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.1.2",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
           }
         }
       }
@@ -5245,8 +5173,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.5"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -5255,15 +5183,15 @@
       "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "4.2.0",
-        "decamelize-keys": "1.1.0",
-        "loud-rejection": "1.6.0",
-        "minimist": "1.2.0",
-        "minimist-options": "3.0.2",
-        "normalize-package-data": "2.4.0",
-        "read-pkg-up": "3.0.0",
-        "redent": "2.0.0",
-        "trim-newlines": "2.0.0"
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -5272,10 +5200,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -5284,8 +5212,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -5294,7 +5222,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -5309,9 +5237,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -5320,8 +5248,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         }
       }
@@ -5332,7 +5260,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge2": {
@@ -5347,19 +5275,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       },
       "dependencies": {
         "is-extglob": {
@@ -5382,7 +5310,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -5403,7 +5331,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5418,8 +5346,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "mixin-deep": {
@@ -5428,8 +5356,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5438,7 +5366,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -5484,10 +5412,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "mute-stream": {
@@ -5502,18 +5430,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -5560,8 +5488,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5576,9 +5504,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -5595,10 +5523,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -5607,7 +5535,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-url": {
@@ -5616,9 +5544,9 @@
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
       "requires": {
-        "prepend-http": "2.0.0",
-        "query-string": "5.1.1",
-        "sort-keys": "2.0.0"
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       },
       "dependencies": {
         "prepend-http": {
@@ -5635,7 +5563,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -5644,10 +5572,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -5674,9 +5602,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -5685,7 +5613,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -5696,7 +5624,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.omit": {
@@ -5705,8 +5633,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -5715,7 +5643,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "once": {
@@ -5724,7 +5652,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -5733,7 +5661,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -5742,8 +5670,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -5760,10 +5688,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "cli-cursor": {
@@ -5772,7 +5700,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -5787,8 +5715,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         }
       }
@@ -5799,8 +5727,8 @@
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "readable-stream": "2.3.5"
+        "is-stream": "^1.0.1",
+        "readable-stream": "^2.0.1"
       }
     },
     "os-homedir": {
@@ -5815,9 +5743,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -5838,7 +5766,7 @@
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
-        "p-reduce": "1.0.0"
+        "p-reduce": "^1.0.0"
       }
     },
     "p-finally": {
@@ -5865,7 +5793,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -5874,7 +5802,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -5895,7 +5823,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -5910,10 +5838,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "parse-github-repo-url": {
@@ -5928,10 +5856,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -5946,7 +5874,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -5957,7 +5885,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -6008,8 +5936,14 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -6029,7 +5963,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -6038,7 +5972,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "posix-character-classes": {
@@ -6108,9 +6042,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "query-string": {
@@ -6119,9 +6053,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "quick-lru": {
@@ -6136,8 +6070,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6146,7 +6080,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6157,10 +6091,10 @@
       "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-chunk": {
@@ -6169,8 +6103,8 @@
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.1"
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
         "pify": {
@@ -6187,7 +6121,7 @@
       "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.2"
       }
     },
     "read-pkg": {
@@ -6196,9 +6130,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -6207,8 +6141,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -6217,13 +6151,13 @@
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "recast": {
@@ -6233,9 +6167,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.11.3",
-        "esprima": "4.0.0",
-        "private": "0.1.8",
-        "source-map": "0.6.1"
+        "esprima": "~4.0.0",
+        "private": "~0.1.5",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -6258,7 +6192,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.7.1"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -6267,8 +6201,8 @@
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "regenerate": {
@@ -6289,9 +6223,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -6300,7 +6234,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -6309,8 +6243,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpu-core": {
@@ -6319,9 +6253,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -6330,8 +6264,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.5",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -6340,7 +6274,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.5"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -6355,7 +6289,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -6382,7 +6316,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -6392,31 +6326,31 @@
       "dev": true
     },
     "request": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "qs": "6.3.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.4.3",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -6437,7 +6371,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-cwd": {
@@ -6446,7 +6380,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-dir": {
@@ -6455,8 +6389,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -6477,7 +6411,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.0"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -6486,8 +6420,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -6503,7 +6437,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -6512,7 +6446,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -6521,12 +6455,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -6537,7 +6471,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -6552,7 +6486,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "rxjs": {
@@ -6576,7 +6510,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "scoped-regex": {
@@ -6603,10 +6537,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -6615,7 +6549,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -6626,7 +6560,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -6641,9 +6575,9 @@
       "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       },
       "dependencies": {
         "glob": {
@@ -6652,12 +6586,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -6692,14 +6626,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -6708,7 +6642,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -6717,7 +6651,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -6728,9 +6662,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -6739,7 +6673,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -6748,7 +6682,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -6757,7 +6691,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -6766,9 +6700,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -6785,16 +6719,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
+        "kind-of": "^3.2.0"
       }
     },
     "sort-keys": {
@@ -6803,7 +6728,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {
@@ -6818,11 +6743,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -6831,8 +6756,8 @@
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -6855,8 +6780,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -6871,8 +6796,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -6887,7 +6812,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -6896,7 +6821,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -6905,7 +6830,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -6915,27 +6840,19 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-extend": {
@@ -6944,8 +6861,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -6954,7 +6871,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -6971,7 +6888,7 @@
       "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
       "dev": true,
       "requires": {
-        "any-observable": "0.2.0"
+        "any-observable": "^0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6992,8 +6909,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7014,7 +6931,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7025,14 +6942,8 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -7040,7 +6951,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -7055,8 +6966,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^1.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -7065,7 +6976,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -7094,11 +7005,11 @@
       "integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
       "dev": true,
       "requires": {
-        "byline": "5.0.0",
-        "duplexer": "0.1.1",
-        "minimist": "0.1.0",
-        "moment": "2.21.0",
-        "through": "2.3.8"
+        "byline": "^5.0.0",
+        "duplexer": "^0.1.1",
+        "minimist": "^0.1.0",
+        "moment": "^2.6.0",
+        "through": "^2.3.4"
       },
       "dependencies": {
         "minimist": {
@@ -7133,8 +7044,8 @@
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
       },
       "dependencies": {
         "rimraf": {
@@ -7157,12 +7068,12 @@
       "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "is-stream": "1.1.0",
-        "make-dir": "1.2.0",
-        "pify": "3.0.0",
-        "temp-dir": "1.0.0",
-        "uuid": "3.2.1"
+        "graceful-fs": "^4.1.2",
+        "is-stream": "^1.1.0",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
         "pify": {
@@ -7179,8 +7090,8 @@
       "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "uuid": "2.0.3"
+        "os-tmpdir": "^1.0.0",
+        "uuid": "^2.0.1"
       },
       "dependencies": {
         "uuid": {
@@ -7221,8 +7132,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "through2-filter": {
@@ -7231,8 +7142,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "timed-out": {
@@ -7247,7 +7158,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -7256,7 +7167,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7265,7 +7176,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7282,7 +7193,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -7291,10 +7202,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -7303,8 +7214,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -7313,7 +7224,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-newlines": {
@@ -7335,10 +7246,13 @@
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -7360,9 +7274,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -7372,9 +7286,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -7399,10 +7313,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7411,7 +7325,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -7420,10 +7334,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -7434,8 +7348,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "1.0.1",
-        "through2-filter": "2.0.0"
+        "json-stable-stringify": "^1.0.0",
+        "through2-filter": "^2.0.0"
       }
     },
     "universalify": {
@@ -7450,8 +7364,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -7460,9 +7374,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -7508,7 +7422,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -7523,7 +7437,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7564,8 +7478,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -7574,17 +7488,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -7593,8 +7499,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -7604,12 +7510,12 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "2.0.0",
-        "vinyl": "1.2.0"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^1.1.0"
       },
       "dependencies": {
         "first-chunk-stream": {
@@ -7618,7 +7524,7 @@
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.5"
+            "readable-stream": "^2.0.2"
           }
         },
         "strip-bom": {
@@ -7627,7 +7533,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-bom-stream": {
@@ -7636,8 +7542,8 @@
           "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
           "dev": true,
           "requires": {
-            "first-chunk-stream": "2.0.0",
-            "strip-bom": "2.0.0"
+            "first-chunk-stream": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         }
       }
@@ -7648,23 +7554,23 @@
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.4",
-        "glob-stream": "5.3.5",
-        "graceful-fs": "4.1.11",
+        "duplexify": "^3.2.0",
+        "glob-stream": "^5.3.2",
+        "graceful-fs": "^4.0.0",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "0.3.0",
-        "lazystream": "1.0.0",
-        "lodash.isequal": "4.5.0",
-        "merge-stream": "1.0.1",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.5",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "1.0.0",
-        "through2": "2.0.3",
-        "through2-filter": "2.0.0",
-        "vali-date": "1.0.0",
-        "vinyl": "1.2.0"
+        "is-valid-glob": "^0.3.0",
+        "lazystream": "^1.0.0",
+        "lodash.isequal": "^4.0.0",
+        "merge-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.0",
+        "readable-stream": "^2.0.4",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^1.0.0",
+        "through2": "^2.0.0",
+        "through2-filter": "^2.0.0",
+        "vali-date": "^1.0.0",
+        "vinyl": "^1.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -7673,7 +7579,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -7684,7 +7590,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "webpack-addons": {
@@ -7693,7 +7599,7 @@
       "integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
       "dev": true,
       "requires": {
-        "jscodeshift": "0.4.1"
+        "jscodeshift": "^0.4.0"
       },
       "dependencies": {
         "ast-types": {
@@ -7720,21 +7626,21 @@
           "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "babel-plugin-transform-flow-strip-types": "6.22.0",
-            "babel-preset-es2015": "6.24.1",
-            "babel-preset-stage-1": "6.24.1",
-            "babel-register": "6.26.0",
-            "babylon": "6.18.0",
-            "colors": "1.2.5",
-            "flow-parser": "0.72.0",
-            "lodash": "4.17.5",
-            "micromatch": "2.3.11",
+            "async": "^1.5.0",
+            "babel-plugin-transform-flow-strip-types": "^6.8.0",
+            "babel-preset-es2015": "^6.9.0",
+            "babel-preset-stage-1": "^6.5.0",
+            "babel-register": "^6.9.0",
+            "babylon": "^6.17.3",
+            "colors": "^1.1.2",
+            "flow-parser": "^0.*",
+            "lodash": "^4.13.1",
+            "micromatch": "^2.3.7",
             "node-dir": "0.1.8",
-            "nomnom": "1.8.1",
-            "recast": "0.12.9",
-            "temp": "0.8.3",
-            "write-file-atomic": "1.3.4"
+            "nomnom": "^1.8.1",
+            "recast": "^0.12.5",
+            "temp": "^0.8.1",
+            "write-file-atomic": "^1.2.0"
           }
         },
         "recast": {
@@ -7744,10 +7650,10 @@
           "dev": true,
           "requires": {
             "ast-types": "0.10.1",
-            "core-js": "2.5.6",
-            "esprima": "4.0.0",
-            "private": "0.1.8",
-            "source-map": "0.6.1"
+            "core-js": "^2.4.1",
+            "esprima": "~4.0.0",
+            "private": "~0.1.5",
+            "source-map": "~0.6.1"
           }
         },
         "source-map": {
@@ -7762,9 +7668,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         }
       }
@@ -7775,32 +7681,32 @@
       "integrity": "sha512-5AsKoL/Ccn8iTrwk3uErdyhetGH+c7VRQ7Itim2GL0IhBRq5rtojVDk00buMRmFmBpw1RvHXq97Gup965LbozA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "diff": "3.5.0",
-        "enhanced-resolve": "4.0.0",
-        "envinfo": "4.4.2",
-        "glob-all": "3.1.0",
-        "global-modules": "1.0.0",
-        "got": "8.3.1",
-        "import-local": "1.0.0",
-        "inquirer": "5.2.0",
-        "interpret": "1.1.0",
-        "jscodeshift": "0.5.0",
-        "listr": "0.13.0",
-        "loader-utils": "1.1.0",
-        "lodash": "4.17.5",
-        "log-symbols": "2.2.0",
-        "mkdirp": "0.5.1",
-        "p-each-series": "1.0.0",
-        "p-lazy": "1.0.0",
-        "prettier": "1.12.1",
-        "supports-color": "5.4.0",
-        "v8-compile-cache": "1.1.2",
-        "webpack-addons": "1.1.5",
-        "yargs": "11.1.0",
-        "yeoman-environment": "2.1.1",
-        "yeoman-generator": "2.0.5"
+        "chalk": "^2.3.2",
+        "cross-spawn": "^6.0.5",
+        "diff": "^3.5.0",
+        "enhanced-resolve": "^4.0.0",
+        "envinfo": "^4.4.2",
+        "glob-all": "^3.1.0",
+        "global-modules": "^1.0.0",
+        "got": "^8.2.0",
+        "import-local": "^1.0.0",
+        "inquirer": "^5.1.0",
+        "interpret": "^1.0.4",
+        "jscodeshift": "^0.5.0",
+        "listr": "^0.13.0",
+        "loader-utils": "^1.1.0",
+        "lodash": "^4.17.5",
+        "log-symbols": "^2.2.0",
+        "mkdirp": "^0.5.1",
+        "p-each-series": "^1.0.0",
+        "p-lazy": "^1.0.0",
+        "prettier": "^1.5.3",
+        "supports-color": "^5.3.0",
+        "v8-compile-cache": "^1.1.2",
+        "webpack-addons": "^1.1.5",
+        "yargs": "^11.1.0",
+        "yeoman-environment": "^2.0.0",
+        "yeoman-generator": "^2.0.4"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7815,7 +7721,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "camelcase": {
@@ -7830,9 +7736,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cliui": {
@@ -7841,9 +7747,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "cross-spawn": {
@@ -7852,11 +7758,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "got": {
@@ -7865,23 +7771,23 @@
           "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "0.7.0",
-            "cacheable-request": "2.1.4",
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "into-stream": "3.1.0",
-            "is-retry-allowed": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.0",
-            "mimic-response": "1.0.0",
-            "p-cancelable": "0.4.1",
-            "p-timeout": "2.0.1",
-            "pify": "3.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "3.0.0",
-            "url-to-options": "1.0.1"
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
           }
         },
         "inquirer": {
@@ -7890,19 +7796,19 @@
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.5",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "5.5.10",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "pify": {
@@ -7923,7 +7829,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -7932,7 +7838,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "url-parse-lax": {
@@ -7941,7 +7847,7 @@
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "dev": true,
           "requires": {
-            "prepend-http": "2.0.0"
+            "prepend-http": "^2.0.0"
           }
         },
         "yargs": {
@@ -7950,18 +7856,18 @@
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -7970,7 +7876,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -7981,7 +7887,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -7996,7 +7902,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       },
       "dependencies": {
         "string-width": {
@@ -8005,9 +7911,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -8031,8 +7937,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -8041,9 +7947,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -8060,9 +7966,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "write-json-file": {
@@ -8071,12 +7977,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
-        "pify": "3.0.0",
-        "sort-keys": "2.0.0",
-        "write-file-atomic": "2.3.0"
+        "detect-indent": "^5.0.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "sort-keys": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8093,8 +7999,8 @@
       "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
       "dev": true,
       "requires": {
-        "sort-keys": "2.0.0",
-        "write-json-file": "2.3.0"
+        "sort-keys": "^2.0.0",
+        "write-json-file": "^2.2.0"
       }
     },
     "xtend": {
@@ -8121,19 +8027,19 @@
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8148,9 +8054,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -8159,9 +8065,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -8174,7 +8080,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8191,21 +8097,21 @@
       "integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "globby": "8.0.1",
-        "grouped-queue": "0.3.3",
-        "inquirer": "5.2.0",
-        "is-scoped": "1.0.0",
-        "lodash": "4.17.10",
-        "log-symbols": "2.2.0",
-        "mem-fs": "1.1.3",
-        "strip-ansi": "4.0.0",
-        "text-table": "0.2.0",
-        "untildify": "3.0.2"
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "diff": "^3.3.1",
+        "escape-string-regexp": "^1.0.2",
+        "globby": "^8.0.1",
+        "grouped-queue": "^0.3.3",
+        "inquirer": "^5.2.0",
+        "is-scoped": "^1.0.0",
+        "lodash": "^4.17.10",
+        "log-symbols": "^2.1.0",
+        "mem-fs": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0",
+        "untildify": "^3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8220,7 +8126,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -8229,9 +8135,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cross-spawn": {
@@ -8240,11 +8146,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -8262,12 +8168,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -8276,13 +8182,13 @@
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "fast-glob": "2.2.1",
-            "glob": "7.1.2",
-            "ignore": "3.3.8",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         },
         "inquirer": {
@@ -8291,19 +8197,19 @@
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.10",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "5.5.10",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "lodash": {
@@ -8324,7 +8230,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -8333,7 +8239,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -8344,31 +8250,31 @@
       "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "chalk": "2.4.1",
-        "cli-table": "0.3.1",
-        "cross-spawn": "6.0.5",
-        "dargs": "5.1.0",
-        "dateformat": "3.0.3",
-        "debug": "3.1.0",
-        "detect-conflict": "1.0.1",
-        "error": "7.0.2",
-        "find-up": "2.1.0",
-        "github-username": "4.1.0",
-        "istextorbinary": "2.2.1",
-        "lodash": "4.17.10",
-        "make-dir": "1.2.0",
-        "mem-fs-editor": "4.0.2",
-        "minimist": "1.2.0",
-        "pretty-bytes": "4.0.2",
-        "read-chunk": "2.1.0",
-        "read-pkg-up": "3.0.0",
-        "rimraf": "2.6.2",
-        "run-async": "2.3.0",
-        "shelljs": "0.8.2",
-        "text-table": "0.2.0",
-        "through2": "2.0.3",
-        "yeoman-environment": "2.1.1"
+        "async": "^2.6.0",
+        "chalk": "^2.3.0",
+        "cli-table": "^0.3.1",
+        "cross-spawn": "^6.0.5",
+        "dargs": "^5.1.0",
+        "dateformat": "^3.0.3",
+        "debug": "^3.1.0",
+        "detect-conflict": "^1.0.0",
+        "error": "^7.0.2",
+        "find-up": "^2.1.0",
+        "github-username": "^4.0.0",
+        "istextorbinary": "^2.2.1",
+        "lodash": "^4.17.10",
+        "make-dir": "^1.1.0",
+        "mem-fs-editor": "^4.0.0",
+        "minimist": "^1.2.0",
+        "pretty-bytes": "^4.0.2",
+        "read-chunk": "^2.1.0",
+        "read-pkg-up": "^3.0.0",
+        "rimraf": "^2.6.2",
+        "run-async": "^2.0.0",
+        "shelljs": "^0.8.0",
+        "text-table": "^0.2.0",
+        "through2": "^2.0.0",
+        "yeoman-environment": "^2.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8377,7 +8283,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "async": {
@@ -8386,7 +8292,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "chalk": {
@@ -8395,9 +8301,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cross-spawn": {
@@ -8406,11 +8312,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "dargs": {
@@ -8434,10 +8340,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "lodash": {
@@ -8452,8 +8358,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -8462,7 +8368,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -8477,9 +8383,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -8488,8 +8394,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "supports-color": {
@@ -8498,7 +8404,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Brett Sun <brett@aragon.one>"
   ],
   "devDependencies": {
-    "coveralls": "^2.13.1",
+    "coveralls": "^3.0.1",
     "ganache-cli": "^6.1.0",
     "lcov-result-merger": "^1.2.0",
     "lerna": "^2.8.0"


### PR DESCRIPTION
solium has a deep dependency on hoek@2.16.3 in voting app, token-manager app, vault app, we will have to wait for a version of solium without these deep dependencies to remove (or update to 4.2.1)  in these apps
![image](https://user-images.githubusercontent.com/8539426/40338011-e0968468-5d40-11e8-99dd-7c5077f4ef11.png)

Updating solium and eth-gas-reporter does not remove or update the hoek dependency to a newer version.

No hoek dependencies in finance app or survey app

Updating coveralls@2.13.3 to coveralls@latest to remove dependency on hoek in root project

Removed 1 high and 6 moderate vulnerabilities in root project

The ticket (#323) specifically stated hoek, but I can remove some other insecure dependencies with this commit if asked :)

Cheers