### PR TITLE
Rename totalVoters => votingPower

### DIFF
--- a/apps/survey/test/survey.js
+++ b/apps/survey/test/survey.js
@@ -109,13 +109,13 @@ contract('Survey app', accounts => {
       })
 
       it('has correct state', async () => {
-        const [isOpen, startDate, snapshotBlock, minParticipationPct, totalVoters, participation, options] = await survey.getSurvey(surveyId)
+        const [isOpen, startDate, snapshotBlock, minParticipationPct, votingPower, participation, options] = await survey.getSurvey(surveyId)
 
         assert.isTrue(isOpen, 'survey should be open')
         assert.equal(creator, nonHolder, 'creator should be correct')
         assert.equal(snapshotBlock, await getBlockNumber() - 1, 'snapshot block should be correct')
         assert.deepEqual(minParticipationPct, minimumAcceptanceParticipationPct, 'min participation should be survey min participation')
-        assert.equal(totalVoters, 100, 'total voters should be 100')
+        assert.equal(votingPower, 100, 'total voters should be 100')
         assert.equal(participation, 0, 'initial participation should be 0') // didn't vote even though creator was holder
         assert.equal(options, optionsCount, 'number of options should be correct')
         assert.equal(metadata, 'metadata', 'should have returned correct metadata')

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -291,18 +291,18 @@ export default observe(
                   endDate: new Date(data.startDate + voteTime),
                   minAcceptQuorum: new BN(data.minAcceptQuorum),
                   nay: new BN(data.nay),
-                  totalVoters: new BN(data.totalVoters),
-                  yea: new BN(data.yea),
                   supportRequiredPct: new BN(supportRequiredPct),
+                  votingPower: new BN(data.votingPower),
+                  yea: new BN(data.yea),
                 },
                 numData: {
                   minAcceptQuorum:
                     parseInt(data.minAcceptQuorum, 10) / pctBaseNum,
                   nay: parseInt(data.nay, 10) / tokenDecimalsBaseNum,
-                  totalVoters:
-                    parseInt(data.totalVoters, 10) / tokenDecimalsBaseNum,
-                  yea: parseInt(data.yea, 10) / tokenDecimalsBaseNum,
                   supportRequiredPct: supportRequiredPctNum / pctBaseNum,
+                  votingPower:
+                    parseInt(data.votingPower, 10) / tokenDecimalsBaseNum,
+                  yea: parseInt(data.yea, 10) / tokenDecimalsBaseNum,
                 },
               }
             })

--- a/apps/voting/app/src/components/VotingCard/VotingCard.js
+++ b/apps/voting/app/src/components/VotingCard/VotingCard.js
@@ -20,7 +20,7 @@ class VotingCard extends React.Component {
       endDate,
       question,
       open,
-      totalVoters,
+      votingPower,
       status,
       id,
     } = this.props
