### PR TITLE
Publish internal packages

### DIFF
--- a/apps/finance/contracts/test/TestImports.sol
+++ b/apps/finance/contracts/test/TestImports.sol
@@ -7,8 +7,8 @@ import "@aragon/os/contracts/factory/EVMScriptRegistryFactory.sol";
 
 import "@aragon/apps-vault/contracts/Vault.sol";
 
-import "@aragon-apps/migrations/contracts/Migrations.sol";
-import "@aragon-apps/minime/contracts/MiniMeToken.sol";
+import "@aragon/apps-shared-migrations/contracts/Migrations.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 // You might think this file is a bit odd, but let me explain.
 // We only use some contracts in our tests, which means Truffle

--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -32,10 +32,10 @@
   "license": "(GPL-3.0-or-later OR AGPL-3.0-or-later)",
   "description": "",
   "devDependencies": {
+    "@aragon/apps-shared-migrations": "1.0.0",
+    "@aragon/apps-shared-minime": "1.0.0",
     "@aragon/cli": "^2.0.4",
     "@aragon/test-helpers": "^1.0.1",
-    "@aragon-apps/migrations": "1.0.0",
-    "@aragon-apps/minime": "1.0.0",
     "eth-gas-reporter": "^0.1.1",
     "ganache-cli": "^6.0.3",
     "solidity-coverage": "0.5.11",

--- a/apps/survey/.solcover.js
+++ b/apps/survey/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
     norpc: true,
-    copyPackages: ['@aragon/os', '@aragon-apps/minime'],
+    copyPackages: ['@aragon/os', '@aragon/apps-shared-minime'],
     skipFiles: [
         'test/TestImports.sol',
         'test/mocks/BadToken.sol',

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -9,7 +9,7 @@ import "@aragon/os/contracts/apps/AragonApp.sol";
 import "@aragon/os/contracts/lib/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/math/SafeMath64.sol";
 
-import "@aragon-apps/minime/contracts/MiniMeToken.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 
 contract Survey is AragonApp {

--- a/apps/survey/contracts/test/TestImports.sol
+++ b/apps/survey/contracts/test/TestImports.sol
@@ -5,7 +5,7 @@ import "@aragon/os/contracts/kernel/Kernel.sol";
 import "@aragon/os/contracts/factory/DAOFactory.sol";
 import "@aragon/os/contracts/factory/EVMScriptRegistryFactory.sol";
 
-import "@aragon-apps/migrations/contracts/Migrations.sol";
+import "@aragon/apps-shared-migrations/contracts/Migrations.sol";
 
 // You might think this file is a bit odd, but let me explain.
 // We only use some contracts in our tests, which means Truffle

--- a/apps/survey/contracts/test/mocks/BadToken.sol
+++ b/apps/survey/contracts/test/mocks/BadToken.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
-import "@aragon-apps/minime/contracts/MiniMeToken.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 
 contract BadToken is MiniMeToken {

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -26,9 +26,9 @@
   "license": "(GPL-3.0-or-later OR AGPL-3.0-or-later)",
   "description": "",
   "devDependencies": {
+    "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/cli": "^2.0.4",
     "@aragon/test-helpers": "^1.0.1",
-    "@aragon-apps/migrations": "1.0.0",
     "babel-helpers": "^6.24.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.18.0",
@@ -46,7 +46,7 @@
     "webpack": "3.10.0"
   },
   "dependencies": {
-    "@aragon/os": "4.0.0-alpha.2",
-    "@aragon-apps/minime": "1.0.0"
+    "@aragon/apps-shared-minime": "1.0.0",
+    "@aragon/os": "4.0.0-alpha.2"
   }
 }

--- a/apps/token-manager/.solcover.js
+++ b/apps/token-manager/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
     norpc: true,
-    copyPackages: ['@aragon/os', '@aragon-apps/minime'],
+    copyPackages: ['@aragon/os', '@aragon/apps-shared-minime'],
     skipFiles: [
         'test/TestImports.sol',
         'test/mocks/ExecutionTarget.sol',

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -13,8 +13,8 @@ import "@aragon/os/contracts/common/Uint256Helpers.sol";
 import "@aragon/os/contracts/lib/token/ERC20.sol";
 import "@aragon/os/contracts/lib/math/SafeMath.sol";
 
-import "@aragon-apps/minime/contracts/ITokenController.sol";
-import "@aragon-apps/minime/contracts/MiniMeToken.sol";
+import "@aragon/apps-shared-minime/contracts/ITokenController.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 
 contract TokenManager is ITokenController, IForwarder, AragonApp {

--- a/apps/token-manager/contracts/test/TestImports.sol
+++ b/apps/token-manager/contracts/test/TestImports.sol
@@ -5,8 +5,8 @@ import "@aragon/os/contracts/kernel/Kernel.sol";
 import "@aragon/os/contracts/factory/DAOFactory.sol";
 import "@aragon/os/contracts/factory/EVMScriptRegistryFactory.sol";
 
-import "@aragon-apps/minime/contracts/MiniMeToken.sol";
-import "@aragon-apps/migrations/contracts/Migrations.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
+import "@aragon/apps-shared-migrations/contracts/Migrations.sol";
 
 // You might think this file is a bit odd, but let me explain.
 // We only use some contracts in our tests, which means Truffle

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@aragon/cli": "^2.0.4",
     "@aragon/test-helpers": "^1.0.1",
-    "@aragon-apps/migrations": "1.0.0",
+    "@aragon/apps-shared-migrations": "1.0.0",
     "eth-gas-reporter": "^0.1.1",
     "ganache-cli": "^6.1.0",
     "solidity-coverage": "0.5.11",
@@ -45,6 +45,6 @@
   },
   "dependencies": {
     "@aragon/os": "4.0.0-alpha.2",
-    "@aragon-apps/minime": "1.0.0"
+    "@aragon/apps-shared-minime": "1.0.0"
   }
 }

--- a/apps/vault/contracts/test/TestImports.sol
+++ b/apps/vault/contracts/test/TestImports.sol
@@ -6,7 +6,7 @@ import "@aragon/os/contracts/factory/DAOFactory.sol";
 import "@aragon/os/contracts/kernel/Kernel.sol";
 import "@aragon/os/contracts/kernel/KernelProxy.sol";
 
-import "@aragon-apps/migrations/contracts/Migrations.sol";
+import "@aragon/apps-shared-migrations/contracts/Migrations.sol";
 
 // You might think this file is a bit odd, but let me explain.
 // We only use these contract in our tests, which means

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@aragon/cli": "^2.0.4",
     "@aragon/test-helpers": "^1.0.1",
-    "@aragon-apps/migrations": "1.0.0",
+    "@aragon/apps-shared-migrations": "1.0.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.1.1",
     "ganache-cli": "^6.1.0",

--- a/apps/voting/.solcover.js
+++ b/apps/voting/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
     norpc: true,
-    copyPackages: ['@aragon/os', '@aragon-apps/minime'],
+    copyPackages: ['@aragon/os', '@aragon/apps-shared-minime'],
     skipFiles: [
         'test/TestImports.sol',
         'test/mocks/ExecutionTarget.sol',

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -10,7 +10,7 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 import "@aragon/os/contracts/lib/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/math/SafeMath64.sol";
 
-import "@aragon-apps/minime/contracts/MiniMeToken.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 
 contract Voting is IForwarder, AragonApp {

--- a/apps/voting/contracts/test/TestImports.sol
+++ b/apps/voting/contracts/test/TestImports.sol
@@ -5,7 +5,7 @@ import "@aragon/os/contracts/kernel/Kernel.sol";
 import "@aragon/os/contracts/factory/DAOFactory.sol";
 import "@aragon/os/contracts/factory/EVMScriptRegistryFactory.sol";
 
-import "@aragon-apps/migrations/contracts/Migrations.sol";
+import "@aragon/apps-shared-migrations/contracts/Migrations.sol";
 
 // You might think this file is a bit odd, but let me explain.
 // We only use some contracts in our tests, which means Truffle

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@aragon/cli": "^2.0.4",
     "@aragon/test-helpers": "^1.0.1",
-    "@aragon-apps/migrations": "1.0.0",
+    "@aragon/apps-shared-migrations": "1.0.0",
     "eth-gas-reporter": "^0.1.5",
     "ganache-cli": "^6.1.0",
     "solidity-coverage": "0.5.11",
@@ -46,6 +46,6 @@
   },
   "dependencies": {
     "@aragon/os": "4.0.0-alpha.2",
-    "@aragon-apps/minime": "1.0.0"
+    "@aragon/apps-shared-minime": "1.0.0"
   }
 }

--- a/apps/voting/test/voting.js
+++ b/apps/voting/test/voting.js
@@ -11,7 +11,7 @@ const EVMScriptRegistryFactory = artifacts.require('@aragon/os/contracts/factory
 const ACL = artifacts.require('@aragon/os/contracts/acl/ACL')
 const Kernel = artifacts.require('@aragon/os/contracts/kernel/Kernel')
 
-const MiniMeToken = artifacts.require('@aragon-apps/minime/contracts/MiniMeToken')
+const MiniMeToken = artifacts.require('@aragon/apps-shared-minime/contracts/MiniMeToken')
 
 const Voting = artifacts.require('VotingMock')
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:vault": "lerna run --scope=@aragon/apps-vault --stream test",
     "test:voting": "lerna run --scope=@aragon/apps-voting --stream test",
     "test:future": "lerna run --scope=@aragon/future-apps-* --concurrency=1 --stream test",
-    "test:shared": "lerna run --scope=@aragon-apps/* --concurrency=1 --stream test",
+    "test:shared": "lerna run --scope=@aragon/apps-shared-* --concurrency=1 --stream test",
     "coverage": "npm run coverage:all",
     "coverage:all": "lerna run --scope=@aragon/apps-* --concurrency=1 --stream coverage",
     "coverage:finance": "lerna run --scope=@aragon/apps-finance --concurrency=1 --stream coverage",

--- a/shared/migrations/package.json
+++ b/shared/migrations/package.json
@@ -2,7 +2,6 @@
   "name": "@aragon/apps-shared-migrations",
   "version": "1.0.0",
   "description": "",
-  "private": true,
   "scripts": {
     "test": "echo \"No tests\""
   }

--- a/shared/migrations/package.json
+++ b/shared/migrations/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aragon-apps/migrations",
+  "name": "@aragon/apps-shared-migrations",
   "version": "1.0.0",
   "description": "",
   "private": true,

--- a/shared/minime/contracts/test/TestImport.sol
+++ b/shared/minime/contracts/test/TestImport.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
-import "@aragon-apps/migrations/contracts/Migrations.sol";
+import "@aragon/apps-shared-migrations/contracts/Migrations.sol";
 
 // You might think this file is a bit odd, but let me explain.
 // We only use some contracts in our tests, which means Truffle

--- a/shared/minime/package.json
+++ b/shared/minime/package.json
@@ -2,7 +2,6 @@
   "name": "@aragon/apps-shared-minime",
   "version": "1.0.0",
   "license": "GPL-3.0-or-later",
-  "private": "true",
   "scripts": {
     "compile": "truffle compile",
     "test": "TRUFFLE_TEST=true npm run ganache-cli:test",

--- a/shared/minime/package.json
+++ b/shared/minime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aragon-apps/minime",
+  "name": "@aragon/apps-shared-minime",
   "version": "1.0.0",
   "license": "GPL-3.0-or-later",
   "private": "true",
@@ -11,8 +11,8 @@
     "truffle:dev": "npx truffle dev"
   },
   "devDependencies": {
+    "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/test-helpers": "^1.0.1",
-    "@aragon-apps/migrations": "1.0.0",
     "ganache-cli": "6.1.8",
     "solidity-coverage": "0.5.8",
     "truffle": "4.1.14"


### PR DESCRIPTION
Moves the internal packages to be scoped as `@aragon/apps-shared-*` so they can be published.

Both are now published: [minime](https://www.npmjs.com/package/@aragon/apps-shared-minime), [migrations](https://www.npmjs.com/package/@aragon/apps-shared-migrations).