### PR TITLE
Add build command to main app repos

### DIFF
--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "postinstall": "cd app && npm install",
     "compile": "truffle compile",
+    "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
     "deploy:rinkeby": "truffle exec scripts/deploy.js --network rinkeby",
     "deploy:devnet": "truffle exec scripts/deploy.js --network devnet",

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "postinstall": "cd app && npm install",
     "compile": "truffle compile",
+    "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
     "deploy:rinkeby": "truffle exec scripts/deploy.js --network rinkeby",
     "deploy:devnet": "truffle exec scripts/deploy.js --network devnet",

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "postinstall": "cd app && npm install",
     "compile": "truffle compile",
+    "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
     "deploy:rinkeby": "truffle exec scripts/deploy.js --network rinkeby",
     "deploy:devnet": "truffle exec scripts/deploy.js --network devnet",

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "truffle compile",
+    "build": "mkdir -p app/build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
     "deploy:rinkeby": "truffle exec scripts/deploy.js --network rinkeby",
     "deploy:devnet": "truffle exec scripts/deploy.js --network devnet",

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "scripts": {
     "compile": "truffle compile",
-    "build": "mkdir -p app/build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
     "deploy:rinkeby": "truffle exec scripts/deploy.js --network rinkeby",
     "deploy:devnet": "truffle exec scripts/deploy.js --network devnet",

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "postinstall": "cd app && npm install",
     "compile": "truffle compile",
+    "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
     "deploy:rinkeby": "truffle exec scripts/deploy.js --network rinkeby",
     "deploy:devnet": "truffle exec scripts/deploy.js --network devnet",


### PR DESCRIPTION
This allows `apm publish` to build the frontend of the apps so just one command is required.

In case of the vault app that doesn't have a frontend, we just create the directory to avoid the issue of trying to publish an inexistent directory.