### PR TITLE
 Survey: emit current option power on ResetVote events instead of previous option powers

### DIFF
--- a/apps/survey/app/src/script.js
+++ b/apps/survey/app/src/script.js
@@ -123,10 +123,7 @@ async function createStore(token, tokenSettings) {
             // We have to manually calculate the option power left when a vote is reset
             returnValues = {
               ...returnValues,
-              // TODO: use BN.js instead
-              optionPower: String(
-                returnValues.optionPower - returnValues.previousStake
-              ),
+              optionPower: returnValues.optionPower,
             }
 
             nextState = await processVote(

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -157,9 +157,10 @@ contract Survey is AragonApp {
             for (uint256 i = 1; i <= previousVote.optionsCastedLength; i++) {
                 OptionCast storage previousOptionCast = previousVote.castedVotes[i];
                 uint256 previousOptionPower = survey.optionPower[previousOptionCast.optionId];
-                survey.optionPower[previousOptionCast.optionId] = previousOptionPower.sub(previousOptionCast.stake);
+                uint256 currentOptionPower = previousOptionPower.sub(previousOptionCast.stake);
+                survey.optionPower[previousOptionCast.optionId] = currentOptionPower;
 
-                emit ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake, previousOptionPower);
+                emit ResetVote(_surveyId, msg.sender, previousOptionCast.optionId, previousOptionCast.stake, currentOptionPower);
             }
 
             // Compute previously casted votes (i.e. substract non-used tokens from stake)


### PR DESCRIPTION
Makes it easier for frontends to correctly respond to votes being reset (if they're trying to correctly reflect the options' powers) and the previous value is always known from `previousStake + currentPower`.