### PR TITLE
Bump aragon-ui to 0.21.0

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aragon/client": "^1.0.0-beta.8",
     "@aragon/templates-tokens": "^1.1.1",
-    "@aragon/ui": "^0.11.0",
+    "@aragon/ui": "^0.21.0",
     "copy-to-clipboard": "^3.0.8",
     "date-fns": "^2.0.0-alpha.7",
     "prop-types": "^15.6.0",

--- a/apps/token-manager/app/package.json
+++ b/apps/token-manager/app/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@aragon/client": "^1.0.0-beta.8",
-    "@aragon/ui": "^0.20.0",
+    "@aragon/ui": "^0.21.0",
     "bn.js": "^4.11.6",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@aragon/client": "^1.0.0-beta.8",
-    "@aragon/ui": "^0.18.2",
+    "@aragon/ui": "^0.21.0",
     "bn.js": "^4.11.8",
     "date-fns": "2.0.0-alpha.7",
     "onecolor": "^3.1.0",


### PR DESCRIPTION
Didn't update survey as it is pinned to `0.16.0`. 