### PR TITLE
Finance: set the budget to 0 when removing a budget

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -265,6 +265,7 @@ contract Finance is AragonApp {
     * @param _token Address for token
     */
     function removeBudget(address _token) authP(CHANGE_BUDGETS_ROLE, arr(_token, uint256(0), settings.budgets[_token])) transitionsPeriod isInitialized external {
+        settings.budgets[_token] = 0;
         settings.hasBudget[_token] = false;
         SetBudget(_token, 0, false);
     }

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -273,6 +273,11 @@ contract('Finance App', accounts => {
 
         it('removing budget allows unlimited spending', async () => {
             await app.removeBudget(token2.address)
+
+            const [budget, hasBudget] = await app.getBudget.call(token2.address)
+            assert.equal(budget, 0, 'removed budget should be 0')
+            assert.isFalse(hasBudget, 'should not have budget')
+
             // budget was 100
             await app.newPayment(token2.address, recipient, 190, time, 0, 1, '')
             assert.equal(await token2.balanceOf(recipient), 190, 'recipient should have received tokens')


### PR DESCRIPTION
Also fixes the issue where the wrong, outdated budget can be passed to `CHANGE_BUDGETS_ROLE`. From https://github.com/ConsenSys/aragon-apps-audit-repo/issues/41:

> However, the settings.budget[_token] value should not be read without first checking settings.hasBudget[_token] because removeBudget keeps the old, invalid settings.budget[_token] value even though the limit is removed.