### PR TITLE
(Token Manager) more descriptive empty card state for token manager

### DIFF
--- a/apps/token-manager/app/src/screens/EmptyState.js
+++ b/apps/token-manager/app/src/screens/EmptyState.js
@@ -8,7 +8,7 @@ const EmptyState = ({ onActivate }) => (
     <EmptyStateCard
       icon={<img src={emptyIcon} alt="" />}
       title="There are no tokens assigned yet"
-      text="Assign tokens to your organization to get started."
+      text="Assign tokens to get started."
       actionText="Assign Tokens"
       onActivate={onActivate}
     />

--- a/apps/token-manager/app/src/screens/EmptyState.js
+++ b/apps/token-manager/app/src/screens/EmptyState.js
@@ -7,8 +7,8 @@ const EmptyState = ({ onActivate }) => (
   <Main>
     <EmptyStateCard
       icon={<img src={emptyIcon} alt="" />}
-      title="Nothing here."
-      text="Assign tokens to start using the app."
+      title="There are no tokens assigned yet"
+      text="Assign tokens to your organization to get started."
       actionText="Assign Tokens"
       onActivate={onActivate}
     />

--- a/apps/voting/app/src/screens/EmptyState.js
+++ b/apps/voting/app/src/screens/EmptyState.js
@@ -6,8 +6,8 @@ import emptyIcon from '../assets/empty-card-icon.svg'
 const EmptyState = ({ onActivate }) => (
   <Main>
     <EmptyStateCard
-      title="There are no votes yet"
-      text="Add a vote to your organization to get started."
+      title="Nothing here."
+      text="Create a new vote to start using the app."
       actionText="New Vote"
       icon={<img src={emptyIcon} alt="" />}
       onActivate={onActivate}

--- a/apps/voting/app/src/screens/EmptyState.js
+++ b/apps/voting/app/src/screens/EmptyState.js
@@ -6,8 +6,8 @@ import emptyIcon from '../assets/empty-card-icon.svg'
 const EmptyState = ({ onActivate }) => (
   <Main>
     <EmptyStateCard
-      title="Nothing here."
-      text="Create a new vote to start using the app."
+      title="There are no votes yet"
+      text="Add a vote to your organization to get started."
       actionText="New Vote"
       icon={<img src={emptyIcon} alt="" />}
       onActivate={onActivate}


### PR DESCRIPTION
Fixes #660.

Updated the empty state card for the Token Manager with more descriptive terminology as suggested in #660. 
