### PR TITLE
Use git clean instead of lerna clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "install": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --nohoist=@aragon/os",
-    "clean": "lerna clean",
+    "clean": "git clean -fdxi apps future-apps shared templates",
     "test": "lerna run --scope=@aragon/apps-* --concurrency=1 --stream test",
     "test:future": "lerna run --scope=@aragon/future-apps-* --concurrency=1 --stream test",
     "test:templates-beta": "lerna run --scope=@aragon/templates-beta --concurrency=1 --stream test",


### PR DESCRIPTION
See https://git-scm.com/docs/git-clean.

Running `npm run clean` now cleans all git ignored files (before `lerna clean` wouldn't remove the nested `app/node_modules` inside each app's folder), interactively, to restore the repo to a pristine state (for, e.g. rebuilding all `package-lock.json`s).