### PR TITLE
Agent: Allow execute to send Eth

### DIFF
--- a/future-apps/actor/contracts/Actor.sol
+++ b/future-apps/actor/contracts/Actor.sol
@@ -45,9 +45,6 @@ contract Actor is Vault, IERC165, IERC1271, IForwarder {
         external // This function MUST always be external as the function performs a low level return, exiting the Actor app execution context
         authP(EXECUTE_ROLE, arr(_target, _ethValue, uint256(getSig(_data)))) // TODO: Test that sig bytes are the least significant bytes
     {
-        require(_ethValue == 0 || _data.length > 0, ERROR_EXECUTE_ETH_NO_DATA); // if ETH value is sent, there must be data
-        require(isContract(_target), ERROR_EXECUTE_TARGET_NOT_CONTRACT);
-
         bool result = _target.call.value(_ethValue)(_data);
 
         if (result) {


### PR DESCRIPTION
I think this is important for a few reasons

1. It will make the Aragon Keyring simpler
2. Preventing execute from just sending eth doesn't add any security - functions can be created to sidestep this. It also might provide a false sense of security.
3. The validation costs gas