### PR TITLE
Responsive menu panel for iframe apps

### DIFF
--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -11,10 +11,13 @@ import {
   PublicUrl,
   SidePanel,
   observe,
+  font,
+  BreakPoint,
 } from '@aragon/ui'
 import Balances from './components/Balances'
 import NewTransferPanelContent from './components/NewTransfer/PanelContent'
 import Transfers from './components/Transfers'
+import MenuButton from './components/MenuButton/MenuButton'
 import { networkContextType } from './lib/provideNetwork'
 import { ETHER_TOKEN_FAKE_ADDRESS } from './lib/token-utils'
 import { makeEtherscanBaseUrl } from './lib/utils'
@@ -24,6 +27,7 @@ import addFundsIcon from './components/assets/add-funds-icon.svg'
 class App extends React.Component {
   static propTypes = {
     app: PropTypes.object.isRequired,
+    sendMessageToWrapper: PropTypes.func.isRequired,
     proxyAddress: PropTypes.string,
   }
   static defaultProps = {
@@ -85,6 +89,11 @@ class App extends React.Component {
     app.deposit(tokenAddress, amount, reference, intentParams)
     this.handleNewTransferClose()
   }
+
+  handleMenuPanelOpen = () => {
+    this.props.sendMessageToWrapper('menuPanel', true)
+  }
+
   render() {
     const {
       app,
@@ -103,7 +112,14 @@ class App extends React.Component {
           <AppView
             appBar={
               <AppBar
-                title="Finance"
+                title={
+                  <Title>
+                    <BreakPoint to="medium">
+                      <MenuButton onClick={this.handleMenuPanelOpen} />
+                    </BreakPoint>
+                    <TitleLabel>Finance</TitleLabel>
+                  </Title>
+                }
                 endContent={
                   <Button mode="strong" onClick={this.handleNewTransferOpen}>
                     New Transfer
@@ -155,6 +171,15 @@ class App extends React.Component {
     )
   }
 }
+
+const Title = styled.span`
+  display: flex;
+  align-items: center;
+`
+
+const TitleLabel = styled.span`
+  ${font({ size: 'xxlarge' })};
+`
 
 const Main = styled.div`
   height: 100vh;

--- a/apps/finance/app/src/components/MenuButton/IconMenu.js
+++ b/apps/finance/app/src/components/MenuButton/IconMenu.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Menu = props => (
+  <svg width="18px" height="14px" viewBox="0 0 18 14" {...props}>
+    <g transform="translate(-19, -25)" stroke="currentColor">
+      <g transform="translate(20, 25)">
+        <path d="M0,1 L16,1" />
+        <path d="M0,7 L16,7" />
+        <path d="M0,13 L16,13" />
+      </g>
+    </g>
+  </svg>
+)
+
+export default Menu

--- a/apps/finance/app/src/components/MenuButton/MenuButton.js
+++ b/apps/finance/app/src/components/MenuButton/MenuButton.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { theme } from '@aragon/ui'
+import IconMenu from './IconMenu'
+
+const StyledButton = styled.button`
+  border: none;
+  background: none;
+  margin-right: 8px;
+  height: 32px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+
+  &:focus {
+    border: 2px solid ${theme.accent};
+  }
+  &:active {
+    border: none;
+  }
+`
+
+export default props => (
+  <StyledButton {...props}>
+    <IconMenu />
+  </StyledButton>
+)

--- a/apps/finance/app/src/index.js
+++ b/apps/finance/app/src/index.js
@@ -39,7 +39,9 @@ class ConnectedApp extends React.Component {
     window.parent.postMessage({ from: 'app', name, value }, '*')
   }
   render() {
-    return <App {...this.state} />
+    return (
+      <App {...this.state} sendMessageToWrapper={this.sendMessageToWrapper} />
+    )
   }
 }
 

--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -12,10 +12,12 @@ import {
   SidePanel,
   font,
   observe,
+  BreakPoint,
 } from '@aragon/ui'
 import EmptyState from './screens/EmptyState'
 import Holders from './screens/Holders'
 import AssignVotePanelContent from './components/Panels/AssignVotePanelContent'
+import MenuButton from './components/MenuButton/MenuButton'
 import { networkContextType } from './provide-network'
 import { hasLoadedTokenSettings } from './token-settings'
 import { makeEtherscanBaseUrl } from './utils'
@@ -29,6 +31,7 @@ const initialAssignTokensConfig = {
 class App extends React.Component {
   static propTypes = {
     app: PropTypes.object.isRequired,
+    sendMessageToWrapper: PropTypes.func.isRequired,
   }
   static defaultProps = {
     appStateReady: false,
@@ -88,6 +91,9 @@ class App extends React.Component {
       sidepanelOpened: true,
     })
   }
+  handleMenuPanelOpen = () => {
+    this.props.sendMessageToWrapper('menuPanel', true)
+  }
   handleSidepanelClose = () => {
     this.setState({ sidepanelOpened: false })
   }
@@ -121,6 +127,9 @@ class App extends React.Component {
               <AppBar
                 title={
                   <Title>
+                    <BreakPoint to="medium">
+                      <MenuButton onClick={this.handleMenuPanelOpen} />
+                    </BreakPoint>
                     <TitleLabel>Token Manager</TitleLabel>
                     {tokenSymbol && <Badge.App>{tokenSymbol}</Badge.App>}
                   </Title>

--- a/apps/token-manager/app/src/components/MenuButton/IconMenu.js
+++ b/apps/token-manager/app/src/components/MenuButton/IconMenu.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Menu = props => (
+  <svg width="18px" height="14px" viewBox="0 0 18 14" {...props}>
+    <g transform="translate(-19, -25)" stroke="currentColor">
+      <g transform="translate(20, 25)">
+        <path d="M0,1 L16,1" />
+        <path d="M0,7 L16,7" />
+        <path d="M0,13 L16,13" />
+      </g>
+    </g>
+  </svg>
+)
+
+export default Menu

--- a/apps/token-manager/app/src/components/MenuButton/MenuButton.js
+++ b/apps/token-manager/app/src/components/MenuButton/MenuButton.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { theme } from '@aragon/ui'
+import IconMenu from './IconMenu'
+
+const StyledButton = styled.button`
+  border: none;
+  background: none;
+  margin-right: 8px;
+  height: 32px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+
+  &:focus {
+    border: 2px solid ${theme.accent};
+  }
+  &:active {
+    border: none;
+  }
+`
+
+export default props => (
+  <StyledButton {...props}>
+    <IconMenu />
+  </StyledButton>
+)

--- a/apps/token-manager/app/src/index.js
+++ b/apps/token-manager/app/src/index.js
@@ -35,7 +35,9 @@ class ConnectedApp extends React.Component {
     window.parent.postMessage({ from: 'app', name, value }, '*')
   }
   render() {
-    return <App {...this.state} />
+    return (
+      <App {...this.state} sendMessageToWrapper={this.sendMessageToWrapper} />
+    )
   }
 }
 

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -8,6 +8,7 @@ import {
   BaseStyles,
   PublicUrl,
   SidePanel,
+  font,
   observe,
 } from '@aragon/ui'
 import BN from 'bn.js'
@@ -22,13 +23,14 @@ import { settingsContextType } from './utils/provideSettings'
 import { hasLoadedVoteSettings } from './vote-settings'
 import { VOTE_YEA } from './vote-types'
 import { EMPTY_CALLSCRIPT } from './evmscript-utils'
-import { makeEtherscanBaseUrl } from './utils'
+import { makeEtherscanBaseUrl, isMobile } from './utils'
 import { isVoteOpen, voteTypeFromContractEnum } from './vote-utils'
 import { shortenAddress, transformAddresses } from './web3-utils'
 
 class App extends React.Component {
   static propTypes = {
     app: PropTypes.object.isRequired,
+    sendMessageToWrapper: PropTypes.func.isRequired,
   }
   static defaultProps = {
     appStateReady: false,
@@ -147,15 +149,21 @@ class App extends React.Component {
     this.setState(opened ? { voteSidebarOpened: true } : { currentVoteId: -1 })
   }
 
+  handleMenuPanelOpen = () => {
+    this.props.sendMessageToWrapper('menuPanel', true)
+  }
+
   shortenAddresses(label) {
-    return transformAddresses(label, (part, isAddress, index) =>
-      isAddress ? (
-        <span title={part} key={index}>
-          {shortenAddress(part)}
-        </span>
-      ) : (
-        <span key={index}>{part}</span>
-      )
+    return transformAddresses(
+      label,
+      (part, isAddress, index) =>
+        isAddress ? (
+          <span title={part} key={index}>
+            {shortenAddress(part)}
+          </span>
+        ) : (
+          <span key={index}>{part}</span>
+        )
     )
   }
   // Shorten addresses, render line breaks, auto link
@@ -225,7 +233,14 @@ class App extends React.Component {
           <AppView
             appBar={
               <AppBar
-                title="Voting"
+                title={
+                  <Title>
+                    {isMobile() && (
+                      <button onClick={this.handleMenuPanelOpen}>M</button>
+                    )}
+                    <TitleLabel>Voting</TitleLabel>
+                  </Title>
+                }
                 endContent={
                   <Button mode="strong" onClick={this.handleCreateVoteOpen}>
                     New Vote
@@ -278,6 +293,16 @@ class App extends React.Component {
     )
   }
 }
+
+const Title = styled.span`
+  display: flex;
+  align-items: center;
+`
+
+const TitleLabel = styled.span`
+  margin-right: 10px;
+  ${font({ size: 'xxlarge' })};
+`
 
 const Main = styled.div`
   height: 100vh;

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -10,6 +10,7 @@ import {
   SidePanel,
   font,
   observe,
+  BreakPoint,
 } from '@aragon/ui'
 import BN from 'bn.js'
 import EmptyState from './screens/EmptyState'
@@ -18,12 +19,13 @@ import tokenAbi from './abi/token-balanceOfAt.json'
 import VotePanelContent from './components/VotePanelContent'
 import NewVotePanelContent from './components/NewVotePanelContent'
 import AutoLink from './components/AutoLink'
+import MenuButton from './components/MenuButton/MenuButton'
 import { networkContextType } from './utils/provideNetwork'
 import { settingsContextType } from './utils/provideSettings'
 import { hasLoadedVoteSettings } from './vote-settings'
 import { VOTE_YEA } from './vote-types'
 import { EMPTY_CALLSCRIPT } from './evmscript-utils'
-import { makeEtherscanBaseUrl, isMobile } from './utils'
+import { makeEtherscanBaseUrl } from './utils'
 import { isVoteOpen, voteTypeFromContractEnum } from './vote-utils'
 import { shortenAddress, transformAddresses } from './web3-utils'
 
@@ -235,9 +237,9 @@ class App extends React.Component {
               <AppBar
                 title={
                   <Title>
-                    {isMobile() && (
-                      <button onClick={this.handleMenuPanelOpen}>M</button>
-                    )}
+                    <BreakPoint to="medium">
+                      <MenuButton onClick={this.handleMenuPanelOpen} />
+                    </BreakPoint>
                     <TitleLabel>Voting</TitleLabel>
                   </Title>
                 }

--- a/apps/voting/app/src/components/MenuButton/IconMenu.js
+++ b/apps/voting/app/src/components/MenuButton/IconMenu.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Menu = props => (
+  <svg width="18px" height="14px" viewBox="0 0 18 14" {...props}>
+    <g transform="translate(-19, -25)" stroke="currentColor">
+      <g transform="translate(20, 25)">
+        <path d="M0,1 L16,1" />
+        <path d="M0,7 L16,7" />
+        <path d="M0,13 L16,13" />
+      </g>
+    </g>
+  </svg>
+)
+
+export default Menu

--- a/apps/voting/app/src/components/MenuButton/MenuButton.js
+++ b/apps/voting/app/src/components/MenuButton/MenuButton.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { theme } from '@aragon/ui'
+import IconMenu from './IconMenu'
+
+const StyledButton = styled.button`
+  border: none;
+  background: none;
+  margin-right: 8px;
+  height: 32px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+
+  &:focus {
+    border: 2px solid ${theme.accent};
+  }
+  &:active {
+    border: none;
+  }
+`
+
+export default props => (
+  <StyledButton {...props}>
+    <IconMenu />
+  </StyledButton>
+)

--- a/apps/voting/app/src/index.js
+++ b/apps/voting/app/src/index.js
@@ -36,7 +36,9 @@ class ConnectedApp extends React.Component {
     window.parent.postMessage({ from: 'app', name, value }, '*')
   }
   render() {
-    return <App {...this.state} />
+    return (
+      <App {...this.state} sendMessageToWrapper={this.sendMessageToWrapper} />
+    )
   }
 }
 


### PR DESCRIPTION
These changes for the `Voting`, `Token Manager` and `Finance` apps add the mechanism to open/close the `MenuPanel` as shown [here](https://github.com/aragon/aragon/pull/539)