### PR TITLE
Change vote function comment to 'yea' from 'yay'

### DIFF
--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -109,7 +109,7 @@ contract Voting is IForwarder, AragonApp {
     }
 
     /**
-    * @notice Vote `_supports ? 'yay' : 'nay'` in vote #`_voteId`
+    * @notice Vote `_supports ? 'yea' : 'nay'` in vote #`_voteId`
     * @param _voteId Id for vote
     * @param _supports Whether voter supports the vote
     * @param _executesIfDecided Whether the vote should execute its action if it becomes decided


### PR DESCRIPTION
Throughout the file, "Yea" is used as the spelling, which accurately aligns with the way it is spelled in US politics https://www.senate.gov/general/Features/votes.htm ,  so it should be 'yea' here instead of 'yay'