### PR TITLE
Voting: don't render SidePanel unless there's a vote to display

### DIFF
--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -167,17 +167,16 @@ class App extends React.Component {
           </AppLayout.ScrollWrapper>
         </AppLayout>
 
-        {displayVotes && (
-          <SidePanel
-            title={
-              currentVote &&
-              `Vote #${currentVoteId} (${currentVote.open ? 'Open' : 'Closed'})`
-            }
-            opened={Boolean(!createVoteVisible && voteVisible)}
-            onClose={this.handleVoteClose}
-            onTransitionEnd={this.handleVoteTransitionEnd}
-          >
-            {currentVote && (
+        {displayVotes &&
+          currentVote && (
+            <SidePanel
+              title={`Vote #${currentVoteId} (${
+                currentVote.open ? 'Open' : 'Closed'
+              })`}
+              opened={Boolean(!createVoteVisible && voteVisible)}
+              onClose={this.handleVoteClose}
+              onTransitionEnd={this.handleVoteTransitionEnd}
+            >
               <VotePanelContent
                 app={app}
                 vote={currentVote}
@@ -186,9 +185,8 @@ class App extends React.Component {
                 tokenContract={tokenContract}
                 onVote={this.handleVote}
               />
-            )}
-          </SidePanel>
-        )}
+            </SidePanel>
+          )}
 
         <SidePanel
           title="New Vote"


### PR DESCRIPTION
Fixes a propTypes error, because `title` is required.

AFAIK, this doesn't affect the `SidePanel`'s rendering and transitioning.