### PR TITLE
Finance: don't try to transition periods on getBudget()

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -424,7 +424,7 @@ contract Finance is AragonApp {
         return settings.periodDuration;
     }
 
-    function getBudget(address _token) transitionsPeriod public view returns (uint256 budget, bool hasBudget) {
+    function getBudget(address _token) public view returns (uint256 budget, bool hasBudget) {
         budget = settings.budgets[_token];
         hasBudget = settings.hasBudget[_token];
     }


### PR DESCRIPTION
Fixes #107.

Allocated budgets aren't associated with a period, so the same information should be returned regardless of the period.