### PR TITLE
Survey: check if option exists when getting option power

### DIFF
--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -290,10 +290,10 @@ contract Survey is AragonApp {
     }
 
     function getOptionPower(uint256 _surveyId, uint256 _optionId) public view surveyExists(_surveyId) returns (uint256) {
-        Survey storage survey_ = surveys[_surveyId];
-        require(_optionId <= survey_.options);
+        SurveyStruct storage survey = surveys[_surveyId];
+        require(_optionId <= survey.options);
 
-        return survey_.optionPower[_optionId];
+        return survey.optionPower[_optionId];
     }
 
     function isParticipationAchieved(uint256 _surveyId) public view surveyExists(_surveyId) returns (bool) {

--- a/apps/survey/test/survey.js
+++ b/apps/survey/test/survey.js
@@ -121,8 +121,20 @@ contract('Survey app', accounts => {
       })
 
       it('fails getting a survey out of bounds', async () => {
-        assertRevert(async () => {
+        return assertRevert(async () => {
           await survey.getSurvey(surveyId + 1)
+        })
+      })
+
+      it('fails getting option power for a survey out of bounds', async () => {
+        return assertRevert(async () => {
+          await survey.getOptionPower(surveyId + 1, 0)
+        })
+      })
+
+      it('fails getting option power for an option out of bounds', async () => {
+        return assertRevert(async () => {
+          await survey.getOptionPower(surveyId, optionsCount + 1)
         })
       })
 


### PR DESCRIPTION
Reverts if trying to get an option power for an option that doesn't exist in a survey.