### PR TITLE
Ignore Vim Tempfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ lerna-debug.log
 */**/abis.json
 */**/.DS_Store
 
+# VIM
+*.swo
+*.swp
+
 # yarn
 yarn-error.log
 


### PR DESCRIPTION

#### Changes
This adds vim tempfiles to the gitignore so they do not appear in `git status`.
Reviewers @izqui