### PR TITLE
Finance: fix unnecessary request to get token logo when loading placeholder

### DIFF
--- a/apps/finance/app/src/components/BalanceToken.js
+++ b/apps/finance/app/src/components/BalanceToken.js
@@ -16,13 +16,15 @@ const splitAmount = amount => {
 const BalanceToken = ({ amount, symbol, convertedAmount = -1 }) => (
   <Main>
     <Token>
-      <img
-        alt=""
-        width="16"
-        height="16"
-        src={`https://chasing-coins.com/coin/logo/${symbol}`}
-      />
-      {symbol}
+      {symbol && (
+        <img
+          alt=""
+          width="16"
+          height="16"
+          src={`https://chasing-coins.com/coin/logo/${symbol}`}
+        />
+      )}
+      {symbol || ' '}
     </Token>
     <Amount>{splitAmount(amount.toFixed(3))}</Amount>
     <ConvertedAmount>

--- a/apps/finance/app/src/components/Balances.js
+++ b/apps/finance/app/src/components/Balances.js
@@ -82,7 +82,7 @@ class Balances extends React.Component {
 
 const EmptyListItem = () => (
   <ListItem style={{ opacity: '0' }}>
-    <BalanceToken symbol=" " amount={0} convertedAmount={0} />
+    <BalanceToken amount={0} convertedAmount={0} />
   </ListItem>
 )
 


### PR DESCRIPTION
Otherwise we always make a request to `https://chasing-coins.com/coin/logo/%C2%A0` unnecessarily.