### PR TITLE
chore: add more cache paths to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,18 @@ language: node_js
 cache:
   directories:
     - node_modules
+    - apps/finance/node_modules
+    - apps/finance/app/node_modules
+    - apps/survey/node_modules
+    - apps/survey/app/node_modules
+    - apps/token-manager/node_modules
+    - apps/token-manager/app/node_modules
+    - apps/vault/node_modules
+    - apps/voting/node_modules
+    - apps/voting/app/node_modules
+    - shared/migrations/node_modules
+    - shared/minime/node_modules
+    - shared/test-helpers/node_modules
 notifications:
   email: false
 node_js:


### PR DESCRIPTION
An experiment to see if this makes our CI faster, as a significant part of each build is spent on npm installing.