### PR TITLE
Publish survey@0.0.1

### DIFF
--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/apps-survey",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "main": "index.js",
   "scripts": {
     "compile": "truffle compile",


### PR DESCRIPTION
Required for dao-kits to install properly.

We can publish 1.0.0 when we merge the frontend.