### PR TITLE
Survey: fix calculation when votes are reset

### DIFF
--- a/apps/survey/app/src/App.js
+++ b/apps/survey/app/src/App.js
@@ -272,11 +272,11 @@ export default observe(observable => {
                 options: optionsHistory.options.map(optionHistory =>
                   optionHistory.reduce((powers, power, index) => {
                     if (index <= nowBucket) {
-                      // Adjust power for participation (so it's a percentage of total partcipation)
-                      // If there's no power filled in this slot, fill it in with the previous power
-                      // (and use 0 for the first index if so)
+                      // Adjust power for participation (so it's a percentage of total participation)
+                      // If there's no power filled in this slot (-1 signifies it's sparse), fill it
+                      // in with the previous power (and use 0 for the first index if so)
                       powers.push(
-                        power
+                        power !== -1
                           ? power / data.participation // no need to adjust for decimals
                           : index === 0
                             ? 0


### PR DESCRIPTION
Discovered while debugging Memefactory's survey DAO. I didn't factor in resetting votes earlier when doing calculations for the history chart.

Also adds `logIndex` as a way to make sure we don't work on the same event.

**Breaking change**: all past survey DAOs use `0` to signify sparseness in their history whereas `-1` is now used (so we can properly account for when a vote is reset back to 0). Although the data model has changed, almost no users on mainnet should be impacted by this change, at least visually.

Before:
<img src="https://user-images.githubusercontent.com/4166642/43458964-49c17354-94cc-11e8-9805-e28d01b30d13.png" height=400 />

After:
<img src="https://user-images.githubusercontent.com/4166642/43458960-45d5fddc-94cc-11e8-8173-357cfd558af3.png" height=400 />