### PR TITLE
Finance: upgrade solidity-coverage to 0.4.3

### DIFF
--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -34,7 +34,7 @@
     "@aragon/test-helpers": "^1.0.0",
     "eth-gas-reporter": "^0.1.1",
     "ganache-cli": "^6.0.3",
-    "solidity-coverage": "0.3.5",
+    "solidity-coverage": "0.4.3",
     "solium": "^1.0.4",
     "truffle": "4.0.5",
     "truffle-hdwallet-provider": "0.0.3"


### PR DESCRIPTION
solidity-coverage@0.3.5 depends on a different version of webpack (3.12.0) rather than what react-scripts wants (3.10.0).