### PR TITLE
Finance: remove limit on transitions per transaction in transitionsPeriod modifier

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -21,7 +21,6 @@ contract Finance is AragonApp {
 
     address constant public ETH = address(0);
     uint64 constant public MAX_PAYMENTS_PER_TX = 20;
-    uint64 constant public MAX_PERIOD_TRANSITIONS_PER_TX = 10;
     uint64 constant public MAX_UINT64 = uint64(-1);
     uint256 constant public MAX_UINT = uint256(-1);
 
@@ -96,7 +95,7 @@ contract Finance is AragonApp {
     // Modifier used by all methods that impact accounting to make sure accounting period
     // is changed before the operation if needed
     modifier transitionsPeriod {
-        bool completeTransition = tryTransitionAccountingPeriod(MAX_PERIOD_TRANSITIONS_PER_TX);
+        bool completeTransition = tryTransitionAccountingPeriod(getMaxPeriodTransitions());
         require(completeTransition);
         _;
     }
@@ -327,7 +326,7 @@ contract Finance is AragonApp {
 
     /**
     * @dev Transitions accounting periods if needed. For preventing OOG attacks, a maxTransitions
-    *      a TTL param is provided. If more than the specified number of periods need to be transitioned,
+    *      param is provided. If more than the specified number of periods need to be transitioned,
     *      it will return false.
     * @notice Transition accounting period if needed
     * @param _maxTransitions Maximum periods that can be transitioned
@@ -576,6 +575,9 @@ contract Finance is AragonApp {
     function _canMakePayment(address _token, uint256 _amount) internal view returns (bool) {
         return getRemainingBudget(_token) >= _amount && vault.balance(_token) >= _amount;
     }
+
+    // Must be view for mocking purposes
+    function getMaxPeriodTransitions() internal view returns (uint256) { return MAX_UINT64; }
 
     function getTimestamp() internal view returns (uint256) { return now; }
 }

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -359,10 +359,11 @@ contract('Finance App', accounts => {
         })
 
         context('many accounting period transitions', () => {
-            let maxTransitions = 0
+            // Arbitrary number of max transitions to simulate OOG behaviour with transitionsPeriod
+            const maxTransitions = 20
 
             beforeEach(async () => {
-                maxTransitions = await app.MAX_PERIOD_TRANSITIONS_PER_TX().then(bn => bn.toNumber())
+                await app.mock_setMaxPeriodTransitions(maxTransitions)
                 await app.mock_setTimestamp(time + (maxTransitions + 2) * periodDuration)
             })
 

--- a/apps/finance/test/mocks/FinanceMock.sol
+++ b/apps/finance/test/mocks/FinanceMock.sol
@@ -3,8 +3,12 @@ pragma solidity 0.4.18;
 import "../../contracts/Finance.sol";
 
 contract FinanceMock is Finance {
-    uint _mockTime = now;
+    uint256 mockTime = now;
+    uint mockMaxPeriodTransitions = MAX_UINT;
 
-    function getTimestamp() internal view returns (uint256) { return _mockTime; }
-    function mock_setTimestamp(uint i) public { _mockTime = i; }
+    function mock_setMaxPeriodTransitions(uint256 i) public { mockMaxPeriodTransitions = i; }
+    function mock_setTimestamp(uint256 i) public { mockTime = i; }
+
+    function getMaxPeriodTransitions() internal view returns (uint256) { return mockMaxPeriodTransitions; }
+    function getTimestamp() internal view returns (uint256) { return mockTime; }
 }

--- a/apps/finance/test/mocks/FinanceMock.sol
+++ b/apps/finance/test/mocks/FinanceMock.sol
@@ -4,7 +4,7 @@ import "../../contracts/Finance.sol";
 
 contract FinanceMock is Finance {
     uint256 mockTime = now;
-    uint mockMaxPeriodTransitions = MAX_UINT;
+    uint256 mockMaxPeriodTransitions = MAX_UINT;
 
     function mock_setMaxPeriodTransitions(uint256 i) public { mockMaxPeriodTransitions = i; }
     function mock_setTimestamp(uint256 i) public { mockTime = i; }


### PR DESCRIPTION
From https://github.com/ConsenSys/aragon-apps-audit-repo/issues/29:

> Remove the MAX_PERIOD_TRANSITION_PER_TX. Items 1 and 2 above together should make this arbitrary cutoff unnecessary.

--------------

If there are too many periods to transition, an OOG error will revert all changed state, including in-flight transfers of ETH or tokens.

However, this does mean the frontend may have a harder time estimating gas costs.