### PR TITLE
Token manager: fix the token badge when the label is too long

### DIFF
--- a/apps/token-manager/app/src/components/SideBar.js
+++ b/apps/token-manager/app/src/components/SideBar.js
@@ -151,9 +151,13 @@ const InfoRow = styled.li`
     color: ${theme.textSecondary};
   }
   > span:nth-child(2) {
-    display: none;
+    opacity: 0;
+    width: 10px;
   }
-  strong {
+  > span:nth-child(3) {
+    flex-shrink: 1;
+  }
+  > strong {
     text-transform: uppercase;
   }
 `

--- a/apps/token-manager/app/src/components/TokenBadge.js
+++ b/apps/token-manager/app/src/components/TokenBadge.js
@@ -8,7 +8,10 @@ class TokenBadge extends React.PureComponent {
       <Main title={`${name} (${address})`}>
         <Label>
           <Icon src={`https://chasing-coins.com/coin/logo/${symbol}`} />
-          <Name>{name === symbol ? name : `${name} (${symbol})`}</Name>
+          <NameWrapper>
+            <Name>{name}</Name>
+            {name !== symbol && <Symbol>({symbol})</Symbol>}
+          </NameWrapper>
         </Label>
       </Main>
     )
@@ -39,11 +42,22 @@ const Icon = styled.img.attrs({ alt: '', width: '16', height: '16' })`
   margin-right: 10px;
 `
 
+const NameWrapper = styled.span`
+  flex-shrink: 1;
+  display: flex;
+  min-width: 0;
+`
+
 const Name = styled.span`
+  flex-shrink: 1;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-width: 0;
-  flex-shrink: 1;
+  min-width: 20%;
+`
+
+const Symbol = styled.span`
+  flex-shrink: 0;
+  margin-left: 5px;
 `
 
 export default TokenBadge

--- a/apps/token-manager/app/src/components/TokenBadge.js
+++ b/apps/token-manager/app/src/components/TokenBadge.js
@@ -8,7 +8,7 @@ class TokenBadge extends React.PureComponent {
       <Main title={`${name} (${address})`}>
         <Label>
           <Icon src={`https://chasing-coins.com/coin/logo/${symbol}`} />
-          {name === symbol ? name : `${name} (${symbol})`}
+          <Name>{name === symbol ? name : `${name} (${symbol})`}</Name>
         </Label>
       </Main>
     )
@@ -23,18 +23,27 @@ const Main = styled.div`
   background: #daeaef;
   border-radius: 3px;
   cursor: default;
+  padding: 0 8px;
 `
 
 const Label = styled.span`
   display: flex;
   align-items: center;
-  padding: 0 8px;
   white-space: nowrap;
   font-size: 15px;
+  min-width: 0;
+  flex-shrink: 1;
 `
 
 const Icon = styled.img.attrs({ alt: '', width: '16', height: '16' })`
   margin-right: 10px;
+`
+
+const Name = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex-shrink: 1;
 `
 
 export default TokenBadge


### PR DESCRIPTION
Before:

<img width="316" alt="image" src="https://user-images.githubusercontent.com/36158/47610438-34532000-da4d-11e8-96c2-6577eef1db60.png">

After:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/36158/47643167-e6ccd500-db6a-11e8-83ce-3712c0cb5a4c.png">

