### PR TITLE
Survey: emit current option's power

### DIFF
--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -53,8 +53,8 @@ contract Survey is AragonApp {
     SurveyStruct[] surveys;
 
     event StartSurvey(uint256 indexed surveyId);
-    event CastVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 optionPower);
-    event ResetVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 optionPower);
+    event CastVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 stake, uint256 optionPower);
+    event ResetVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 previousStake, uint256 optionPower);
     event ChangeMinParticipation(uint256 minParticipationPct);
 
     /**
@@ -124,9 +124,10 @@ contract Survey is AragonApp {
             // voter removes their vote
             for (uint256 i = 1; i <= previousVote.optionsCastedLength; i++) {
                 OptionCast storage previousOptionCast = previousVote.castedVotes[i];
-                survey.optionPower[previousOptionCast.optionId] = survey.optionPower[previousOptionCast.optionId].sub(previousOptionCast.stake);
+                uint256 previousOptionPower = survey.optionPower[previousOptionCast.optionId];
+                survey.optionPower[previousOptionCast.optionId] = previousOptionPower.sub(previousOptionCast.stake);
 
-                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, survey.optionPower[previousOptionCast.optionId]);
+                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake, previousOptionPower);
             }
 
             // compute previously casted votes (i.e. substract non-used tokens from stake)
@@ -180,7 +181,7 @@ contract Survey is AragonApp {
             // keep track of staked used so far
             totalVoted = totalVoted.add(stake);
 
-            CastVote(_surveyId, msg.sender, optionId, survey.optionPower[optionId]);
+            CastVote(_surveyId, msg.sender, optionId, stake, survey.optionPower[optionId]);
         }
 
         // compute and register non used tokens

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -53,8 +53,8 @@ contract Survey is AragonApp {
     SurveyStruct[] surveys;
 
     event StartSurvey(uint256 indexed surveyId);
-    event CastVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 stake);
-    event ResetVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 previousStake);
+    event CastVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 optionPower);
+    event ResetVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 optionPower);
     event ChangeMinParticipation(uint256 minParticipationPct);
 
     /**
@@ -126,7 +126,7 @@ contract Survey is AragonApp {
                 OptionCast storage previousOptionCast = previousVote.castedVotes[i];
                 survey.optionPower[previousOptionCast.optionId] = survey.optionPower[previousOptionCast.optionId].sub(previousOptionCast.stake);
 
-                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake);
+                ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, survey.optionPower[previousOptionCast.optionId]);
             }
 
             // compute previously casted votes (i.e. substract non-used tokens from stake)
@@ -180,7 +180,7 @@ contract Survey is AragonApp {
             // keep track of staked used so far
             totalVoted = totalVoted.add(stake);
 
-            CastVote(_surveyId, msg.sender, optionId, stake);
+            CastVote(_surveyId, msg.sender, optionId, survey.optionPower[optionId]);
         }
 
         // compute and register non used tokens


### PR DESCRIPTION
Makes it much, much easier on the frontend to calculate historical information about how an option was voted in a survey.

The voter's stake can still be found either by looking at the contract (if it hasn't been changed), or by looking at the events between two voting events.