### PR TITLE
chore: allow coverage test for finance app to fail due to excessive timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ env:
   - TASK=coverage:vault
   - TASK=coverage:voting
   - TASK=test:shared
+matrix:
+  allow_failures:
+    - env: TASK=coverage:finance
 before_script:
   - npm prune
 script:


### PR DESCRIPTION
Until https://github.com/sc-forks/solidity-coverage/issues/283 is fixed, the finance app requires a ridiculous amount of time to instrument its dependencies during coverage testing and usually causes the travis build to fail by hitting the max build time (50min).

Not the nicest, but it's a coverage test and there's not much else we can do for now aside from fixing solidity-coverage.