### PR TITLE
Finance: add asterisks to all required input fields

### DIFF
--- a/apps/finance/app/src/components/NewTransfer/TokenSelector.js
+++ b/apps/finance/app/src/components/NewTransfer/TokenSelector.js
@@ -98,6 +98,7 @@ class TokenSelector extends React.Component {
             items={items}
             active={activeIndex}
             onChange={this.handleChange}
+            required
             wide
           />
         </Field>
@@ -108,6 +109,7 @@ class TokenSelector extends React.Component {
               placeholder="SYM…"
               value={customToken.value}
               onChange={this.handleCustomTokenChange}
+              required
               wide
             />
           </Field>

--- a/apps/finance/app/src/components/NewTransfer/Withdrawal.js
+++ b/apps/finance/app/src/components/NewTransfer/Withdrawal.js
@@ -9,6 +9,7 @@ import {
   Text,
   TextInput,
   theme,
+  unselectable,
 } from '@aragon/ui'
 import { toDecimals } from '../../lib/math-utils'
 import { addressPattern, isAddress } from '../../lib/web3-utils'
@@ -139,10 +140,10 @@ class Withdrawal extends React.Component {
         </Field>
         <AmountField>
           <label>
-            <Text.Block color={theme.textSecondary} smallcaps>
+            <StyledTextBlock>
               Amount
               <StyledAsterisk />
-            </Text.Block>
+            </StyledTextBlock>
           </label>
           <CombinedInput>
             <TextInput.Number
@@ -203,12 +204,20 @@ const CombinedInput = styled.div`
   }
 `
 
+const StyledTextBlock = styled(Text.Block).attrs({
+  color: theme.textSecondary,
+  smallcaps: true,
+})`
+  ${unselectable()};
+  display: flex;
+`
+
 const StyledAsterisk = styled.span.attrs({
   children: '*',
   title: 'Required',
 })`
   color: ${theme.accent};
-  float: right;
+  margin-left: auto;
   padding-top: 3px;
   font-size: 12px;
 `

--- a/apps/finance/app/src/components/NewTransfer/Withdrawal.js
+++ b/apps/finance/app/src/components/NewTransfer/Withdrawal.js
@@ -141,6 +141,7 @@ class Withdrawal extends React.Component {
           <label>
             <Text.Block color={theme.textSecondary} smallcaps>
               Amount
+              <StyledAsterisk />
             </Text.Block>
           </label>
           <CombinedInput>
@@ -200,6 +201,16 @@ const CombinedInput = styled.div`
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
+`
+
+const StyledAsterisk = styled.span.attrs({
+  children: '*',
+  title: 'Required',
+})`
+  color: ${theme.accent};
+  float: right;
+  padding-top: 3px;
+  font-size: 12px;
 `
 
 const ValidationError = ({ message }) => (


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/508, adding asterisks to these panels:

<img width="300" alt="screen shot 2018-12-08 at 12 35 52 pm" src="https://user-images.githubusercontent.com/4166642/49685597-fc2c0c00-fae5-11e8-8906-e67e28f40548.png">

-----

<img width="300" alt="screen shot 2018-12-08 at 12 35 59 pm" src="https://user-images.githubusercontent.com/4166642/49685598-fe8e6600-fae5-11e8-90ff-acbd8ec1a157.png">

-----

<img width="300" alt="screen shot 2018-12-08 at 12 36 04 pm" src="https://user-images.githubusercontent.com/4166642/49685600-00f0c000-fae6-11e8-860f-f72f0a8122bc.png">

------

Also makes the label unselectable in cases where we used a custom label.