### PR TITLE
Voting: refactor state and better enforce bignumber purity

### DIFF
--- a/apps/voting/app/.eslintrc
+++ b/apps/voting/app/.eslintrc
@@ -19,6 +19,7 @@
   },
   "plugins": ["prettier", "react"],
   "rules": {
+    "valid-jsdoc": "error",
     "react/prop-types": 0,
     "prettier/prettier": [
       "error",

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { isBefore } from 'date-fns/esm'
 import { AragonApp, AppBar, Button, SidePanel, observe } from '@aragon/ui'
+import BN from 'bn.js'
 import EmptyState from './screens/EmptyState'
 import Votes from './screens/Votes'
 import tokenAbi from './abi/token-balanceOfAt.json'
@@ -9,12 +9,12 @@ import VotePanelContent from './components/VotePanelContent'
 import NewVotePanelContent from './components/NewVotePanelContent'
 import AppLayout from './components/AppLayout'
 import { networkContextType } from './utils/provideNetwork'
-import { safeDiv } from './math-utils'
+import { settingsContextType } from './utils/provideSettings'
 import { hasLoadedVoteSettings } from './vote-settings'
 import { VOTE_YEA } from './vote-types'
 import {
   EMPTY_CALLSCRIPT,
-  getQuorumProgress,
+  isVoteOpen,
   voteTypeFromContractEnum,
 } from './vote-utils'
 
@@ -27,20 +27,23 @@ class App extends React.Component {
       etherscanBaseUrl: 'https://rinkeby.etherscan.io',
       name: 'rinkeby',
     },
-    pctBase: -1,
-    tokenAddress: null,
-    tokenDecimals: 18,
+    settingsLoaded: false,
     tokenSymbol: '',
-    supportRequiredPct: -1,
     userAccount: '',
     votes: [],
-    voteTime: -1,
   }
   static childContextTypes = {
     network: networkContextType,
+    settings: settingsContextType,
   }
   getChildContext() {
-    return { network: this.props.network }
+    return {
+      network: this.props.network,
+      settings: {
+        pctBase: this.props.pctBase,
+        voteTime: this.props.voteTime,
+      },
+    }
   }
 
   constructor(props) {
@@ -49,7 +52,6 @@ class App extends React.Component {
     this.state = {
       createVoteVisible: false,
       currentVoteId: -1,
-      settingsLoaded: false,
       tokenContract: this.getTokenContract(props.tokenAddress),
       voteVisible: false,
       voteSidebarOpened: false,
@@ -57,15 +59,6 @@ class App extends React.Component {
     }
   }
   componentWillReceiveProps(nextProps) {
-    const { settingsLoaded } = this.state
-
-    // Is this the first time we've loaded the settings?
-    if (!settingsLoaded && hasLoadedVoteSettings(nextProps)) {
-      this.setState({
-        settingsLoaded: true,
-      })
-    }
-
     // Refresh the token contract if its address changes
     if (nextProps.tokenAddress !== this.props.tokenAddress) {
       this.setState({
@@ -146,45 +139,37 @@ class App extends React.Component {
   render() {
     const {
       app,
-      pctBase,
-      supportRequiredPct,
-      userAccount,
-      votes,
-      voteTime,
+      settingsLoaded,
       tokenDecimals,
       tokenSymbol,
+      userAccount,
+      votes,
     } = this.props
 
     const {
       createVoteVisible,
       currentVoteId,
-      settingsLoaded,
       tokenContract,
       voteSidebarOpened,
       voteVisible,
       userAccountVotes,
     } = this.state
 
-    const displayVotes = settingsLoaded && votes.length > 0
-    const supportRequired = settingsLoaded ? supportRequiredPct / pctBase : -1
+    const now = new Date()
+    const appReady = settingsLoaded && votes.length > 0
 
     // Add useful properties to the votes
-    const preparedVotes = displayVotes
-      ? votes.map(vote => {
-          const endDate = new Date(vote.data.startDate + voteTime)
-          return {
-            ...vote,
-            endDate,
-            // Open if not executed and now is still before end date
-            open: !vote.data.executed && isBefore(new Date(), endDate),
-            quorum: safeDiv(vote.data.minAcceptQuorum, pctBase),
-            quorumProgress: getQuorumProgress(vote),
-            support: supportRequired,
-            userAccountVote: voteTypeFromContractEnum(
-              userAccountVotes.get(vote.voteId)
-            ),
-          }
-        })
+    const preparedVotes = appReady
+      ? votes.map(vote => ({
+          ...vote,
+          data: {
+            ...vote.data,
+            open: isVoteOpen(vote, now),
+          },
+          userAccountVote: voteTypeFromContractEnum(
+            userAccountVotes.get(vote.voteId)
+          ),
+        }))
       : votes
 
     const currentVote =
@@ -207,7 +192,7 @@ class App extends React.Component {
           </AppLayout.Header>
           <AppLayout.ScrollWrapper>
             <AppLayout.Content>
-              {displayVotes ? (
+              {appReady ? (
                 <Votes
                   votes={preparedVotes}
                   onSelectVote={this.handleVoteOpen}
@@ -223,13 +208,11 @@ class App extends React.Component {
           title={`Vote #${currentVoteId} (${
             currentVote && currentVote.open ? 'Open' : 'Closed'
           })`}
-          opened={
-            currentVote && displayVotes && !createVoteVisible && voteVisible
-          }
+          opened={appReady && currentVote && !createVoteVisible && voteVisible}
           onClose={this.handleVoteClose}
           onTransitionEnd={this.handleVoteTransitionEnd}
         >
-          {displayVotes &&
+          {appReady &&
             currentVote && (
               <VotePanelContent
                 app={app}
@@ -260,7 +243,65 @@ class App extends React.Component {
   }
 }
 
-export default observe(
-  observable => observable.map(state => ({ ...state })),
-  {}
-)(App)
+export default observe(observable => {
+  return observable.map(state => {
+    const settingsLoaded = hasLoadedVoteSettings(state)
+    if (!settingsLoaded) {
+      return {
+        ...state,
+        settingsLoaded,
+      }
+    }
+
+    const { pctBase, supportRequiredPct, tokenDecimals, voteTime } = state
+
+    const pctBaseNum = parseInt(pctBase, 10)
+    const supportRequiredPctNum = parseInt(supportRequiredPct, 10)
+    const tokenDecimalsNum = parseInt(tokenDecimals, 10)
+    const tokenDecimalsBaseNum = Math.pow(10, tokenDecimalsNum)
+
+    return {
+      ...state,
+
+      settingsLoaded,
+      pctBase: new BN(pctBase),
+      supportRequiredPct: new BN(supportRequiredPct),
+      tokenDecimals: new BN(tokenDecimals),
+
+      numData: {
+        pctBase: pctBaseNum,
+        supportRequiredPct: supportRequiredPctNum,
+        tokenDecimals: tokenDecimalsNum,
+      },
+
+      // Transform the vote data for the frontend
+      votes:
+        state && state.votes
+          ? state.votes.map(vote => {
+              const { data } = vote
+              return {
+                ...vote,
+                data: {
+                  ...data,
+                  endDate: new Date(data.startDate + voteTime),
+                  minAcceptQuorum: new BN(data.minAcceptQuorum),
+                  nay: new BN(data.nay),
+                  totalVoters: new BN(data.totalVoters),
+                  yea: new BN(data.yea),
+                  supportRequiredPct: new BN(supportRequiredPct),
+                },
+                numData: {
+                  minAcceptQuorum:
+                    parseInt(data.minAcceptQuorum, 10) / pctBaseNum,
+                  nay: parseInt(data.nay, 10) / tokenDecimalsBaseNum,
+                  totalVoters:
+                    parseInt(data.totalVoters, 10) / tokenDecimalsBaseNum,
+                  yea: parseInt(data.yea, 10) / tokenDecimalsBaseNum,
+                  supportRequiredPct: supportRequiredPctNum / pctBaseNum,
+                },
+              }
+            })
+          : [],
+    }
+  })
+}, {})(App)

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -242,65 +242,67 @@ class App extends React.Component {
   }
 }
 
-export default observe(observable => {
-  return observable.map(state => {
-    const appStateReady = hasLoadedVoteSettings(state)
-    if (!appStateReady) {
+export default observe(
+  observable =>
+    observable.map(state => {
+      const appStateReady = hasLoadedVoteSettings(state)
+      if (!appStateReady) {
+        return {
+          ...state,
+          appStateReady,
+        }
+      }
+
+      const { pctBase, supportRequiredPct, tokenDecimals, voteTime } = state
+
+      const pctBaseNum = parseInt(pctBase, 10)
+      const supportRequiredPctNum = parseInt(supportRequiredPct, 10)
+      const tokenDecimalsNum = parseInt(tokenDecimals, 10)
+      const tokenDecimalsBaseNum = Math.pow(10, tokenDecimalsNum)
+
       return {
         ...state,
+
         appStateReady,
+        pctBase: new BN(pctBase),
+        supportRequiredPct: new BN(supportRequiredPct),
+        tokenDecimals: new BN(tokenDecimals),
+
+        numData: {
+          pctBase: pctBaseNum,
+          supportRequiredPct: supportRequiredPctNum,
+          tokenDecimals: tokenDecimalsNum,
+        },
+
+        // Transform the vote data for the frontend
+        votes:
+          state && state.votes
+            ? state.votes.map(vote => {
+                const { data } = vote
+                return {
+                  ...vote,
+                  data: {
+                    ...data,
+                    endDate: new Date(data.startDate + voteTime),
+                    minAcceptQuorum: new BN(data.minAcceptQuorum),
+                    nay: new BN(data.nay),
+                    totalVoters: new BN(data.totalVoters),
+                    yea: new BN(data.yea),
+                    supportRequiredPct: new BN(supportRequiredPct),
+                  },
+                  numData: {
+                    minAcceptQuorum:
+                      parseInt(data.minAcceptQuorum, 10) / pctBaseNum,
+                    nay: parseInt(data.nay, 10) / tokenDecimalsBaseNum,
+                    totalVoters:
+                      parseInt(data.totalVoters, 10) / tokenDecimalsBaseNum,
+                    yea: parseInt(data.yea, 10) / tokenDecimalsBaseNum,
+                    supportRequiredPct: supportRequiredPctNum / pctBaseNum,
+                  },
+                }
+              })
+            : [],
       }
-    }
-
-    const { pctBase, supportRequiredPct, tokenDecimals, voteTime } = state
-
-    const pctBaseNum = parseInt(pctBase, 10)
-    const supportRequiredPctNum = parseInt(supportRequiredPct, 10)
-    const tokenDecimalsNum = parseInt(tokenDecimals, 10)
-    const tokenDecimalsBaseNum = Math.pow(10, tokenDecimalsNum)
-
-    return {
-      ...state,
-
-      appStateReady,
-      pctBase: new BN(pctBase),
-      supportRequiredPct: new BN(supportRequiredPct),
-      tokenDecimals: new BN(tokenDecimals),
-
-      numData: {
-        pctBase: pctBaseNum,
-        supportRequiredPct: supportRequiredPctNum,
-        tokenDecimals: tokenDecimalsNum,
-      },
-
-      // Transform the vote data for the frontend
-      votes:
-        state && state.votes
-          ? state.votes.map(vote => {
-              const { data } = vote
-              return {
-                ...vote,
-                data: {
-                  ...data,
-                  endDate: new Date(data.startDate + voteTime),
-                  minAcceptQuorum: new BN(data.minAcceptQuorum),
-                  nay: new BN(data.nay),
-                  totalVoters: new BN(data.totalVoters),
-                  yea: new BN(data.yea),
-                  supportRequiredPct: new BN(supportRequiredPct),
-                },
-                numData: {
-                  minAcceptQuorum:
-                    parseInt(data.minAcceptQuorum, 10) / pctBaseNum,
-                  nay: parseInt(data.nay, 10) / tokenDecimalsBaseNum,
-                  totalVoters:
-                    parseInt(data.totalVoters, 10) / tokenDecimalsBaseNum,
-                  yea: parseInt(data.yea, 10) / tokenDecimalsBaseNum,
-                  supportRequiredPct: supportRequiredPctNum / pctBaseNum,
-                },
-              }
-            })
-          : [],
-    }
-  })
-}, {})(App)
+    }),
+  {}
+)(App)

--- a/apps/voting/app/src/components/SummaryRows.js
+++ b/apps/voting/app/src/components/SummaryRows.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { theme } from '@aragon/ui'
+import { formatNumber } from '../math-utils'
 
 const SummaryRows = ({ yea, nay, symbol }) => (
   <div>
@@ -11,7 +12,7 @@ const SummaryRows = ({ yea, nay, symbol }) => (
         <div>{yea.pct}%</div>
       </RowStart>
       <Amount>
-        {yea.amount} {symbol}
+        {formatNumber(yea.amount, 5)} {symbol}
       </Amount>
     </Row>
     <Row>
@@ -21,7 +22,7 @@ const SummaryRows = ({ yea, nay, symbol }) => (
         <div>{nay.pct}%</div>
       </RowStart>
       <Amount>
-        {nay.amount} {symbol}
+        {formatNumber(nay.amount, 5)} {symbol}
       </Amount>
     </Row>
   </div>

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -14,8 +14,9 @@ import {
 } from '@aragon/ui'
 import provideNetwork from '../utils/provideNetwork'
 import { VOTE_NAY, VOTE_YEA } from '../vote-types'
-import { roundToDecimals } from '../math-utils'
+import { round } from '../math-utils'
 import { pluralize } from '../utils'
+import { getQuorumProgress } from '../vote-utils'
 import VoteSummary from './VoteSummary'
 import VoteStatus from './VoteStatus'
 import VoteSuccess from './VoteSuccess'
@@ -145,16 +146,16 @@ class VotePanelContent extends React.Component {
       return null
     }
 
-    const { endDate, open, quorum, quorumProgress, support } = vote
     const {
       creator,
-      metadata,
-      nay,
-      yea,
-      totalVoters,
       description,
+      endDate,
+      metadata,
+      open,
       snapshotBlock,
     } = vote.data
+    const { minAcceptQuorum } = vote.numData
+    const quorumProgress = getQuorumProgress(vote)
 
     return (
       <React.Fragment>
@@ -164,15 +165,7 @@ class VotePanelContent extends React.Component {
               <Label>{open ? 'Time Remaining:' : 'Status'}</Label>
             </h2>
             <div>
-              {open ? (
-                <Countdown end={endDate} />
-              ) : (
-                <VoteStatus
-                  vote={vote}
-                  support={support}
-                  tokenSupply={totalVoters}
-                />
-              )}
+              {open ? <Countdown end={endDate} /> : <VoteStatus vote={vote} />}
             </div>
             <StyledVoteSuccess vote={vote} />
           </div>
@@ -181,14 +174,14 @@ class VotePanelContent extends React.Component {
               <Label>Total support</Label>
             </h2>
             <div>
-              {roundToDecimals(quorumProgress * 100, 2)}%{' '}
+              {round(quorumProgress * 100, 2)}%{' '}
               <Text size="small" color={theme.textSecondary}>
-                ({roundToDecimals(quorum * 100, 2)}% needed)
+                ({round(minAcceptQuorum * 100, 2)}% needed)
               </Text>
             </div>
             <StyledSummaryBar
               positiveSize={quorumProgress}
-              requiredSize={quorum}
+              requiredSize={minAcceptQuorum}
               show={ready}
               compact
             />
@@ -236,9 +229,7 @@ class VotePanelContent extends React.Component {
         <SidePanelSeparator />
 
         <VoteSummary
-          votesYea={yea}
-          votesNay={nay}
-          support={support}
+          vote={vote}
           tokenSymbol={tokenSymbol}
           tokenDecimals={tokenDecimals}
           ready={ready}

--- a/apps/voting/app/src/components/VoteStatus.js
+++ b/apps/voting/app/src/components/VoteStatus.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { theme, IconTime, IconCross, IconCheck } from '@aragon/ui'
+import provideSettings from '../utils/provideSettings'
 import {
   VOTE_STATUS_ONGOING,
   VOTE_STATUS_REJECTED,
@@ -36,8 +37,8 @@ const ATTRIBUTES = {
   },
 }
 
-const VoteStatus = ({ vote, cardStyle }) => {
-  const status = getVoteStatus(vote)
+const VoteStatus = ({ cardStyle, settings, vote }) => {
+  const status = getVoteStatus(vote, settings.pctBase)
   const { label, Icon, color, bold } = ATTRIBUTES[status]
   return (
     <Main
@@ -62,4 +63,4 @@ const StatusLabel = styled.span`
   margin-left: ${({ spaced }) => (spaced ? '5px' : '0')};
 `
 
-export default VoteStatus
+export default provideSettings(VoteStatus)

--- a/apps/voting/app/src/components/VoteSuccess.js
+++ b/apps/voting/app/src/components/VoteSuccess.js
@@ -1,16 +1,17 @@
 import React from 'react'
 import styled from 'styled-components'
 import { theme, IconCross, IconCheck } from '@aragon/ui'
+import provideSettings from '../utils/provideSettings'
 import { getVoteSuccess } from '../vote-utils'
 
-const VoteSuccess = ({ vote, ...props }) => (
+const VoteSuccess = ({ settings, vote, ...props }) => (
   <Main {...props}>
     {(() => {
       if (!vote.open) {
         return 'Voting has ended'
       }
 
-      const success = getVoteSuccess(vote)
+      const success = getVoteSuccess(vote, settings.pctBase)
       const Icon = success ? IconCheck : IconCross
       return (
         <React.Fragment>
@@ -42,4 +43,4 @@ const StatusLabel = styled.span`
   margin-left: 15px;
 `
 
-export default VoteSuccess
+export default provideSettings(VoteSuccess)

--- a/apps/voting/app/src/components/VoteSummary.js
+++ b/apps/voting/app/src/components/VoteSummary.js
@@ -1,23 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Text, theme } from '@aragon/ui'
-import { safeDiv, percentageList, tokenAmount } from '../math-utils'
+import { percentageList, safeDiv } from '../math-utils'
 import SummaryBar from './SummaryBar'
 import SummaryRows from './SummaryRows'
 
-const VoteSummary = ({
-  votesYea,
-  votesNay,
-  quorum,
-  quorumProgress,
-  support,
-  tokenSymbol,
-  tokenDecimals,
-  ready,
-}) => {
-  const totalVotes = votesYea + votesNay
-  const votesYeaVotersSize = safeDiv(votesYea, totalVotes)
-  const votesNayVotersSize = safeDiv(votesNay, totalVotes)
+const VoteSummary = ({ vote, tokenSymbol, tokenDecimals, ready }) => {
+  const { yea, nay, supportRequiredPct } = vote.numData
+  const totalVotes = yea + nay
+  const votesYeaVotersSize = safeDiv(yea, totalVotes)
+  const votesNayVotersSize = safeDiv(nay, totalVotes)
 
   const [yeaPct, nayPct] = percentageList(
     [votesYeaVotersSize, votesNayVotersSize],
@@ -32,7 +24,7 @@ const VoteSummary = ({
             Current votes{' '}
           </Text>
           <Text size="xsmall" color={theme.textSecondary}>
-            ({Math.round(support * 100)}% needed)
+            ({Math.round(supportRequiredPct * 100)}% needed)
           </Text>
         </span>
       </Header>
@@ -40,13 +32,13 @@ const VoteSummary = ({
       <SummaryBar
         positiveSize={votesYeaVotersSize}
         negativeSize={votesNayVotersSize}
-        requiredSize={support}
+        requiredSize={supportRequiredPct}
         show={ready}
       />
 
       <SummaryRows
-        yea={{ pct: yeaPct, amount: tokenAmount(votesYea, tokenDecimals) }}
-        nay={{ pct: nayPct, amount: tokenAmount(votesNay, tokenDecimals) }}
+        yea={{ pct: yeaPct, amount: yea }}
+        nay={{ pct: nayPct, amount: nay }}
         symbol={tokenSymbol}
       />
     </Main>

--- a/apps/voting/app/src/components/VotingCard/VotingCard.js
+++ b/apps/voting/app/src/components/VotingCard/VotingCard.js
@@ -19,7 +19,7 @@ class VotingCard extends React.Component {
       options,
       endDate,
       question,
-      opened,
+      open,
       totalVoters,
       status,
       id,
@@ -27,7 +27,7 @@ class VotingCard extends React.Component {
     return (
       <Main>
         <Header>
-          {opened ? (
+          {open ? (
             <Countdown end={endDate} />
           ) : (
             <PastDate dateTime={format(endDate, 'yyyy-MM-dd[T]HH:mm:ss')}>

--- a/apps/voting/app/src/math-utils.js
+++ b/apps/voting/app/src/math-utils.js
@@ -43,7 +43,7 @@ export function percentageList(values, digits = 0) {
  * @returns {number} Rounded number
  */
 export function round(num, decimals = 2) {
-  const rounded = +(Math.round(num + 'e+' + decimals) + 'e-' + decimals)
+  const rounded = Number(Math.round(num + 'e+' + decimals) + 'e-' + decimals)
   return Number.isNaN(rounded) ? +num.toFixed(decimals) : rounded
 }
 

--- a/apps/voting/app/src/math-utils.js
+++ b/apps/voting/app/src/math-utils.js
@@ -1,29 +1,43 @@
-import BN from 'bn.js'
-
-// Return 0 if denominator is 0 to avoid NaNs
-export function safeDiv(num, denom) {
-  return denom ? num / denom : 0
-}
-
-// Make a token amount human readable
-export function tokenAmount(value, decimals = 18) {
-  if (decimals === 0) {
-    return String(value)
-  }
-  const amount = new BN(value)
-  const divisor = new BN(10).pow(new BN(decimals))
-  const left = amount.div(divisor).toString()
-  const right = amount.mod(divisor).toString()
-  return `${left}.${right.padEnd(decimals, '0')}`
-}
-
-export function roundToDecimals(value, decimals = 2) {
+export function formatNumber(num, decimals = 2) {
   const multiplicator = Math.pow(10, decimals)
-  return Math.round(value * multiplicator) / multiplicator
+  const roundedNum = Math.round(num * multiplicator) / multiplicator
+  const numString = String(roundedNum)
+
+  if (!decimals) {
+    return numString
+  }
+
+  const [whole, decimal = ''] = numString.split('.')
+  return `${whole}.${
+    decimal.length > decimal
+      ? decimal.slice(0, decimals)
+      : decimal.padEnd(decimals, '0')
+  }`
 }
 
 export function percentageList(values, digits = 0) {
   return scaleValuesSet(values, digits)
+}
+
+/**
+ * Generic round function, see:
+ *  - https://stackoverflow.com/a/18358056/1375656
+ *  - https://stackoverflow.com/a/19722641/1375656
+ *
+ * Fixed for NaNs on really small values
+ *
+ * @param {number} num Number to round
+ * @param {number} [places=2] Number of places to round to
+ * @param {number} Rounded number
+ */
+export function round(num, places = 2) {
+  const rounded = +(Math.round(num + 'e+' + places) + 'e-' + places)
+  return Number.isNaN(rounded) ? +num.toFixed(places) : rounded
+}
+
+// Return 0 if denominator is 0 to avoid NaNs
+export function safeDiv(num, denom) {
+  return denom ? num / denom : 0
 }
 
 // Get a list of rounded 0 => `total` numbers, from a list of 0 => 1 values.
@@ -43,7 +57,6 @@ export function scaleValuesSet(values, digits = 0, total = 100) {
     const percentage = Math.floor(value * total * digitsMultiplicator)
     remaining -= percentage
     return {
-      value,
       percentage,
       remain: (value * total * digitsMultiplicator) % 1,
     }

--- a/apps/voting/app/src/math-utils.js
+++ b/apps/voting/app/src/math-utils.js
@@ -1,4 +1,13 @@
-export function formatNumber(num, decimals = 2) {
+/**
+ * Format numbers for a given number of decimal places
+ *
+ * @param {number} num Number to round
+ * @param {number} [decimals=2] Number of decimals to round to
+ * @param {Object} [options] Options object
+ * @param {bool} [options.truncate=true] Whether to truncate the trailing decimals (if they're 0)
+ * @returns {String} Formatted number
+ */
+export function formatNumber(num, decimals = 2, { truncate = true } = {}) {
   const multiplicator = Math.pow(10, decimals)
   const roundedNum = Math.round(num * multiplicator) / multiplicator
   const numString = String(roundedNum)
@@ -8,11 +17,14 @@ export function formatNumber(num, decimals = 2) {
   }
 
   const [whole, decimal = ''] = numString.split('.')
-  return `${whole}.${
-    decimal.length > decimal
-      ? decimal.slice(0, decimals)
-      : decimal.padEnd(decimals, '0')
-  }`
+  const trimmedDecimals = truncate ? decimal.replace(/0+$/, '') : decimals
+  return trimmedDecimals.length
+    ? `${whole}.${
+        trimmedDecimals.length > decimals
+          ? trimmedDecimals.slice(0, decimals)
+          : trimmedDecimals
+      }`
+    : whole
 }
 
 export function percentageList(values, digits = 0) {
@@ -27,12 +39,12 @@ export function percentageList(values, digits = 0) {
  * Fixed for NaNs on really small values
  *
  * @param {number} num Number to round
- * @param {number} [places=2] Number of places to round to
- * @param {number} Rounded number
+ * @param {number} [decimals=2] Number of decimals to round to
+ * @returns {number} Rounded number
  */
-export function round(num, places = 2) {
-  const rounded = +(Math.round(num + 'e+' + places) + 'e-' + places)
-  return Number.isNaN(rounded) ? +num.toFixed(places) : rounded
+export function round(num, decimals = 2) {
+  const rounded = +(Math.round(num + 'e+' + decimals) + 'e-' + decimals)
+  return Number.isNaN(rounded) ? +num.toFixed(decimals) : rounded
 }
 
 // Return 0 if denominator is 0 to avoid NaNs

--- a/apps/voting/app/src/math-utils.js
+++ b/apps/voting/app/src/math-utils.js
@@ -44,7 +44,7 @@ export function percentageList(values, digits = 0) {
  */
 export function round(num, decimals = 2) {
   const rounded = Number(Math.round(num + 'e+' + decimals) + 'e-' + decimals)
-  return Number.isNaN(rounded) ? +num.toFixed(decimals) : rounded
+  return Number.isNaN(rounded) ? Number(num.toFixed(decimals)) : rounded
 }
 
 // Return 0 if denominator is 0 to avoid NaNs

--- a/apps/voting/app/src/screens/Votes.js
+++ b/apps/voting/app/src/screens/Votes.js
@@ -31,11 +31,14 @@ class Votes extends React.Component {
   }
   render() {
     const { votes, onSelectVote } = this.props
-    const sortedVotes = votes.sort((a, b) => (a.endDate > b.endDate ? -1 : 1))
-    const openedVotes = sortedVotes.filter(({ open }) => open)
-    const closedVotes = sortedVotes.filter(vote => !openedVotes.includes(vote))
+    const sortedVotes = votes.sort(
+      (a, b) => (a.data.endDate > b.data.endDate ? -1 : 1)
+    )
+
+    const openVotes = sortedVotes.filter(vote => vote.data.open)
+    const closedVotes = sortedVotes.filter(vote => !openVotes.includes(vote))
     const votingGroups = [
-      ['Opened votes', openedVotes],
+      ['Open votes', openVotes],
       ['Past votes', closedVotes],
     ]
     return (
@@ -55,19 +58,19 @@ class Votes extends React.Component {
                     status={
                       vote.open ? null : <VoteStatus vote={vote} cardStyle />
                     }
-                    endDate={vote.endDate}
-                    opened={vote.open}
+                    endDate={vote.data.endDate}
+                    open={vote.data.open}
                     question={this.getQuestionLabel(vote.data)}
-                    totalVoters={vote.data.totalVoters}
+                    totalVoters={vote.numData.totalVoters}
                     onOpen={onSelectVote}
                     options={[
                       {
                         label: this.optionLabel('Yes', vote, VOTE_YEA),
-                        power: vote.data.yea,
+                        power: vote.numData.yea,
                       },
                       {
                         label: this.optionLabel('No', vote, VOTE_NAY),
-                        power: vote.data.nay,
+                        power: vote.numData.nay,
                         color: theme.negative,
                       },
                     ]}

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -76,7 +76,7 @@ async function initialize(tokenAddr) {
       err
     )
     console.err('Defaulting to 18...')
-    tokenDecimals = 18
+    tokenDecimals = '18'
   }
 
   return createStore(token, { decimals: tokenDecimals, symbol: tokenSymbol })
@@ -231,12 +231,8 @@ function loadVoteSettings() {
             .call(name)
             .first()
             .map(val => {
-              if (type === 'number') {
-                return parseInt(val, 10)
-              }
               if (type === 'time') {
-                // Adjust for js time (in ms vs s)
-                return parseInt(val, 10) * 1000
+                return marshallDate(val)
               }
               return val
             })
@@ -261,7 +257,6 @@ function loadTokenDecimals(tokenContract) {
     tokenContract
       .decimals()
       .first()
-      .map(val => parseInt(val, 10))
       .subscribe(resolve, reject)
   })
 }
@@ -292,13 +287,20 @@ function marshallVote({
   return {
     creator,
     executed,
-    minAcceptQuorum: parseInt(minAcceptQuorum, 10),
-    nay: parseInt(nay, 10),
-    snapshotBlock: parseInt(snapshotBlock, 10),
-    startDate: parseInt(startDate, 10) * 1000, // adjust for js time (in ms vs s)
-    totalVoters: parseInt(totalVoters, 10),
-    yea: parseInt(yea, 10),
-    script,
     description,
+    minAcceptQuorum,
+    nay,
+    script,
+    totalVoters,
+    yea,
+    // Like times, blocks should be safe to represent as real numbers
+    snapshotBlock: parseInt(snapshotBlock, 10),
+    startDate: marshallDate(startDate, 10),
   }
+}
+
+function marshallDate(date) {
+  // Represent dates as real numbers, as it's very unlikely they'll hit the limit...
+  // Adjust for js time (in ms vs s)
+  return parseInt(date, 10) * 1000
 }

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -164,15 +164,16 @@ async function loadVoteDescription(vote) {
   }
 
   const path = await app.describeScript(vote.script).toPromise()
-
   vote.description = path
-    .map(step => {
-      const identifier = step.identifier ? ` (${step.identifier})` : ''
-      const app = step.name ? `${step.name}${identifier}` : `${step.to}`
+    ? path
+        .map(step => {
+          const identifier = step.identifier ? ` (${step.identifier})` : ''
+          const app = step.name ? `${step.name}${identifier}` : `${step.to}`
 
-      return `${app}: ${step.description || 'No description'}`
-    })
-    .join('\n')
+          return `${app}: ${step.description || 'No description'}`
+        })
+        .join('\n')
+    : ''
 
   return vote
 }

--- a/apps/voting/app/src/utils/provideSettings.js
+++ b/apps/voting/app/src/utils/provideSettings.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import getDisplayName from 'react-display-name'
+import BN from 'bn.js'
+
+export const settingsContextType = PropTypes.shape({
+  pctBase: PropTypes.instanceOf(BN),
+  voteTime: PropTypes.number,
+})
+
+const provideSettings = Component => {
+  const GetSettings = (props, context) => <Component {...context} {...props} />
+  GetSettings.contextTypes = {
+    settings: settingsContextType,
+  }
+  GetSettings.displayName = `GetSettings(${getDisplayName(Component)})`
+  return GetSettings
+}
+
+export default provideSettings

--- a/apps/voting/app/src/vote-settings.js
+++ b/apps/voting/app/src/vote-settings.js
@@ -1,8 +1,8 @@
 const voteSettings = [
   ['token', 'tokenAddress'],
   ['voteTime', 'voteTime', 'time'],
-  ['PCT_BASE', 'pctBase', 'number'],
-  ['supportRequiredPct', 'supportRequiredPct', 'number'],
+  ['PCT_BASE', 'pctBase', 'bignumber'],
+  ['supportRequiredPct', 'supportRequiredPct', 'bignumber'],
 ]
 
 export function hasLoadedVoteSettings(state) {

--- a/apps/voting/app/src/vote-utils.js
+++ b/apps/voting/app/src/vote-utils.js
@@ -36,18 +36,29 @@ export function getVoteStatus(vote, pctBase) {
 }
 
 export function getVoteSuccess(vote, pctBase) {
-  const { yea, nay, minAcceptQuorum, supportRequiredPct } = vote.data
+  const {
+    yea,
+    minAcceptQuorum,
+    nay,
+    supportRequiredPct,
+    totalVoters,
+  } = vote.data
 
-  // Mirror on-chain calculation
   const totalVotes = yea.add(nay)
   if (totalVotes.isZero()) {
     return false
   }
   const yeaPct = yea.mul(pctBase).div(totalVotes)
+  const yeaOfTotalPowerPct = yea.mul(pctBase).div(totalVoters)
 
-  // yea / totalVotes > supportRequiredPct
-  // yea / totalVotes > minAcceptQuorum
-  return yeaPct.gt(supportRequiredPct) && yeaPct.gt(minAcceptQuorum)
+  // Mirror on-chain calculation
+  // yea / votingPower > supportRequiredPct ||
+  //   (yea / totalVotes > supportRequiredPct &&
+  //    yea / votingPower > minAcceptQuorum)
+  return (
+    yeaOfTotalPowerPct.gt(supportRequiredPct) ||
+    (yeaPct.gt(supportRequiredPct) && yeaOfTotalPowerPct.gt(minAcceptQuorum))
+  )
 }
 
 // Enums are not supported by the ABI yet:


### PR DESCRIPTION
Depends on #483.

Refactors the internal state model of the app.

Main changes:

- Moved most of the vote data structure manipulation into the `observe` block, as they don't need to be done on each render, and this helps ensure type purity as it's the "entry point" for data
- Moved everything related to a vote's contract state into `vote.data`
- Added a settings context provider (old API) for cases where we need some of the voting app's settings
- Except for time-based values, avoid passing back numbers from the script (prefer strings)
- Add `numData` fields to both the settings and each vote, for calculations that don't require accurate operations
- Use exact calculations when they're safer (e.g. when mimicking [`canExecute()`](https://github.com/aragon/aragon-apps/blob/master/apps/voting/contracts/Voting.sol#L194)