### PR TITLE
Survey: avoid shadowing minParticipationPct in getSurvey()

### DIFF
--- a/apps/survey/app/src/script.js
+++ b/apps/survey/app/src/script.js
@@ -452,14 +452,14 @@ function loadTokenSymbol(tokenContract) {
 function marshallSurvey({
   startDate,
   snapshotBlock,
-  minParticipationPct,
+  minParticipation,
   votingPower,
   participation,
   options,
 }) {
   return {
     startDate: parseInt(startDate, 10) * 1000, // adjust for js time (in ms vs s)
-    minParticipationPct: parseInt(minParticipationPct, 10),
+    minParticipation: parseInt(minParticipation, 10),
     snapshotBlock: parseInt(snapshotBlock, 10),
     votingPower: parseInt(votingPower, 10),
     participation: parseInt(participation, 10),

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -264,7 +264,7 @@ contract Survey is AragonApp {
             bool open,
             uint64 startDate,
             uint64 snapshotBlock,
-            uint64 minParticipationPct,
+            uint64 minParticipation,
             uint256 votingPower,
             uint256 participation,
             uint256 options
@@ -275,7 +275,7 @@ contract Survey is AragonApp {
         open = _isSurveyOpen(survey);
         startDate = survey.startDate;
         snapshotBlock = survey.snapshotBlock;
-        minParticipationPct = survey.minParticipationPct;
+        minParticipation = survey.minParticipationPct;
         votingPower = survey.votingPower;
         participation = survey.participation;
         options = survey.options;


### PR DESCRIPTION
Fixes compiler warning from https://github.com/aragon/aragon-apps/pull/680/files#r257791103.