### PR TITLE
Fix date format

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -8,7 +8,7 @@
     "@aragon/templates-tokens": "^1.1.1",
     "@aragon/ui": "^0.11.0",
     "copy-to-clipboard": "^3.0.8",
-    "date-fns": "^2.0.0-alpha.7",
+    "date-fns": "2.0.0-alpha.22",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-display-name": "^0.2.3",

--- a/apps/finance/app/src/components/TransferRow.js
+++ b/apps/finance/app/src/components/TransferRow.js
@@ -8,7 +8,6 @@ import {
   ContextMenu,
   ContextMenuItem,
   SafeLink,
-  formatHtmlDatetime,
   theme,
 } from '@aragon/ui'
 import provideNetwork from '../lib/provideNetwork'
@@ -61,12 +60,12 @@ class TransferRow extends React.Component {
       true,
       { rounding: 5 }
     )
-    const formattedDate = formatHtmlDatetime(date)
+    const formattedDate = format(date, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx")
     return (
       <TableRow>
         <NoWrapCell>
           <time dateTime={formattedDate} title={formattedDate}>
-            {format(date, 'DD/MM/YY')}
+            {format(date, 'dd/MM/yy')}
           </time>
         </NoWrapCell>
         <NoWrapCell>

--- a/apps/finance/app/src/components/TransferRow.js
+++ b/apps/finance/app/src/components/TransferRow.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import copy from 'copy-to-clipboard'
-import { format } from 'date-fns/esm'
+import { format } from 'date-fns'
 import {
   TableRow,
   TableCell,

--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { compareDesc } from 'date-fns/esm'
+import { compareDesc } from 'date-fns'
 import {
   Button,
   Table,

--- a/apps/survey/app/package.json
+++ b/apps/survey/app/package.json
@@ -7,7 +7,7 @@
     "@aragon/client": "1.0.0-beta.9",
     "@aragon/ui": "0.16.0",
     "bignumber.js": "^7.2.1",
-    "date-fns": "2.0.0-alpha.8",
+    "date-fns": "2.0.0-alpha.22",
     "onecolor": "^3.0.5",
     "prop-types": "^15.6.0",
     "react": "^16.3.1",

--- a/apps/survey/app/src/components/SurveyCard/SurveyCard.js
+++ b/apps/survey/app/src/components/SurveyCard/SurveyCard.js
@@ -35,8 +35,10 @@ class SurveyCard extends React.Component {
           {open ? (
             <Countdown end={endDate} />
           ) : (
-            <PastDate dateTime={format(endDate, 'yyyy-MM-dd[T]HH:mm:ss')}>
-              {format(endDate, 'dd MMM yyyy HH:mm')}
+            <PastDate
+              dateTime={format(endDate, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx")}
+            >
+              {format(endDate, 'EEEEEE MMM yyyy HH:mm')}
             </PastDate>
           )}
         </Header>

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -7,7 +7,7 @@
     "@aragon/client": "^1.0.0-beta.8",
     "@aragon/ui": "^0.18.2",
     "bn.js": "^4.11.8",
-    "date-fns": "2.0.0-alpha.7",
+    "date-fns": "2.0.0-alpha.22",
     "onecolor": "^3.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.5.2",

--- a/apps/voting/app/src/components/VotingCard/VotingCard.js
+++ b/apps/voting/app/src/components/VotingCard/VotingCard.js
@@ -30,8 +30,10 @@ class VotingCard extends React.Component {
           {open ? (
             <Countdown end={endDate} />
           ) : (
-            <PastDate dateTime={format(endDate, 'yyyy-MM-dd[T]HH:mm:ss')}>
-              {format(endDate, 'dd MMM yyyy HH:mm')}
+            <PastDate
+              dateTime={format(endDate, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx")}
+            >
+              {format(endDate, 'EEEEEE MMM yyyy HH:mm')}
             </PastDate>
           )}
 

--- a/apps/voting/app/src/vote-utils.js
+++ b/apps/voting/app/src/vote-utils.js
@@ -1,4 +1,4 @@
-import { isBefore } from 'date-fns/esm'
+import { isBefore } from 'date-fns'
 import {
   VOTE_ABSENT,
   VOTE_YEA,


### PR DESCRIPTION
Fixes the datetime formatting and pins `date-fns` to `@2.0.0-beta.22` so we don't get more unexpected surprises :).

See https://gist.github.com/kossnocorp/a307a464760b405bb78ef5020a4ab136#changed-8 for the new format tokens and https://date-fns.org/v2.0.0-alpha.22/docs/Unicode-Tokens for popularly confused unicode tokens.