### PR TITLE
Payroll review

### DIFF
--- a/future-apps/payroll/arapp.json
+++ b/future-apps/payroll/arapp.json
@@ -16,7 +16,7 @@
         }
     ],
     "roles": [
-        { "name": "Add employees", "id": "ADD_EMPLOYEE_ROLE", "params": ["Initial yearly payroll", "Start date"] },
+        { "name": "Add employees", "id": "ADD_EMPLOYEE_ROLE", "params": ["Account address", "Initial yearly payroll", "Start date"] },
         { "name": "Remove employees", "id": "REMOVE_EMPLOYEE_ROLE" },
         { "name": "Allowed Tokens Manager", "id": "ALLOWED_TOKENS_MANAGER_ROLE", "params": "Token" },
         { "name": "Change Price Feed", "id": "CHANGE_PRICE_FEED_ROLE", "params": ["Old Price Feed", "New Price Feed"] },

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -50,15 +50,15 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
     address[] private allowedTokensArray;
 
     event AddEmployee(
-        uint128 employeeId,
-        address accountAddress,
+        uint128 indexed employeeId,
+        address indexed accountAddress,
         uint256 initialYearlyDenominationSalary,
         string name,
         uint256 startDate
     );
 
-    event Fund(address sender, address token, uint amount, uint balance, bytes data);
-    event SendPayroll(address employee, address token, uint amount);
+    event Fund(address indexed sender, address indexed token, uint amount, uint balance, bytes data);
+    event SendPayroll(address indexed employee, address indexed token, uint amount);
     event SetPriceFeed(address feed);
     event SetRateExpiryTime(uint64 time);
 

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -256,9 +256,8 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
     /**
      * @dev Set token distribution for payments to an employee (the caller)
      * @notice Set token distribution for payments to an employee (the caller).
-     *         Only callable once every 6 months
      * @param tokens Array with the tokens to receive, they must belong to allowed tokens for employee
-     * @param distribution Array (correlated to tokens) with the proportions (integers over 100)
+     * @param distribution Array (correlated to tokens) with the proportions (integers summing to 100)
      */
     function determineAllocation(address[] tokens, uint8[] distribution) external {
         Employee storage employee = employees[employeeIds[msg.sender]];
@@ -268,10 +267,14 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         // check arrays match
         require(tokens.length == distribution.length);
 
+        // delete previous allocation
+        for (uint32 j = 0; j < allowedTokensArray.length; j++) {
+            delete employee.allocation[allowedTokensArray[j]];
+        }
+
         // check distribution is right
         uint8 sum = 0;
-        uint32 i;
-        for (i = 0; i < distribution.length; i++) {
+        for (uint32 i = 0; i < distribution.length; i++) {
             // check token is allowed
             require(allowedTokens[tokens[i]]);
             // set distribution

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -7,6 +7,7 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 import "@aragon/os/contracts/lib/zeppelin/token/ERC20.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/zeppelin/math/SafeMath64.sol";
+import "@aragon/os/contracts/lib/zeppelin/math/SafeMath8.sol";
 
 import "@aragon/ppf-contracts/contracts/IFeed.sol";
 
@@ -19,6 +20,7 @@ import "@aragon/apps-finance/contracts/Finance.sol";
 contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (removes pure and interface doesnt match)
     using SafeMath for uint256;
     using SafeMath64 for uint64;
+    using SafeMath8 for uint8;
 
     // kernel roles
     bytes32 constant public ADD_EMPLOYEE_ROLE = keccak256("ADD_EMPLOYEE_ROLE");
@@ -281,8 +283,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
             require(allowedTokens[tokens[i]]);
             // set distribution
             employee.allocation[tokens[i]] = distribution[i];
-            sum += distribution[i];
-            require(sum >= distribution[i]);
+            sum = sum.add(distribution[i]);
         }
         require(sum == 100);
     }

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -315,7 +315,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
 
         employee.accountAddress = newAddress;
         employeeIds[newAddress] = employeeId;
-        employeeIds[msg.sender] = 0;
+        delete employeeIds[msg.sender];
     }
 
     /**
@@ -350,6 +350,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @dev Get payment proportion for a token and an employee (the caller)
      * @notice Get payment proportion for a token and an employee (the caller)
      * @param token The token address
+     * @return Allocation for token and employee
      */
     function getAllocation(address token) external view returns (uint8 allocation) {
         return employees[employeeIds[msg.sender]].allocation[token];
@@ -365,7 +366,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
     }
 
     /**
-     * @dev IForwarder interface conformance. Forwards any token holder action.
+     * @dev IForwarder interface conformance. Forwards any employee action.
      * @param _evmScript script being executed
      */
     function forward(bytes _evmScript) public {

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -319,7 +319,36 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
     }
 
     /**
-     * @dev Return all important info too through employees mapping
+     * @dev Return all Employee's important info
+     * @notice Return all Employee's important info
+     * @param accountAddress Employee's address to receive payments
+     * @return Employee's identifier
+     * @return Employee's annual salary, per second in denomination Token
+     * @return Employee's name
+     * @return Employee's last call to payment distribution date
+     * @return Employee's last payment received date
+     */
+    function getEmployeeByAddress(address accountAddress)
+        external
+        view
+        returns (
+            uint128 employeeId,
+            uint256 denominationSalary,
+            string name,
+            uint256 lastPayroll
+        )
+    {
+        employeeId = employeeIds[accountAddress];
+
+        Employee memory employee = employees[employeeId];
+
+        denominationSalary = employee.denominationTokenSalary;
+        name = employee.name;
+        lastPayroll = employee.lastPayroll;
+    }
+
+    /**
+     * @dev Return all Employee's important info
      * @notice Return all Employee's important info
      * @param employeeId Employee's identifier
      * @return Employee's address to receive payments
@@ -338,7 +367,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
             uint256 lastPayroll
         )
     {
-        Employee storage employee = employees[employeeId];
+        Employee memory employee = employees[employeeId];
 
         accountAddress = employee.accountAddress;
         denominationSalary = employee.denominationTokenSalary;
@@ -497,5 +526,4 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
     }
 
     function getTimestamp() internal view returns (uint256) { return now; }
-
 }

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -474,7 +474,6 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         // update last payroll date first thing (to avoid re-entrancy)
         employee.lastPayroll = getTimestamp();
         // loop over allowed tokens
-        somethingPaid = false;
         for (uint32 i = 0; i < allowedTokensArray.length; i++) {
             address token = allowedTokensArray[i];
             if (employee.allocation[token] == 0)

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -131,7 +131,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         uint256 initialYearlyDenominationSalary
     )
         external
-        authP(ADD_EMPLOYEE_ROLE, arr(initialYearlyDenominationSalary, getTimestamp()))
+        authP(ADD_EMPLOYEE_ROLE, arr(accountAddress, initialYearlyDenominationSalary, getTimestamp()))
     {
         _addEmployee(
             accountAddress,
@@ -154,7 +154,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         string name
     )
         external
-        authP(ADD_EMPLOYEE_ROLE, arr(initialYearlyDenominationSalary, getTimestamp()))
+        authP(ADD_EMPLOYEE_ROLE, arr(accountAddress, initialYearlyDenominationSalary, getTimestamp()))
     {
         _addEmployee(
             accountAddress,
@@ -180,7 +180,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         uint256 startDate
     )
         external
-        authP(ADD_EMPLOYEE_ROLE, arr(initialYearlyDenominationSalary, startDate))
+        authP(ADD_EMPLOYEE_ROLE, arr(accountAddress, initialYearlyDenominationSalary, startDate))
     {
         _addEmployee(
             accountAddress,
@@ -201,7 +201,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         uint256 yearlyDenominationSalary
     )
         external
-        authP(ADD_EMPLOYEE_ROLE, arr(yearlyDenominationSalary, 0))
+        authP(ADD_EMPLOYEE_ROLE, arr(employees[employeeId].accountAddress, yearlyDenominationSalary, 0))
     {
         /* check that employee exists */
         require(employeeIds[employees[employeeId].accountAddress] != 0);

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -118,7 +118,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
 
     /**
      * @dev Add token to the allowed set
-     * @notice Add token to the allowed set
+     * @notice Add `_allowedToken` to the set of allowed tokens
      * @param _allowedToken New token allowed for payment
      */
     function addAllowedToken(address _allowedToken) isInitialized external authP(ALLOWED_TOKENS_MANAGER_ROLE, arr(_allowedToken)) {
@@ -134,8 +134,8 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      */
 
     /**
-     * @dev Add employee to Payroll
-     * @notice Add employee to Payroll. See addEmployeeWithNameAndStartDate
+     * @dev Add employee to Payroll. See addEmployeeWithNameAndStartDate
+     * @notice Add employee with address `accountAddress` to Payroll with a salary of `initialDenominationSalary` per second.
      * @param accountAddress Employee's address to receive Payroll
      * @param initialDenominationSalary Employee's salary, per second in denomination Token
      */
@@ -155,8 +155,8 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
     }
 
     /**
-     * @dev Add employee to Payroll
-     * @notice Add employee to Payroll. See addEmployeeWithNameAndStartDate
+     * @dev Add employee to Payroll. See addEmployeeWithNameAndStartDate
+     * @notice Add employee `name` with address `accountAddress` to Payroll with a salary of `initialDenominationSalary` per second.
      * @param accountAddress Employee's address to receive Payroll
      * @param initialDenominationSalary Employee's salary, per second in denomination Token
      * @param name Employee's name
@@ -179,7 +179,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
 
     /**
      * @dev Add employee to Payroll
-     * @notice Creates employee, adds it to mappings, initializes values.
+     * @notice Add employee `name` with address `accountAddress` to Payroll with a salary of `initialDenominationSalary` per second, starting on `startDate`.
      * @param accountAddress Employee's address to receive Payroll
      * @param initialDenominationSalary Employee's salary, per second in denomintation Token
      * @param name Employee's name
@@ -204,6 +204,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
 
     /**
      * @dev Set employee's annual salary
+     * @notice Set employee #`employeeId` annual salary to `denominationSalary` per second.
      * @param employeeId Employee's identifier
      * @param denominationSalary Employee's new salary, per second in denomintation Token
      */
@@ -221,6 +222,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
 
     /**
      * @dev Remove employee from Payroll
+     * @notice Remove employee #`employeeId` from Payroll
      * @param employeeId Employee's identifier
      */
     function removeEmployee(uint128 employeeId) isInitialized employeeExists(employeeId) external auth(REMOVE_EMPLOYEE_ROLE) {
@@ -301,7 +303,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
 
     /**
      * @dev Change employee account address. To be called by Employee
-     * @notice Change employee account address
+     * @notice Change employee account address to `newAddress`
      * @param newAddress New address to receive payments
      */
     function changeAddressByEmployee(address newAddress) isInitialized employeeMatches external {

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -101,7 +101,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @notice Sets the Price Feed for exchange rates to `_feed`.
      * @param _feed The Price Feed address
      */
-    function setPriceFeed(IFeed _feed) external authP(CHANGE_PRICE_FEED_ROLE, arr(feed, _feed)) {
+    function setPriceFeed(IFeed _feed) isInitialized external authP(CHANGE_PRICE_FEED_ROLE, arr(feed, _feed)) {
         _setPriceFeed(_feed);
     }
 
@@ -110,7 +110,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @notice Sets the exchange rate expiry time to `_time`.
      * @param _time The expiration time in seconds for exchange rates
      */
-    function setRateExpiryTime(uint64 _time) external authP(MODIFY_RATE_EXPIRY_ROLE, arr(uint256(_time))) {
+    function setRateExpiryTime(uint64 _time) isInitialized external authP(MODIFY_RATE_EXPIRY_ROLE, arr(uint256(_time))) {
         _setRateExpiryTime(_time);
     }
 
@@ -119,7 +119,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @notice Add token to the allowed set
      * @param _allowedToken New token allowed for payment
      */
-    function addAllowedToken(address _allowedToken) external authP(ALLOWED_TOKENS_MANAGER_ROLE, arr(_allowedToken)) {
+    function addAllowedToken(address _allowedToken) isInitialized external authP(ALLOWED_TOKENS_MANAGER_ROLE, arr(_allowedToken)) {
         require(!allowedTokens[_allowedToken]);
         allowedTokens[_allowedToken] = true;
         allowedTokensArray.push(_allowedToken);
@@ -209,6 +209,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         uint128 employeeId,
         uint256 denominationSalary
     )
+        isInitialized
         employeeExists(employeeId)
         external
         authP(ADD_EMPLOYEE_ROLE, arr(employees[employeeId].accountAddress, denominationSalary, 0))
@@ -220,7 +221,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @dev Remove employee from Payroll
      * @param employeeId Employee's identifier
      */
-    function removeEmployee(uint128 employeeId) employeeExists(employeeId) external auth(REMOVE_EMPLOYEE_ROLE) {
+    function removeEmployee(uint128 employeeId) isInitialized employeeExists(employeeId) external auth(REMOVE_EMPLOYEE_ROLE) {
         // Pay owed salary to employee
         _payTokens(employeeId);
 
@@ -233,7 +234,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      *      but in case it happens, this function allows to recover them.
      * @notice Allows to send ETH from this contract to Finance, to avoid locking them in contract forever.
      */
-    function escapeHatch() external {
+    function escapeHatch() isInitialized external {
         finance.call.value(this.balance)();
     }
 
@@ -244,7 +245,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
             but in case it happens, this function allows to recover them.
      * @notice Allows to send tokens from this contract to Finance, to avoid locked tokens in contract forever
      */
-    function depositToFinance(address token) external {
+    function depositToFinance(address token) isInitialized external {
         ERC20 tokenContract = ERC20(token);
         uint256 value = tokenContract.balanceOf(this);
         if (value == 0)
@@ -262,7 +263,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @param tokens Array with the tokens to receive, they must belong to allowed tokens for employee
      * @param distribution Array (correlated to tokens) with the proportions (integers summing to 100)
      */
-    function determineAllocation(address[] tokens, uint8[] distribution) employeeMatches external {
+    function determineAllocation(address[] tokens, uint8[] distribution) isInitialized employeeMatches external {
         Employee storage employee = employees[employeeIds[msg.sender]];
 
         // check arrays match
@@ -290,7 +291,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @dev To withdraw payment by employee (the caller). The amount owed since last call will be transferred.
      * @notice To withdraw payment by employee (the caller). The amount owed since last call will be transferred.
      */
-    function payday() employeeMatches external {
+    function payday() isInitialized employeeMatches external {
         Employee storage employee = employees[employeeIds[msg.sender]];
 
         bool somethingPaid = _payTokens(employeeIds[msg.sender]);
@@ -302,7 +303,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
      * @notice Change employee account address
      * @param newAddress New address to receive payments
      */
-    function changeAddressByEmployee(address newAddress) employeeMatches external {
+    function changeAddressByEmployee(address newAddress) isInitialized employeeMatches external {
         // check that account doesn't exist
         require(employeeIds[newAddress] == 0);
         // check it's non-null address
@@ -389,6 +390,7 @@ contract Payroll is AragonApp { //, IForwarder { // makes coverage crash (remove
         string name,
         uint256 startDate
     )
+        isInitialized
         internal
     {
         // check that account doesn't exist

--- a/future-apps/payroll/test/payroll.js
+++ b/future-apps/payroll/test/payroll.js
@@ -66,8 +66,7 @@ contract('Payroll', function(accounts) {
   const getTimePassed = async (employeeId) => {
     let employee = await payroll.getEmployee(employeeId);
     let currentTime = await payroll.getTimestampPublic();
-    let timePassed = currentTime - employee[3];
-    return new Promise(resolve => {resolve(timePassed);});
+    return currentTime - employee[3];
   };
 
   before(async () => {
@@ -346,10 +345,10 @@ contract('Payroll', function(accounts) {
     const getTxFee = async (transaction) => {
       let tx = await getTransaction(transaction.tx);
       let gasPrice = new web3.BigNumber(tx.gasPrice);
-      let txFee = gasPrice.times(transaction.receipt.cumulativeGasUsed);
 
-      return new Promise(resolve => {resolve(txFee);});
+      return gasPrice.times(transaction.receipt.cumulativeGasUsed);
     };
+
     const addInitialBalance = async (token, name="", generate=true, decimals=18) => {
       let txFee = new web3.BigNumber(0);
       // add some tokens to Payroll (it shouldn't happen, but to test it)
@@ -366,7 +365,7 @@ contract('Payroll', function(accounts) {
       vaultTokenBalances[token.address] = vaultBalance;
       payrollTokenBalances[token.address] = payrollBalance;
 
-      return new Promise(resolve => {resolve(txFee);});
+      return txFee;
     };
     const checkFinalBalance = async (token, name="") => {
       let vaultBalance = await token.balanceOf(vault.address);

--- a/future-apps/payroll/test/payroll.js
+++ b/future-apps/payroll/test/payroll.js
@@ -579,7 +579,18 @@ contract('Payroll', function(accounts) {
     return assertRevert(async () => {
       await payroll.payday({from: employee2});
     })
+  })
 
+  it("determining allocation deletes previous entries", async () => {
+    await payroll.determineAllocation([ETH], [100], {from: employee1});
+    await payroll.determineAllocation([usdToken.address], [100], {from: employee1});
+    const tokens = [usdToken, erc20Token1, erc20Token2]
+    const currencies = [ETH].concat(tokens.map(c => c.address))
+    let totalAllocation = 0
+    for (let tokenAddress of currencies) {
+      totalAllocation += parseInt(await payroll.getAllocation(tokenAddress, {from: employee1}), 10)
+    }
+    assert.equal(totalAllocation, 100, "Total allocation should remain 100")
   })
 
   it('fails to change the price feed time to 0', async () => {

--- a/future-apps/payroll/test/payroll.js
+++ b/future-apps/payroll/test/payroll.js
@@ -136,7 +136,18 @@ contract('Payroll', function(accounts) {
     assert.equal(employee[0], employee1_1, "Employee account doesn't match");
     assert.equal(employee[1].toString(), salary1_1.toString(), "Employee salary doesn't match");
     assert.equal(employee[2], name, "Employee name doesn't match");
+    assert.equal(employee[3].toString(), (await payroll.getTimestampPublic()).toString(), "last payroll should match")
   });
+
+  it('get employee by its address', async () => {
+    let name = '';
+    let employeeId = 1;
+    let employee = await payroll.getEmployeeByAddress(employee1_1);
+    assert.equal(employee[0], employeeId, "Employee Id doesn't match");
+    assert.equal(employee[1].toString(), salary1_1.toString(), "Employee salary doesn't match");
+    assert.equal(employee[2], name, "Employee name doesn't match");
+    assert.equal(employee[3].toString(), (await payroll.getTimestampPublic()).toString(), "last payroll should match")
+  })
 
   it("fails adding again same employee", async () => {
     return assertRevert(async () => {

--- a/future-apps/payroll/test/payroll.js
+++ b/future-apps/payroll/test/payroll.js
@@ -28,11 +28,11 @@ contract('Payroll', function(accounts) {
   let employee1_2 = accounts[4];
   let unused_account = accounts[7];
   let total_salary = 0;
-  let salary1_1 = (new web3.BigNumber(100000)).times(USD_PRECISION);
-  let salary1_2 = (new web3.BigNumber(110000)).times(USD_PRECISION);
+  let salary1_1 = (new web3.BigNumber(100000)).times(USD_PRECISION).dividedToIntegerBy(SECONDS_IN_A_YEAR);
+  let salary1_2 = (new web3.BigNumber(110000)).times(USD_PRECISION).dividedToIntegerBy(SECONDS_IN_A_YEAR);
   let salary1 = salary1_1;
-  let salary2_1 = (new web3.BigNumber(120000)).times(USD_PRECISION);
-  let salary2_2 = (new web3.BigNumber(125000)).times(USD_PRECISION);
+  let salary2_1 = (new web3.BigNumber(120000)).times(USD_PRECISION).dividedToIntegerBy(SECONDS_IN_A_YEAR);
+  let salary2_2 = (new web3.BigNumber(125000)).times(USD_PRECISION).dividedToIntegerBy(SECONDS_IN_A_YEAR);
   let salary2 = salary2_1;
   let usdToken;
   let erc20Token1;
@@ -128,10 +128,6 @@ contract('Payroll', function(accounts) {
     });
   });
 
-  const convertAndRoundSalary = function (a) {
-    return a.dividedToIntegerBy(SECONDS_IN_A_YEAR).times(SECONDS_IN_A_YEAR);
-  };
-
   it("adds employee", async () => {
     let name = '';
     let employeeId = 1;
@@ -139,7 +135,7 @@ contract('Payroll', function(accounts) {
     salary1 = salary1_1;
     let employee = await payroll.getEmployee(employeeId);
     assert.equal(employee[0], employee1_1, "Employee account doesn't match");
-    assert.equal(employee[1].toString(), convertAndRoundSalary(salary1_1).toString(), "Employee salary doesn't match");
+    assert.equal(employee[1].toString(), salary1_1.toString(), "Employee salary doesn't match");
     assert.equal(employee[2], name, "Employee name doesn't match");
   });
 
@@ -156,7 +152,7 @@ contract('Payroll', function(accounts) {
     salary2 = salary2_1;
     let employee = await payroll.getEmployee(employeeId);
     assert.equal(employee[0], employee2, "Employee account doesn't match");
-    assert.equal(employee[1].toString(), convertAndRoundSalary(salary2_1).toString(), "Employee salary doesn't match");
+    assert.equal(employee[1].toString(), salary2_1.toString(), "Employee salary doesn't match");
     assert.equal(employee[2], name, "Employee name doesn't match");
   });
 
@@ -180,7 +176,7 @@ contract('Payroll', function(accounts) {
     salary2 = salary2_1;
     let employee = await payroll.getEmployee(employeeId);
     assert.equal(employee[0], employee2, "Employee account doesn't match");
-    assert.equal(employee[1].toString(), convertAndRoundSalary(salary2_1).toString(), "Employee salary doesn't match");
+    assert.equal(employee[1].toString(), salary2_1.toString(), "Employee salary doesn't match");
     assert.equal(employee[2], name, "Employee name doesn't match");
   });
 
@@ -189,7 +185,7 @@ contract('Payroll', function(accounts) {
     await payroll.determineAllocation([usdToken.address], [100], {from: employee2});
     let initialBalance = await usdToken.balanceOf(employee2);
     let timePassed = await getTimePassed(employeeId);
-    let owed = salary2.dividedToIntegerBy(SECONDS_IN_A_YEAR).times(timePassed);
+    let owed = salary2.times(timePassed);
     await payroll.removeEmployee(employeeId);
     salary2 = 0;
     let finalBalance = await usdToken.balanceOf(employee2);
@@ -209,7 +205,7 @@ contract('Payroll', function(accounts) {
     let transaction = await payroll.addEmployeeWithNameAndStartDate(employee2, salary2_2, name, Math.floor((new Date()).getTime() / 1000) - 2628600);
     let employee = await payroll.getEmployee(employeeId);
     assert.equal(employee[0], employee2, "Employee account doesn't match");
-    assert.equal(employee[1].toString(), convertAndRoundSalary(salary2_2).toString(), "Employee salary doesn't match");
+    assert.equal(employee[1].toString(), salary2_2.toString(), "Employee salary doesn't match");
     assert.equal(employee[2], name, "Employee name doesn't match");
     salary2 = salary2_2;
   });
@@ -219,7 +215,7 @@ contract('Payroll', function(accounts) {
     await payroll.setEmployeeSalary(employeeId, salary1_2);
     salary1 = salary1_2;
     let employee = await payroll.getEmployee(employeeId);
-    assert.equal(employee[1].toString(), convertAndRoundSalary(salary1_2).toString(), "Salary doesn't match");
+    assert.equal(employee[1].toString(), salary1_2.toString(), "Salary doesn't match");
   });
 
   it("fails modifying non-existent employee salary", async () => {
@@ -501,7 +497,7 @@ contract('Payroll', function(accounts) {
     };
 
     const checkTokenBalances = async (token, salary, timePassed, initialBalancePayroll, initialBalanceEmployee, exchangeRate, allocation, name='') => {
-      let payed = salary.dividedToIntegerBy(SECONDS_IN_A_YEAR).times(exchangeRate).times(allocation).times(timePassed).dividedToIntegerBy(100).dividedToIntegerBy(ONE)
+      let payed = salary.times(exchangeRate).times(allocation).times(timePassed).dividedToIntegerBy(100).dividedToIntegerBy(ONE)
       let expectedPayroll = initialBalancePayroll.minus(payed);
       let expectedEmployee = initialBalanceEmployee.plus(payed);
       let newBalancePayroll;
@@ -520,7 +516,7 @@ contract('Payroll', function(accounts) {
       let txFee = gasPrice.times(transaction.receipt.cumulativeGasUsed);
       let newEthPayroll = await getBalance(vault.address);
       let newEthEmployee2 = await getBalance(employee2);
-      let payed = salary2.dividedToIntegerBy(SECONDS_IN_A_YEAR).times(etherExchangeRate).times(ethAllocation).times(timePassed).dividedToIntegerBy(100).dividedToIntegerBy(ONE)
+      let payed = salary2.times(etherExchangeRate).times(ethAllocation).times(timePassed).dividedToIntegerBy(100).dividedToIntegerBy(ONE)
       let expectedPayroll = initialEthPayroll.minus(payed);
       let expectedEmployee2 = initialEthEmployee2.plus(payed).minus(txFee);
       //logPayroll(salary2, initialEthPayroll, initialEthEmployee2, payed, newEthPayroll, newEthEmployee2, expectedPayroll, expectedEmployee2, "ETH");

--- a/future-apps/payroll/test/payroll_init.js
+++ b/future-apps/payroll/test/payroll_init.js
@@ -1,0 +1,108 @@
+const { assertRevert } = require('@aragon/test-helpers/assertThrow');
+
+const MiniMeToken = artifacts.require('@aragon/os/contracts/common/MiniMeToken');
+const Vault = artifacts.require('Vault');
+const Finance = artifacts.require('Finance');
+const Payroll = artifacts.require("Payroll");
+const PriceFeedMock = artifacts.require("./mocks/feed/PriceFeedMock.sol");
+
+contract('Payroll without init', function([owner, employee1, _]) {
+  let vault, finance, payroll, priceFeed, erc20Token1;
+
+  const SECONDS_IN_A_YEAR = 31557600; // 365.25 days
+  const erc20Token1Decimals = 18;
+
+  const deployErc20Token = async (name="ERC20Token", decimals=18) => {
+    let token = await MiniMeToken.new("0x0", "0x0", 0, name, decimals, 'E20', true); // dummy parameters for minime
+    let amount = new web3.BigNumber(10**9).times(new web3.BigNumber(10**decimals));
+    let sender = owner;
+    let receiver = finance.address;
+    let initialSenderBalance = await token.balanceOf(sender);
+    let initialVaultBalance = await token.balanceOf(vault.address);
+    await token.generateTokens(sender, amount);
+    await token.approve(receiver, amount, {from: sender});
+    await finance.deposit(token.address, amount, "Initial deployment", {from: sender});
+    assert.equal((await token.balanceOf(sender)).toString(), initialSenderBalance.toString());
+    assert.equal((await token.balanceOf(vault.address)).toString(), (new web3.BigNumber(initialVaultBalance).plus(amount)).toString());
+    return token;
+  };
+
+  beforeEach(async () => {
+    vault = await Vault.new();
+    await vault.initializeWithBase(vault.address)
+    finance = await Finance.new();
+    await finance.initialize(vault.address, SECONDS_IN_A_YEAR); // more than one day
+
+    priceFeed = await PriceFeedMock.new();
+    payroll = await Payroll.new();
+
+    // Deploy ERC 20 Tokens
+    erc20Token1 = await deployErc20Token("Token 1", erc20Token1Decimals);
+  })
+
+  it('fails to call setPriceFeed', async () => {
+    return assertRevert(async () => {
+      await payroll.setPriceFeed(priceFeed.address)
+    })
+  })
+
+  it('fails to call setRateExpiryTime', async () => {
+    return assertRevert(async () => {
+      await payroll.setRateExpiryTime(1000)
+    })
+  })
+
+  it('fails to call addAllowedToken', async () => {
+    return assertRevert(async () => {
+      await payroll.addAllowedToken(erc20Token1.address)
+    })
+  })
+
+  it('fails to call addEmployee', async () => {
+    return assertRevert(async () => {
+      await payroll.addEmployee(employee1, 10000)
+    })
+  })
+
+  it('fails to call setEmployeeSalary', async () => {
+    return assertRevert(async () => {
+      await payroll.setEmployeeSalary(1, 20000)
+    })
+  })
+
+  it('fails to call removeEmployee', async () => {
+    return assertRevert(async () => {
+      await payroll.removeEmployee(1)
+    })
+  })
+
+  it('fails to call escapeHatch', async () => {
+    return assertRevert(async () => {
+      await payroll.escapeHatch()
+    })
+  })
+
+  it('fails to call depositToFinance', async () => {
+    return assertRevert(async () => {
+      await payroll.depositToFinance(erc20Token1.address)
+    })
+  })
+
+  it('fails to call determineAllocation', async () => {
+    return assertRevert(async () => {
+      await payroll.determineAllocation([erc20Token1.address], [100], { from: employee1 })
+    })
+  })
+
+  it('fails to call payday', async () => {
+    return assertRevert(async () => {
+      await payroll.payday({ from: employee1 })
+    })
+  })
+
+  it('fails to call changeAddressByEmployee', async () => {
+    return assertRevert(async () => {
+      await payroll.changeAddressByEmployee(owner, { from: employee1 })
+    })
+  })
+})


### PR DESCRIPTION
Addressing @sohkai review:

Big:
​
- [X] _payTokens() is at risk of re-entrancy: if an employee sets their address to have a fallback that re-enters the payroll app, both of payday() and removeEmployee() will give that employee more funds than they should
- [X] Should determineAllocation() clear the employee's allocation mapping before setting it (otherwise old allocations could still exist)?
- [X] Setting allocation: time between could be parameterized in the initialize (https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L253) (But I think this isn't actually true... there's no speed bump for setting allocations afaik?)
​
Small:
​
- [X] Events: some of the parameters could be indexed
- [X] ADD_EMPLOYEE_ROLE: should this also pass the address (useful if you wanted to whitelist / blacklist certain addresses, e.g. those who hold a token?)
- [x] Maybe another role should be added for setEmployeeSalary?
- [X] Setting salary: seems weird that the arguments are in yearly time, when the storage is in second time. Could push that responsibility to a frontend instead?
- [X] Could make require(employeeIds[employees[employeeId].accountAddress] != 0) an employeeExists modifier
- [ ] escapehatch might not be necessary anymore; token escape hatch could also be comboed into one function
- [X] https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L255 should probably say integers summing to 100?
- [X] We could make a small uint8 safemath implementation and use it instead of checking asserts (could even push it to zeppelin)
- [X] https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L316 could use a delete instead
- [x] getEmployee(): could have an overload for getting the employee by address
- [X] getAllocation() is missing a return natspec description: https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L350
- [X] https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L367 has a small typo ("token")
- [x] https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L427 is technically unnecessary (it's defaulted to false)
- [ ] If we're going to use uint32 to iterate over allowedTokensArray (https://github.com/aragon/aragon-apps/blob/master/future-apps/payroll/contracts/Payroll.sol#L428), we should probably also check that the length does not overflow when we push to it (and add a comment or assertion in the iteration); given gas costs, I'd suggest even lowering that allowed space to uint16 or something.
- [x] Sprinkle some radspec
- [X] Add isInitialized to state modifying functions
