### PR TITLE
Pin parcel-bundler and date-fns to prevent any break

### DIFF
--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aragon/client": "^1.0.0-beta.8",
     "@aragon/ui": "^0.18.2",
-    "date-fns": "^2.0.0-alpha.7",
+    "date-fns": "2.0.0-alpha.7",
     "prop-types": "^15.6.0",
     "react": "^16.5.2",
     "react-blockies": "^1.2.2",
@@ -34,7 +34,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "^4.0.0",
-    "parcel-bundler": "^1.9.7",
+    "parcel-bundler": "1.9.7",
     "prettier": "^1.8.2"
   },
   "scripts": {


### PR DESCRIPTION
Until we upgrade the app to support the newer versions.