### PR TITLE
Beta Template: prepublish => prepublishOnly

### DIFF
--- a/templates/beta/package.json
+++ b/templates/beta/package.json
@@ -4,7 +4,7 @@
   "description": "Beta template for v0.5 Aragon orgs",
   "main": "index.js",
   "scripts": {
-    "prepublish": "truffle compile && node scripts/extract-abis.js",
+    "prepublishOnly": "truffle compile && node scripts/extract-abis.js",
     "deploy:rinkeby": "truffle migrate --network rinkeby --reset",
     "deploy:rpc": "truffle migrate --network rpc --reset",
     "deploy:devnet": "truffle migrate --network devnet --reset",


### PR DESCRIPTION
`npm install`ing in the root would fail because the beta template's `prepublish` script would run and fail.