### PR TITLE
Voting: require votes to have positive token snapshots

### DIFF
--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -274,6 +274,7 @@ contract Voting is IForwarder, AragonApp {
         vote_.metadata = _metadata;
         vote_.snapshotBlock = getBlockNumber() - 1; // avoid double voting in this very block
         vote_.totalVoters = token.totalSupplyAt(vote_.snapshotBlock);
+        require(vote_.totalVoters > 0);
         vote_.supportRequiredPct = supportRequiredPct;
         vote_.minAcceptQuorumPct = minAcceptQuorumPct;
 


### PR DESCRIPTION
😅 Not sure how we've missed this for so long.

Without checking that the token has a total supply, you could create locked votes. We already have this check in the Survey app.