### PR TITLE
Finance: use attached Vault's initialization block as starting block for events

### DIFF
--- a/apps/finance/app/src/abi/vault-getinitializationblock.json
+++ b/apps/finance/app/src/abi/vault-getinitializationblock.json
@@ -1,0 +1,14 @@
+{
+  "constant": true,
+  "inputs": [],
+  "name": "getInitializationBlock",
+  "outputs": [
+    {
+      "name": "",
+      "type": "uint256"
+    }
+  ],
+  "payable": false,
+  "stateMutability": "view",
+  "type": "function"
+}

--- a/apps/finance/app/src/script.js
+++ b/apps/finance/app/src/script.js
@@ -110,10 +110,7 @@ async function createStore(settings) {
       .first()
       .toPromise()
   } catch (err) {
-    console.error(
-      "Could not get attached vault's initialization block:",
-      err
-    )
+    console.error("Could not get attached vault's initialization block:", err)
   }
 
   return app.store(


### PR DESCRIPTION
Use the vault's own initialization block as the `fromBlock` when subscribing to vault events.