### PR TITLE
fix: provide correct network type to IdentityBadges

### DIFF
--- a/apps/token-manager/app/src/components/HolderRow.js
+++ b/apps/token-manager/app/src/components/HolderRow.js
@@ -12,6 +12,7 @@ import {
   IdentityBadge,
   breakpoint,
 } from '@aragon/ui'
+import provideNetwork from '../provide-network'
 import { formatBalance } from '../utils'
 import { WindowSize } from '../WindowSizeProvider'
 
@@ -38,6 +39,7 @@ class HolderRow extends React.Component {
       groupMode,
       isCurrentUser,
       maxAccountTokens,
+      network,
       shorten,
       tokenDecimalsBase,
     } = this.props
@@ -49,7 +51,11 @@ class HolderRow extends React.Component {
       <TableRow>
         <StyledTableCell>
           <Owner>
-            <IdentityBadge entity={address} shorten={shorten} />
+            <IdentityBadge
+              entity={address}
+              networkType={network.type}
+              shorten={shorten}
+            />
             {isCurrentUser && (
               <Badge.Identity
                 style={{ fontVariant: 'small-caps' }}
@@ -136,7 +142,7 @@ const IconWrapper = styled.span`
   color: ${theme.textSecondary};
 `
 
-export default props => (
+export default provideNetwork(props => (
   <WindowSize>
     {({ width, fromMedium }) => (
       <HolderRow
@@ -145,4 +151,4 @@ export default props => (
       />
     )}
   </WindowSize>
-)
+))

--- a/apps/token-manager/app/src/components/SideBar.js
+++ b/apps/token-manager/app/src/components/SideBar.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Text, theme, IdentityBadge, breakpoint } from '@aragon/ui'
+import provideNetwork from '../provide-network'
 import { formatBalance, stakesPercentages } from '../utils'
 import { WindowSize } from '../WindowSizeProvider'
 import TokenBadge from './TokenBadge'
@@ -41,6 +42,7 @@ class SideBar extends React.Component {
   render() {
     const {
       holders,
+      network,
       tokenAddress,
       tokenDecimalsBase,
       tokenName,
@@ -110,6 +112,7 @@ class SideBar extends React.Component {
                       <StakesListBullet style={{ background: color }} />
                       <IdentityBadge
                         entity={name}
+                        networkType={network.type}
                         shorten={fromMedium || width < 520}
                       />
                     </span>
@@ -214,4 +217,4 @@ const StakesListBullet = styled.span`
   }
 `
 
-export default SideBar
+export default provideNetwork(SideBar)

--- a/apps/voting/app/src/components/VotePanelContent.js
+++ b/apps/voting/app/src/components/VotePanelContent.js
@@ -146,7 +146,7 @@ class VotePanelContent extends React.Component {
   }
   render() {
     const {
-      network: { etherscanBaseUrl },
+      network,
       vote,
       ready,
       shortAddresses,
@@ -236,7 +236,11 @@ class VotePanelContent extends React.Component {
             <Label>Created By</Label>
           </h2>
           <Creator>
-            <IdentityBadge entity={creator} shorten={shortAddresses} />
+            <IdentityBadge
+              entity={creator}
+              networkType={network.type}
+              shorten={shortAddresses}
+            />
           </Creator>
         </Part>
         <SidePanelSeparator />


### PR DESCRIPTION
Unlike aragon/aragon, in the apps we don't have an override for `IdentityBadge` that provides the network (though we probably should make that shim).