@@ -45,7 +45,7 @@ class VotingCard extends React.Component {
               <Text color={theme.textTertiary}>#{id} </Text>
               <span>{question}</span>
             </Question>
-            <VotingOptions totalVoters={totalVoters} options={options} />
+            <VotingOptions options={options} votingPower={votingPower} />
           </Content>
           <Footer>
             <SecondaryButton onClick={this.handleOpen}>

--- a/apps/voting/app/src/components/VotingCard/VotingOptions.js
+++ b/apps/voting/app/src/components/VotingCard/VotingOptions.js
@@ -26,11 +26,11 @@ class VotingOptions extends React.Component {
   }
   render() {
     const { delay } = this.state
-    const { options, totalVoters } = this.props
+    const { options, votingPower } = this.props
 
     const percentages =
-      totalVoters > 0
-        ? percentageList(options.map(o => o.power / totalVoters), 2)
+      votingPower > 0
+        ? percentageList(options.map(o => o.power / votingPower), 2)
         : [0, 0]
 
     return (
@@ -41,7 +41,7 @@ class VotingOptions extends React.Component {
             delay={delay}
             config={springs.stiff}
             from={{ value: 0 }}
-            to={{ value: totalVoters > 0 ? option.power / totalVoters : 0 }}
+            to={{ value: votingPower > 0 ? option.power / votingPower : 0 }}
             native
           >
             {({ value }) => (

--- a/apps/voting/app/src/screens/Votes.js
+++ b/apps/voting/app/src/screens/Votes.js
@@ -61,7 +61,7 @@ class Votes extends React.Component {
                     endDate={vote.data.endDate}
                     open={vote.data.open}
                     question={this.getQuestionLabel(vote.data)}
-                    totalVoters={vote.numData.totalVoters}
+                    votingPower={vote.numData.votingPower}
                     onOpen={onSelectVote}
                     options={[
                       {

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -271,7 +271,7 @@ function loadTokenSymbol(tokenContract) {
   })
 }
 
-// Apply transmations to a vote received from web3
+// Apply transformations to a vote received from web3
 // Note: ignores the 'open' field as we calculate that locally
 function marshallVote({
   creator,
@@ -280,7 +280,7 @@ function marshallVote({
   nay,
   snapshotBlock,
   startDate,
-  totalVoters,
+  votingPower,
   yea,
   script,
   description,
@@ -292,7 +292,7 @@ function marshallVote({
     minAcceptQuorum,
     nay,
     script,
-    totalVoters,
+    votingPower,
     yea,
     // Like times, blocks should be safe to represent as real numbers
     snapshotBlock: parseInt(snapshotBlock, 10),

--- a/apps/voting/app/src/vote-utils.js
+++ b/apps/voting/app/src/vote-utils.js
@@ -20,8 +20,8 @@ export function isVoteOpen(vote, date) {
   return !executed && isBefore(date, endDate)
 }
 
-export const getQuorumProgress = ({ numData: { yea, totalVoters } }) =>
-  yea / totalVoters
+export const getQuorumProgress = ({ numData: { yea, votingPower } }) =>
+  yea / votingPower
 
 export function getVoteStatus(vote, pctBase) {
   if (vote.data.executed) {
@@ -41,7 +41,7 @@ export function getVoteSuccess(vote, pctBase) {
     minAcceptQuorum,
     nay,
     supportRequiredPct,
-    totalVoters,
+    votingPower,
   } = vote.data
 
   const totalVotes = yea.add(nay)
@@ -49,7 +49,7 @@ export function getVoteSuccess(vote, pctBase) {
     return false
   }
   const yeaPct = yea.mul(pctBase).div(totalVotes)
-  const yeaOfTotalPowerPct = yea.mul(pctBase).div(totalVoters)
+  const yeaOfTotalPowerPct = yea.mul(pctBase).div(votingPower)
 
   // Mirror on-chain calculation
   // yea / votingPower > supportRequiredPct ||

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -44,7 +44,7 @@ contract Voting is IForwarder, AragonApp {
         uint64 minAcceptQuorumPct;
         uint256 yea;
         uint256 nay;
-        uint256 totalVoters;
+        uint256 votingPower;
         bytes executionScript;
         mapping (address => VoterState) voters;
     }
@@ -208,7 +208,7 @@ contract Voting is IForwarder, AragonApp {
         }
 
         // Voting is already decided
-        if (_isValuePct(vote_.yea, vote_.totalVoters, vote_.supportRequiredPct)) {
+        if (_isValuePct(vote_.yea, vote_.votingPower, vote_.supportRequiredPct)) {
             return true;
         }
 
@@ -223,7 +223,7 @@ contract Voting is IForwarder, AragonApp {
             return false;
         }
         // Has min quorum?
-        if (!_isValuePct(vote_.yea, vote_.totalVoters, vote_.minAcceptQuorumPct)) {
+        if (!_isValuePct(vote_.yea, vote_.votingPower, vote_.minAcceptQuorumPct)) {
             return false;
         }
 
@@ -243,7 +243,7 @@ contract Voting is IForwarder, AragonApp {
             uint64 minAcceptQuorum,
             uint256 yea,
             uint256 nay,
-            uint256 totalVoters,
+            uint256 votingPower,
             bytes script
         )
     {
@@ -257,7 +257,7 @@ contract Voting is IForwarder, AragonApp {
         minAcceptQuorum = vote_.minAcceptQuorumPct;
         yea = vote_.yea;
         nay = vote_.nay;
-        totalVoters = vote_.totalVoters;
+        votingPower = vote_.votingPower;
         script = vote_.executionScript;
     }
 
@@ -269,8 +269,8 @@ contract Voting is IForwarder, AragonApp {
         internal
         returns (uint256 voteId)
     {
-        uint256 totalVoters = token.totalSupplyAt(vote_.snapshotBlock);
-        require(totalVoters > 0, ERROR_NO_VOTING_POWER);
+        uint256 votingPower = token.totalSupplyAt(vote_.snapshotBlock);
+        require(votingPower > 0, ERROR_NO_VOTING_POWER);
 
         voteId = votesLength++;
         Vote storage vote_ = votes[voteId];
@@ -278,7 +278,7 @@ contract Voting is IForwarder, AragonApp {
         vote_.snapshotBlock = getBlockNumber64() - 1; // avoid double voting in this very block
         vote_.supportRequiredPct = supportRequiredPct;
         vote_.minAcceptQuorumPct = minAcceptQuorumPct;
-        vote_.totalVoters = totalVoters;
+        vote_.votingPower = votingPower;
         vote_.executionScript = _executionScript;
 
         emit StartVote(voteId, msg.sender, _metadata);

--- a/apps/voting/test/voting.js
+++ b/apps/voting/test/voting.js
@@ -218,7 +218,7 @@ contract('Voting App', accounts => {
                 })
 
                 it('has correct state', async () => {
-                    const [isOpen, isExecuted, startDate, snapshotBlock, supportRequired, minQuorum, y, n, totalVoters, execScript] = await voting.getVote(voteId)
+                    const [isOpen, isExecuted, startDate, snapshotBlock, supportRequired, minQuorum, y, n, votingPower, execScript] = await voting.getVote(voteId)
 
                     assert.isTrue(isOpen, 'vote should be open')
                     assert.isFalse(isExecuted, 'vote should not be executed')
@@ -228,7 +228,7 @@ contract('Voting App', accounts => {
                     assert.equal(minQuorum.toNumber(), minimumAcceptanceQuorum.toNumber(), 'min quorum should be app min quorum')
                     assert.equal(y, 0, 'initial yea should be 0')
                     assert.equal(n, 0, 'initial nay should be 0')
-                    assert.equal(totalVoters.toString(), bigExp(100, decimals).toString(), 'total voters should be 100')
+                    assert.equal(votingPower.toString(), bigExp(100, decimals).toString(), 'total voters should be 100')
                     assert.equal(execScript, script, 'script should be correct')
                     assert.equal(metadata, 'metadata', 'should have returned correct metadata')
                     assert.equal(await voting.getVoterState(voteId, nonHolder), VOTER_STATE.ABSENT, 'nonHolder should not have voted')


### PR DESCRIPTION
Aligns the terminology used between the Voting and Survey apps.

`votingPower` is a lot more clear than `totalVoters`, as `totalVoters` implies the number of people who voted.

**BREAKING CHANGE** for the voting app's frontend.