### PR TITLE
Voting: remove react-blockies

### DIFF
--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -11,7 +11,6 @@
     "onecolor": "^3.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.5.2",
-    "react-blockies": "^1.2.2",
     "react-dom": "^16.2.0",
     "react-linkify": "^0.2.2",
     "react-spring": "^5.7.2",

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import Blockies from 'react-blockies'
 import {
   Button,
   IdentityBadge,
@@ -396,20 +395,6 @@ const Question = styled.p`
 const Creator = styled.div`
   display: flex;
   align-items: center;
-`
-
-const CreatorImg = styled.div`
-  margin-right: 20px;
-  canvas {
-    display: block;
-    border: 1px solid ${theme.contentBorder};
-    border-radius: 16px;
-  }
-  & + div {
-    a {
-      color: ${theme.accent};
-    }
-  }
 `
 
 const ButtonsContainer = styled.div`


### PR DESCRIPTION
`react-blockies` isn't used anymore since it's been replaced by the `IdentityBadge`, and this also removes some dead code.