### PR TITLE
Finance: explain why setPaymentStatus() doesn't transition periods

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -342,6 +342,10 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         external
         authP(MANAGE_PAYMENTS_ROLE, arr(_paymentId, uint256(_active ? 1 : 0)))
         paymentExists(_paymentId)
+        // Note that we do not require this action to transition periods, as it doesn't directly
+        // impact any accounting periods.
+        // Not having to transition periods also makes disabling payments easier to prevent funds
+        // from being pulled out in the event of a breach.
     {
         payments[_paymentId].inactive = !_active;
         emit ChangePaymentState(_paymentId, _active);


### PR DESCRIPTION
From https://github.com/ConsenSys/aragon-apps-audit-repo/issues/45:

-----------------------------

Transitioning periods is only necessary when an action is related to the accounting periods, and these periods can be affected by any of the following:

- A transfer (in or out of the Finance app)
- Changing the period duration
- Changing the budget (since it's effective immediately, it should transition periods to only impact the relevant period if the app's behind)

Disabling or enabling a payment doesn't directly impact any of the above. I think an argument could be made either way, but I believe not having the modifier is safer, as it makes this management related functionality easier than pulling funds out (although this can also be argued in the reverse if the manager is malicious).