### PR TITLE
Token Manager: fix input fields' step behavour and accuracy

### DIFF
--- a/apps/token-manager/app/src/components/Panels/AssignVotePanelContent.js
+++ b/apps/token-manager/app/src/components/Panels/AssignVotePanelContent.js
@@ -1,8 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Button, Field, IconCross, Text, TextInput } from '@aragon/ui'
-import BN from 'bn.js'
 import { addressPattern, isAddress } from '../../web3-utils'
+import { fromDecimals, toDecimals } from '../../utils'
+
+// Any more and the number input field starts to put numbers in scientific notation
+const MAX_INPUT_DECIMAL_BASE = 6
 
 const initialState = {
   amount: '',
@@ -58,12 +61,12 @@ class AssignVotePanelContent extends React.Component {
   handleSubmit = event => {
     event.preventDefault()
     const { amount, holder } = this.state
-    const { mode } = this.props
+    const { mode, tokenDecimals } = this.props
     const holderAddress = holder.value.trim()
     if (isAddress(holderAddress)) {
       this.props.onUpdateTokens({
         mode,
-        amount: amount,
+        amount: toDecimals(amount, tokenDecimals),
         holder: holderAddress,
       })
     } else {
@@ -77,10 +80,11 @@ class AssignVotePanelContent extends React.Component {
   }
   render() {
     const { amount, holder } = this.state
-    const { mode, tokenDecimalsBase } = this.props
-    const tokenBase = tokenDecimalsBase
-      ? new BN(1).div(tokenDecimalsBase).toNumber()
-      : 0
+    const { mode, tokenDecimals } = this.props
+    const minTokenStep = fromDecimals(
+      '1',
+      Math.min(MAX_INPUT_DECIMAL_BASE, tokenDecimals)
+    )
     return (
       <div>
         <form onSubmit={this.handleSubmit}>
@@ -110,8 +114,8 @@ class AssignVotePanelContent extends React.Component {
             <TextInput.Number
               value={amount}
               onChange={this.handleAmountChange}
-              min={tokenBase}
-              step={tokenBase}
+              min={minTokenStep}
+              step={minTokenStep}
               required
               wide
             />

--- a/apps/token-manager/app/src/utils.js
+++ b/apps/token-manager/app/src/utils.js
@@ -1,6 +1,80 @@
 import BN from 'bn.js'
 
 /**
+ * Get the whole and decimal parts from a number.
+ * Trims leading and trailing zeroes.
+ *
+ * @param {string} num the number
+ * @returns {Array<string>} array with the [<whole>, <decimal>] parts of the number
+ */
+function splitDecimalNumber(num) {
+  const [whole = '', dec = ''] = num.split('.')
+  return [
+    whole.replace(/^0*/, ''), // trim leading zeroes
+    dec.replace(/0*$/, ''), // trim trailing zeroes
+  ]
+}
+
+/**
+ * Format a decimal-based number back to a normal number
+ *
+ * @param {string} num the number
+ * @param {number} decimals number of decimal places
+ * @param {Object} [options] options object
+ * @param {bool} [options.truncate=true] Should the number be truncated to its decimal base
+ * @returns {string} formatted number
+ */
+export function fromDecimals(num, decimals, { truncate = true } = {}) {
+  const [whole, dec] = splitDecimalNumber(num)
+  if (!whole && !dec) {
+    return '0'
+  }
+
+  const paddedWhole = whole.padStart(decimals + 1, '0')
+  const decimalIndex = paddedWhole.length - decimals
+  const wholeWithoutBase = paddedWhole.slice(0, decimalIndex)
+  const decWithoutBase = paddedWhole.slice(decimalIndex)
+
+  if (!truncate && dec) {
+    // We need to keep all the zeroes in this case
+    return `${wholeWithoutBase}.${decWithoutBase}${dec}`
+  }
+
+  // Trim any trailing zeroes from the new decimals
+  const decWithoutBaseTrimmed = decWithoutBase.replace(/0*$/, '')
+  if (decWithoutBaseTrimmed) {
+    return `${wholeWithoutBase}.${decWithoutBaseTrimmed}`
+  }
+
+  return wholeWithoutBase
+}
+
+/**
+ * Format the number to be in a given decimal base
+ *
+ * @param {string} num the number
+ * @param {number} decimals number of decimal places
+ * @param {Object} [options] options object
+ * @param {bool} [options.truncate=true] Should the number be truncated to its decimal base
+ * @returns {string} formatted number
+ */
+export function toDecimals(num, decimals, { truncate = true } = {}) {
+  const [whole, dec] = splitDecimalNumber(num)
+  if (!whole && !dec) {
+    return '0'
+  }
+
+  const wholeLengthWithBase = whole.length + decimals
+  const withoutDecimals = (whole + dec).padEnd(wholeLengthWithBase, '0')
+  const wholeWithBase = withoutDecimals.slice(0, wholeLengthWithBase)
+
+  if (!truncate && wholeWithBase.length < withoutDecimals.length) {
+    return `${wholeWithBase}.${withoutDecimals.slice(wholeLengthWithBase)}`
+  }
+  return wholeWithBase
+}
+
+/**
  * Format the balance to a fixed number of decimals
  *
  * @param {BN} amount the total amount

--- a/apps/token-manager/app/src/utils.test.js
+++ b/apps/token-manager/app/src/utils.test.js
@@ -1,12 +1,142 @@
 import BN from 'bn.js'
-import { stakesPercentages, formatBalance } from './utils'
+import {
+  formatBalance,
+  fromDecimals,
+  stakesPercentages,
+  toDecimals,
+} from './utils'
 
 const bn = v => new BN(v)
 
-const totalPercentage = stakes =>
-  stakes.reduce((total, stake) => total + stake.percentage, 0)
+describe('fromDecimals', () => {
+  test('Should adjust from decimal base', () => {
+    expect(fromDecimals('3', 3)).toBe('0.003')
+    expect(fromDecimals('3.0', 3)).toBe('0.003')
+    expect(fromDecimals('123', 3)).toBe('0.123')
+    expect(fromDecimals('1234', 3)).toBe('1.234')
+    expect(fromDecimals('3000', 3)).toBe('3')
+    expect(fromDecimals('3001', 3)).toBe('3.001')
+    expect(fromDecimals('3010', 3)).toBe('3.01')
+    expect(fromDecimals('30000', 3)).toBe('30')
+    expect(fromDecimals('123456', 3)).toBe('123.456')
+
+    // Use decimal base 0
+    expect(fromDecimals('1', 0)).toBe('1')
+    expect(fromDecimals('123', 0)).toBe('123')
+
+    // Use decimal base 1
+    expect(fromDecimals('1', 1)).toBe('0.1')
+    expect(fromDecimals('123', 1)).toBe('12.3')
+
+    // Use decimal base 18
+    // The zeroes length to use is 18 - <length of whole>
+    expect(fromDecimals('1', 18)).toBe(`0.${'0'.repeat(17)}1`)
+    expect(fromDecimals('12', 18)).toBe(`0.${'0'.repeat(16)}12`)
+    expect(fromDecimals('12345678', 18)).toBe(`0.${'0'.repeat(10)}12345678`)
+  })
+  test('Should truncate trailing decimals after adjusting by default', () => {
+    expect(fromDecimals('34.123456', 0)).toBe('34')
+    expect(fromDecimals('34.123456', 1)).toBe('3.4')
+    expect(fromDecimals('34.123456', 3)).toBe('0.034')
+  })
+  test('Should not truncate trailing decimals if asked not to', () => {
+    expect(fromDecimals('34.123456', 0, { truncate: false })).toBe('34.123456')
+    expect(fromDecimals('34.123456', 1, { truncate: false })).toBe('3.4123456')
+    expect(fromDecimals('34.123456', 3, { truncate: false })).toBe(
+      '0.034123456'
+    )
+    expect(fromDecimals('34.000012', 3, { truncate: false })).toBe(
+      '0.034000012'
+    )
+    expect(fromDecimals('0.000012', 3, { truncate: false })).toBe('0.000000012')
+  })
+  test('Should trim leading zeroes when adjusting', () => {
+    expect(fromDecimals('0000123', 3)).toBe('0.123')
+    expect(fromDecimals('0003123', 3)).toBe('3.123')
+  })
+  test('Should return 0 if only zeroes are given', () => {
+    expect(fromDecimals('0', 3)).toBe('0')
+    expect(fromDecimals('0000', 3)).toBe('0')
+    expect(fromDecimals('0.0', 3)).toBe('0')
+    expect(fromDecimals('.0', 3)).toBe('0')
+    expect(fromDecimals('.000', 3)).toBe('0')
+    expect(fromDecimals('.', 3)).toBe('0')
+  })
+  test('Should return 0 if any empty string is given', () => {
+    expect(fromDecimals('', 3)).toBe('0')
+  })
+})
+
+describe('toDecimals', () => {
+  test('Should adjust to decimal base', () => {
+    expect(toDecimals('0.123', 3)).toBe('123')
+    expect(toDecimals('.123', 3)).toBe('123')
+    expect(toDecimals('3', 3)).toBe('3000')
+    expect(toDecimals('3.0', 3)).toBe('3000')
+    expect(toDecimals('3.123', 3)).toBe('3123')
+    expect(toDecimals('34.12', 3)).toBe('34120')
+    expect(toDecimals('3412', 3)).toBe('3412000')
+
+    // Use decimal base 0
+    expect(toDecimals('1', 0)).toBe('1')
+    expect(toDecimals('123', 0)).toBe('123')
+
+    // Use decimal base 1
+    expect(toDecimals('1', 1)).toBe('10')
+    expect(toDecimals('1.1', 1)).toBe('11')
+    expect(toDecimals('123', 1)).toBe('1230')
+
+    // Use decimal base 18
+    // The padEnd length to use is <length of whole> + 18
+    expect(toDecimals('1', 18)).toBe('1'.padEnd(19, '0'))
+    expect(toDecimals('34', 18)).toBe('34'.padEnd(20, '0'))
+    expect(toDecimals('34.123456', 18)).toBe('34123456'.padEnd(20, '0'))
+  })
+  test('Should truncate trailing decimals after adjusting by default', () => {
+    expect(toDecimals('34.123456', 0)).toBe('34')
+    expect(toDecimals('34.123456', 1)).toBe('341')
+    expect(toDecimals('34.123456', 3)).toBe('34123')
+  })
+  test('Should not truncate trailing decimals if asked not to', () => {
+    expect(toDecimals('34.123456', 0, { truncate: false })).toBe('34.123456')
+    expect(toDecimals('34.123456', 1, { truncate: false })).toBe('341.23456')
+    expect(toDecimals('34.123456', 3, { truncate: false })).toBe('34123.456')
+  })
+  test('Should trim leading zeroes when adjusting', () => {
+    expect(toDecimals('0000.123', 3)).toBe('123')
+    expect(toDecimals('0003.123', 3)).toBe('3123')
+  })
+  test('Should return 0 if only zeroes are given', () => {
+    expect(toDecimals('0', 3)).toBe('0')
+    expect(toDecimals('0000', 3)).toBe('0')
+    expect(toDecimals('0.0', 3)).toBe('0')
+    expect(toDecimals('.0', 3)).toBe('0')
+    expect(toDecimals('.000', 3)).toBe('0')
+    expect(toDecimals('.', 3)).toBe('0')
+  })
+  test('Should return 0 if any empty string is given', () => {
+    expect(toDecimals('', 3)).toBe('0')
+  })
+})
+
+describe('formatBalance', () => {
+  test('Should not display the decimals if they are 0', () => {
+    expect(formatBalance(bn(3000), bn(1000))).toBe('3')
+  })
+  test('Should display decimals correctly', () => {
+    expect(formatBalance(bn(3001), bn(1000), 3)).toBe('3.001')
+    expect(formatBalance(bn(3010), bn(1000), 3)).toBe('3.01')
+  })
+  test('Should adapt based on the precision', () => {
+    expect(formatBalance(bn(3001), bn(1000), 1)).toBe('3')
+    expect(formatBalance(bn(3101), bn(1000), 1)).toBe('3.1')
+  })
+})
 
 describe('stakePercentages()', () => {
+  const totalPercentage = stakes =>
+    stakes.reduce((total, stake) => total + stake.percentage, 0)
+
   test(
     'Items having the same value should have ' +
       'an equal percentage, if divisible',
@@ -47,19 +177,5 @@ describe('stakePercentages()', () => {
     expect(stakes).toHaveLength(4)
     expect(totalPercentage(stakes)).toBe(100)
     expect(stakes.map(s => s.percentage)).toEqual([33, 33, 33, 1])
-  })
-})
-
-describe('formatBalance', () => {
-  test('Should not display the decimals if they are 0', () => {
-    expect(formatBalance(bn(3000), bn(1000))).toBe('3')
-  })
-  test('Should display decimals correctly', () => {
-    expect(formatBalance(bn(3001), bn(1000), 3)).toBe('3.001')
-    expect(formatBalance(bn(3010), bn(1000), 3)).toBe('3.01')
-  })
-  test('Should adapt based on the precision', () => {
-    expect(formatBalance(bn(3001), bn(1000), 1)).toBe('3')
-    expect(formatBalance(bn(3101), bn(1000), 1)).toBe('3.1')
   })
 })


### PR DESCRIPTION
Builds on #480 and #485.

Introduces `fromDecimals()` and `toDecimals()` utilities to translate between a string number and a token decimal base (very, very similar to `toWei()` and `fromWei()`).

Fixes the input field not having a step, and the accuracy of the conversion (`parseFloat()` would be inaccurate on large decimal bases).