### PR TITLE
Finance: Remove unnecessary defaulting of the selected token

### DIFF
--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -30,12 +30,6 @@ class Transfers extends React.Component {
   state = {
     ...initialState,
   }
-  componentDidMount() {
-    this.setState({ selectedToken: 0 })
-  }
-  componentWillReceiveProps() {
-    this.setState({ selectedToken: 0 })
-  }
   handleTokenChange = index => {
     this.setState({ selectedToken: index, displayedTransfers: 10 })
   }


### PR DESCRIPTION
Fixes the filter reverting back to the first token when a prop update happens.