### PR TITLE
Known tokens fallback

### DIFF
--- a/apps/finance/app/src/components/BalanceToken.js
+++ b/apps/finance/app/src/components/BalanceToken.js
@@ -15,7 +15,7 @@ const splitAmount = amount => {
 
 const BalanceToken = ({ amount, symbol, verified, convertedAmount = -1 }) => (
   <Main>
-    <Token>
+    <Token title={symbol || 'Unknown symbol'}>
       {verified &&
         symbol && (
           <img
@@ -25,7 +25,7 @@ const BalanceToken = ({ amount, symbol, verified, convertedAmount = -1 }) => (
             src={`https://chasing-coins.com/coin/logo/${symbol}`}
           />
         )}
-      {symbol || ' '}
+      {symbol || '?'}
     </Token>
     <Amount>{splitAmount(amount.toFixed(3))}</Amount>
     <ConvertedAmount>
@@ -41,9 +41,8 @@ const Main = styled.div``
 const Token = styled.div`
   display: flex;
   align-items: center;
-  font-variant: small-caps;
-  text-transform: lowercase;
-  font-size: 18px;
+  text-transform: uppercase;
+  font-size: 14px;
   color: ${theme.textSecondary};
   img {
     margin-right: 10px;


### PR DESCRIPTION
Builds on #615, fixes #561 

Some known tokens don’t strictly follow ERC-20 and it would be difficult to adapt to every situation. The data listed in this map is used as a fallback if either the name or the symbol can’t be determined from the contract only.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/36158/50224974-89514980-039f-11e9-84d2-7e8022030ad5.png">
