### PR TITLE
(Voting) more descriptive empty state card

### DIFF
--- a/apps/voting/app/src/screens/EmptyState.js
+++ b/apps/voting/app/src/screens/EmptyState.js
@@ -6,8 +6,8 @@ import emptyIcon from '../assets/empty-card-icon.svg'
 const EmptyState = ({ onActivate }) => (
   <Main>
     <EmptyStateCard
-      title="Nothing here."
-      text="Create a new vote to start using the app."
+      title="There are no votes yet"
+      text="Add a vote to your organization to get started."
       actionText="New Vote"
       icon={<img src={emptyIcon} alt="" />}
       onActivate={onActivate}

--- a/apps/voting/app/src/screens/EmptyState.js
+++ b/apps/voting/app/src/screens/EmptyState.js
@@ -7,7 +7,7 @@ const EmptyState = ({ onActivate }) => (
   <Main>
     <EmptyStateCard
       title="There are no votes yet"
-      text="Add a vote to your organization to get started."
+      text="Create a new vote to get started."
       actionText="New Vote"
       icon={<img src={emptyIcon} alt="" />}
       onActivate={onActivate}


### PR DESCRIPTION
Fixes #245.

Updated the empty state card for the voting App with more descriptive terminology as suggested in #245.

Will update the other Apps accordingly, once this one is approved. 