### PR TITLE
Packs certain uint256s into uint64 to save gas

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -26,11 +26,11 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     bytes32 public constant DISABLE_PAYMENTS_ROLE = keccak256("DISABLE_PAYMENTS_ROLE");
 
     uint64 public constant MAX_PAYMENTS_PER_TX = 20;
+    uint64 internal constant NO_PAYMENT = 0;
+    uint64 internal constant NO_TRANSACTION = 0;
+    uint64 internal constant MAX_UINT64 = uint64(-1);
 
     uint256 internal constant MAX_UINT = uint256(-1);
-    uint64 internal constant MAX_UINT64 = uint64(-1);
-    uint256 internal constant NO_PAYMENT = 0;
-    uint256 internal constant NO_TRANSACTION = 0;
 
     // Order optimized for storage
     struct Payment {

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -19,8 +19,8 @@ contract Survey is AragonApp {
     bytes32 public constant CREATE_SURVEYS_ROLE = keccak256("CREATE_SURVEYS_ROLE");
     bytes32 public constant MODIFY_PARTICIPATION_ROLE = keccak256("MODIFY_PARTICIPATION_ROLE");
 
-    uint256 public constant PCT_BASE = 10 ** 18; // 0% = 0; 1% = 10^16; 100% = 10^18
-    uint256 public constant ABSTAIN_VOTE = 0;
+    uint64 public constant PCT_BASE = 10 ** 18; // 0% = 0; 1% = 10^16; 100% = 10^18
+    uint64 public constant ABSTAIN_VOTE = 0;
 
     struct OptionCast {
         uint256 optionId;
@@ -53,9 +53,9 @@ contract Survey is AragonApp {
         mapping (address => MultiOptionVote) votes;     // voter -> options voted, with its stakes
     }
 
+    uint64 public surveyTime;
     MiniMeToken public token;
     uint256 public minParticipationPct;
-    uint64 public surveyTime;
 
     // We are mimicing an array, we use a mapping instead to make app upgrade more graceful
     mapping (uint256 => SurveyStruct) internal surveys;


### PR DESCRIPTION
#461
This reduces uint256s to uint64s where it saves gas due to the tight packing feature of Solidity.  