### PR TITLE
Survey: adapt mock test token to aragonOS PR 357

### DIFF
--- a/apps/survey/test/mocks/BadToken.sol
+++ b/apps/survey/test/mocks/BadToken.sol
@@ -5,8 +5,8 @@ import "@aragon/os/contracts/lib/minime/MiniMeToken.sol";
 
 contract BadToken is MiniMeToken {
     function BadToken(
-        address _tokenFactory,
-        address _parentToken,
+        MiniMeTokenFactory _tokenFactory,
+        MiniMeToken _parentToken,
         uint _parentSnapShotBlock,
         string _tokenName,
         uint8 _decimalUnits,


### PR DESCRIPTION
Using static contract types instead of adddresses for MiniMe.
See https://github.com/aragon/aragonOS/pull/357