### PR TITLE
Token Manager: fix empty state action

### DIFF
--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -44,7 +44,7 @@ class App extends React.Component {
 
     this.handleSidepanelClose()
   }
-  handleAppBarLaunchAssignTokens = () => {
+  handleLaunchAssignTokensNoHolder = () => {
     this.handleLaunchAssignTokens('')
   }
   handleLaunchAssignTokens = holder => {
@@ -95,7 +95,7 @@ class App extends React.Component {
               endContent={
                 <Button
                   mode="strong"
-                  onClick={this.handleAppBarLaunchAssignTokens}
+                  onClick={this.handleLaunchAssignTokensNoHolder}
                 >
                   Assign Tokens
                 </Button>
@@ -118,7 +118,9 @@ class App extends React.Component {
                   onRemoveTokens={this.handleLaunchRemoveTokens}
                 />
               ) : (
-                <EmptyState onActivate={this.handleLaunchAssignTokens} />
+                <EmptyState
+                  onActivate={this.handleLaunchAssignTokensNoHolder}
+                />
               )}
             </AppLayout.Content>
           </AppLayout.ScrollWrapper>


### PR DESCRIPTION
Fixes the empty state action button opening up the panel with '[Object object]' because it passes the event object 😅 