### PR TITLE
Explicitly define state visibility

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -80,10 +80,10 @@ contract Finance is AragonApp {
 
     IVaultConnector public vault;
 
-    Payment[] payments; // first index is 1
-    Transaction[] transactions; // first index is 1
-    Period[] periods; // first index is 0
-    Settings settings;
+    Payment[] internal payments; // first index is 1
+    Transaction[] internal transactions; // first index is 1
+    Period[] internal periods; // first index is 0
+    Settings internal settings;
 
     event NewPeriod(uint256 indexed periodId, uint64 periodStarts, uint64 periodEnds);
     event SetBudget(address indexed token, uint256 amount, bool hasBudget);

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -54,7 +54,7 @@ contract Survey is AragonApp {
         mapping (address => MultiOptionVote) votes;    // voter -> options voted, with its stakes
     }
 
-    SurveyStruct[] surveys;
+    SurveyStruct[] internal surveys;
 
     event StartSurvey(uint256 indexed surveyId);
     event CastVote(uint256 indexed surveyId, address indexed voter, uint256 option, uint256 stake, uint256 optionPower);

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -38,8 +38,8 @@ contract TokenManager is ITokenController, AragonApp, IForwarder {
         bool revokable;
     }
 
-    mapping (address => TokenVesting[]) vestings;
-    mapping (address => bool) everHeld;
+    mapping (address => TokenVesting[]) internal vestings;
+    mapping (address => bool) internal everHeld;
 
     // Returns all holders the token had (since managing it).
     // Some of them can have a balance of 0.

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -39,7 +39,7 @@ contract TokenManager is ITokenController, AragonApp, IForwarder {
     }
 
     mapping (address => TokenVesting[]) internal vestings;
-    mapping (address => bool) internal everHeld;
+    mapping (address => bool) public everHeld;
 
     // Returns all holders the token had (since managing it).
     // Some of them can have a balance of 0.

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -44,7 +44,7 @@ contract Voting is IForwarder, AragonApp {
         mapping (address => VoterState) voters;
     }
 
-    Vote[] votes;
+    Vote[] internal votes; // first index is 1
 
     event StartVote(uint256 indexed voteId);
     event CastVote(uint256 indexed voteId, address indexed voter, bool supports, uint256 stake);


### PR DESCRIPTION
Explicitly set the state to be `internal`, since these either have custom getters or have indices start at `1`.