### PR TITLE
Survey: add event when votes are reset

### DIFF
--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -54,6 +54,7 @@ contract Survey is AragonApp {
 
     event StartSurvey(uint256 indexed surveyId);
     event CastVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 stake);
+    event ResetVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 previousStake);
     event ChangeMinParticipation(uint256 minParticipationPct);
 
     /**
@@ -124,6 +125,8 @@ contract Survey is AragonApp {
             for (uint256 i = 1; i <= previousVote.optionsCastedLength; i++) {
                 OptionCast storage previousOptionCast = previousVote.castedVotes[i];
                 survey.optionPower[previousOptionCast.optionId] = survey.optionPower[previousOptionCast.optionId].sub(previousOptionCast.stake);
+
+                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake)
             }
 
             // compute previously casted votes (i.e. substract non-used tokens from stake)

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -126,7 +126,7 @@ contract Survey is AragonApp {
                 OptionCast storage previousOptionCast = previousVote.castedVotes[i];
                 survey.optionPower[previousOptionCast.optionId] = survey.optionPower[previousOptionCast.optionId].sub(previousOptionCast.stake);
 
-                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake)
+                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake);
             }
 
             // compute previously casted votes (i.e. substract non-used tokens from stake)


### PR DESCRIPTION
Just realized that if someone directly invokes `resetVote()`, we'd never be able to know about it because there's no events.

This does cause `voteOptions()` to emit some, strictly speaking, unnecessary events (`CastVote` will be emitted immediately after), but I think this is better than hiding them; otherwise, from an event stream, it might look like that person is always adding more and more votes on each vote rather than resetting them each time.