### PR TITLE
chore: remove docker from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 sudo: required
-services:
-  - docker
 language: node_js
 cache:
   directories:


### PR DESCRIPTION
AFAIK we only needed it for the dao-kits, which have since been moved.