### PR TITLE
Voting: tweak forwarding action's radspec to be more clear that a vote is not always casted

### DIFF
--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -171,7 +171,7 @@ contract Voting is IForwarder, AragonApp {
     }
 
     /**
-    * @notice Creates a vote to execute the desired action, and casts a support vote
+    * @notice Creates a vote to execute the desired action, and casts a support vote if possible
     * @dev IForwarder interface conformance
     * @param _evmScript Start vote with script
     */


### PR DESCRIPTION
In the case of > 1 forwarding steps before the Voting app is reached (e.g. allowing only token holders to create votes), it's impossible for the voting app to automatically vote on behalf of the end user who started the transaction right now.

This adjusts the radspec text to give us some leeway in the messaging around this case.