### PR TITLE
Vault: rename events to avoid clashing with ERC20 Transfer event

### DIFF
--- a/apps/vault/contracts/Vault.sol
+++ b/apps/vault/contracts/Vault.sol
@@ -18,8 +18,8 @@ contract Vault is EtherTokenConstant, AragonApp, DepositableStorage {
     string private constant ERROR_TOKEN_TRANSFER_FROM_REVERTED = "VAULT_TOKEN_TRANSFER_FROM_REVERT";
     string private constant ERROR_TOKEN_TRANSFER_REVERTED = "VAULT_TOKEN_TRANSFER_REVERTED";
 
-    event Transfer(address indexed token, address indexed to, uint256 amount);
-    event Deposit(address indexed token, address indexed sender, uint256 amount);
+    event VaultTransfer(address indexed token, address indexed to, uint256 amount);
+    event VaultDeposit(address indexed token, address indexed sender, uint256 amount);
 
     /**
     * @dev On a normal send() or transfer() this fallback is never executed as it will be
@@ -67,7 +67,7 @@ contract Vault is EtherTokenConstant, AragonApp, DepositableStorage {
             require(ERC20(_token).transfer(_to, _value), ERROR_TOKEN_TRANSFER_REVERTED);
         }
 
-        emit Transfer(_token, _to, _value);
+        emit VaultTransfer(_token, _to, _value);
     }
 
     function balance(address _token) public view returns (uint256) {
@@ -97,6 +97,6 @@ contract Vault is EtherTokenConstant, AragonApp, DepositableStorage {
             require(ERC20(_token).transferFrom(msg.sender, this, _value), ERROR_TOKEN_TRANSFER_FROM_REVERTED);
         }
 
-        emit Deposit(_token, msg.sender, _value);
+        emit VaultDeposit(_token, msg.sender, _value);
     }
 }


### PR DESCRIPTION
To prevent the Vault from being identified as an ERC20, causing fun things like this:
<img width="452" alt="2018-10-28 at 2 34 57 pm" src="https://user-images.githubusercontent.com/447328/47616554-bd566f80-dabe-11e8-9139-c69e0c4c5e6e.png">
<img width="1151" alt="2018-10-28 at 2 35 09 pm" src="https://user-images.githubusercontent.com/447328/47616555-bf203300-dabe-11e8-93d9-1d192e2f6767.png">
