### PR TITLE
chore: use prepare script instead of postinstall to avoid installing app dependencies in dependents

### DIFF
--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.0-rc.1",
   "main": "index.js",
   "scripts": {
-    "postinstall": "cd app && npm install",
     "compile": "truffle compile",
     "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
@@ -20,6 +19,7 @@
     "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
     "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:test": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
+    "prepare": "cd app && npm install",
     "prepublishOnly": "truffle compile --all"
   },
   "files": [

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0-rc.1",
   "main": "index.js",
   "scripts": {
-    "postinstall": "cd app && npm install",
     "compile": "truffle compile",
     "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
@@ -20,6 +19,7 @@
     "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
     "console": "node_modules/.bin/truffle console",
     "ganache-cli:test": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
+    "prepare": "cd app && npm install",
     "prepublishOnly": "truffle compile --all"
   },
   "keywords": [],

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.0-rc.1",
   "main": "index.js",
   "scripts": {
-    "postinstall": "cd app && npm install",
     "compile": "truffle compile",
     "build": "cd app && npm run build",
     "deploy:rpc": "truffle exec scripts/deploy.js --network rpc",
@@ -20,6 +19,7 @@
     "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
     "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:test": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
+    "prepare": "cd app && npm install",
     "prepublishOnly": "truffle compile --all"
   },
   "keywords": [],

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -20,6 +20,7 @@
     "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
     "truffle:dev": "node_modules/.bin/truffle dev",
     "ganache-cli:test": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
+    "prepare": "cd app && npm install",
     "prepublishOnly": "truffle compile --all"
   },
   "keywords": [],


### PR DESCRIPTION
The `rc.1` builds are broken as well, because we don't publish the `app/` directory anymore.