### PR TITLE
Finance, Token Manager, Survey, Voting: fix function-visibility

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -361,7 +361,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
      * @notice Send tokens held in this contract to the Vault
      * @param _token Token whose balance is going to be transferred.
      */
-    function recoverToVault(address _token) public isInitialized transitionsPeriod {
+    function recoverToVault(address _token) external isInitialized transitionsPeriod {
         uint256 amount = _token == ETH ? address(this).balance : ERC20(_token).staticBalanceOf(this);
         require(amount > 0, ERROR_RECOVER_AMOUNT_ZERO);
 
@@ -383,7 +383,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     * @return success Boolean indicating whether the accounting period is the correct one (if false,
     *                 maxTransitions was surpased and another call is needed)
     */
-    function tryTransitionAccountingPeriod(uint64 _maxTransitions) public isInitialized returns (bool success) {
+    function tryTransitionAccountingPeriod(uint64 _maxTransitions) external isInitialized returns (bool success) {
         return _tryTransitionAccountingPeriod(_maxTransitions);
     }
 

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -387,7 +387,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         return _tryTransitionAccountingPeriod(_maxTransitions);
     }
 
-    // consts
+    // Getter fns
 
     /**
     * @dev Disable recovery escape hatch if the app has been initialized, as it could be used
@@ -487,6 +487,33 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         income = tokenStatement.income;
     }
 
+    function getPeriodDuration() public view returns (uint64) {
+        return settings.periodDuration;
+    }
+
+    function getBudget(address _token) public view returns (uint256 budget, bool hasBudget) {
+        budget = settings.budgets[_token];
+        hasBudget = settings.hasBudget[_token];
+    }
+
+    /**
+    * @dev We have to check for initialization as budgets are only valid after initializing
+    */
+    function getRemainingBudget(address _token) public view isInitialized returns (uint256) {
+        return _getRemainingBudget(_token);
+    }
+
+    /**
+    * @dev We have to check for initialization as periods are only valid after initializing
+    */
+    function currentPeriodId() public view isInitialized returns (uint64) {
+        return _currentPeriodId();
+    }
+
+    /**
+    * @dev Initialization check is implicitly provided by `recurringPaymentExists()` as new
+    *      recurring payments can only be created via `newPayment(),` which requires initialization
+    */
     function nextPaymentTime(uint256 _paymentId) public view recurringPaymentExists(_paymentId) returns (uint64) {
         RecurringPayment storage payment = recurringPayments[_paymentId];
 
@@ -500,30 +527,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         return nextPayment;
     }
 
-    function getPeriodDuration() public view returns (uint64) {
-        return settings.periodDuration;
-    }
-
-    function getBudget(address _token) public view returns (uint256 budget, bool hasBudget) {
-        budget = settings.budgets[_token];
-        hasBudget = settings.hasBudget[_token];
-    }
-
-    /**
-    * @dev We have to check for initialization as periods are only valid after initializing
-    */
-    function getRemainingBudget(address _token) public view isInitialized returns (uint256) {
-        return _getRemainingBudget(_token);
-    }
-
-    /**
-    * @dev We have to check for initialization as periods are only valid after initializing
-    */
-    function currentPeriodId() public view isInitialized returns (uint64) {
-        return _currentPeriodId();
-    }
-
-    // internal fns
+    // Internal fns
 
     function _deposit(address _token, uint256 _amount, string _reference, address _sender, bool _isExternalDeposit) internal {
         require(_amount > 0, ERROR_DEPOSIT_AMOUNT_ZERO);
@@ -734,6 +738,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         return periodsLength - 1;
     }
 
+    // Mocked fns (overrided during testing)
     // Must be view for mocking purposes
+
     function getMaxPeriodTransitions() internal view returns (uint64) { return MAX_UINT64; }
 }

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -167,7 +167,6 @@ contract Survey is AragonApp {
         external
         surveyExists(_surveyId)
     {
-        require(_optionIds.length == _stakes.length && _optionIds.length > 0, ERROR_VOTE_WRONG_INPUT);
         require(canVote(_surveyId, msg.sender), ERROR_CAN_NOT_VOTE);
 
         _voteOptions(_surveyId, _optionIds, _stakes);
@@ -301,6 +300,8 @@ contract Survey is AragonApp {
     * @dev Assumes the survey exists and that msg.sender can vote
     */
     function _voteOptions(uint256 _surveyId, uint256[] _optionIds, uint256[] _stakes) internal {
+        require(_optionIds.length == _stakes.length && _optionIds.length > 0, ERROR_VOTE_WRONG_INPUT);
+
         SurveyStruct storage survey = surveys[_surveyId];
 
         // Revert previous votes, if any

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -269,6 +269,9 @@ contract Survey is AragonApp {
 
     // Internal fns
 
+    /*
+    * @dev Assumes the survey exists and that msg.sender can vote
+    */
     function _resetVote(uint256 _surveyId) internal {
         SurveyStruct storage survey = surveys[_surveyId];
         MultiOptionVote storage previousVote = survey.votes[msg.sender];
@@ -294,6 +297,9 @@ contract Survey is AragonApp {
         }
     }
 
+    /*
+    * @dev Assumes the survey exists and that msg.sender can vote
+    */
     function _voteOptions(uint256 _surveyId, uint256[] _optionIds, uint256[] _stakes) internal {
         SurveyStruct storage survey = surveys[_surveyId];
 

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -203,6 +203,12 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         emit RevokeVesting(_holder, _vestingId, nonVested);
     }
 
+    // Forwarding fns
+
+    function isForwarder() external pure returns (bool) {
+        return true;
+    }
+
     /**
     * @notice Execute desired action as a token holder
     * @dev IForwarder interface conformance. Forwards any token holder action.
@@ -218,10 +224,6 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         blacklist[0] = address(token);
 
         runScript(_evmScript, input, blacklist);
-    }
-
-    function isForwarder() public pure returns (bool) {
-        return true;
     }
 
     function canForward(address _sender, bytes) public view returns (bool) {

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -230,28 +230,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         return hasInitialized() && token.balanceOf(_sender) > 0;
     }
 
-    function getVesting(
-        address _recipient,
-        uint256 _vestingId
-    )
-        public
-        view
-        vestingExists(_recipient, _vestingId)
-        returns (
-            uint256 amount,
-            uint64 start,
-            uint64 cliff,
-            uint64 vesting,
-            bool revokable
-        )
-    {
-        TokenVesting storage tokenVesting = vestings[_recipient][_vestingId];
-        amount = tokenVesting.amount;
-        start = tokenVesting.start;
-        cliff = tokenVesting.cliff;
-        vesting = tokenVesting.vesting;
-        revokable = tokenVesting.revokable;
-    }
+    // ITokenController fns
 
     /*
     * @dev Notifies the controller about a token transfer allowing the controller to decide whether to allow it or react if desired (only callable from the token)
@@ -276,6 +255,14 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     }
 
     /**
+    * @dev Notifies the controller about an approval allowing the controller to react if desired
+    * @return False if the controller does not authorize the approval
+    */
+    function onApprove(address, address, uint) public returns (bool) {
+        return true;
+    }
+
+    /**
     * @notice Called when ether is sent to the MiniMe Token contract
     * @return True if the ether is accepted, false for it to throw
     */
@@ -287,16 +274,29 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         return false;
     }
 
-    /**
-    * @dev Notifies the controller about an approval allowing the controller to react if desired
-    * @return False if the controller does not authorize the approval
-    */
-    function onApprove(address, address, uint) public returns (bool) {
-        return true;
-    }
+    // Getter fns
 
-    function _isBalanceIncreaseAllowed(address _receiver, uint _inc) internal view returns (bool) {
-        return token.balanceOf(_receiver).add(_inc) <= maxAccountTokens;
+    function getVesting(
+        address _recipient,
+        uint256 _vestingId
+    )
+        public
+        view
+        vestingExists(_recipient, _vestingId)
+        returns (
+            uint256 amount,
+            uint64 start,
+            uint64 cliff,
+            uint64 vesting,
+            bool revokable
+        )
+    {
+        TokenVesting storage tokenVesting = vestings[_recipient][_vestingId];
+        amount = tokenVesting.amount;
+        start = tokenVesting.start;
+        cliff = tokenVesting.cliff;
+        vesting = tokenVesting.vesting;
+        revokable = tokenVesting.revokable;
     }
 
     function spendableBalanceOf(address _holder) public view returns (uint256) {
@@ -328,6 +328,22 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     */
     function allowRecoverability(address _token) public view returns (bool) {
         return _token != address(token);
+    }
+
+    // Internal fns
+
+    function _assign(address _receiver, uint256 _amount) internal {
+        require(_isBalanceIncreaseAllowed(_receiver, _amount), ERROR_ASSIGN_BALANCE_INCREASE_NOT_ALLOWED);
+        // Must use transferFrom() as transfer() does not give the token controller full control
+        require(token.transferFrom(this, _receiver, _amount), ERROR_ASSIGN_TRANSFER_FROM_REVERTED);
+    }
+
+    function _mint(address _receiver, uint256 _amount) internal {
+        token.generateTokens(_receiver, _amount); // minime.generateTokens() never returns false
+    }
+
+    function _isBalanceIncreaseAllowed(address _receiver, uint _inc) internal view returns (bool) {
+        return token.balanceOf(_receiver).add(_inc) <= maxAccountTokens;
     }
 
     /**
@@ -385,15 +401,5 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
 
         // tokens - vestedTokens
         return tokens.sub(vestedTokens);
-    }
-
-    function _assign(address _receiver, uint256 _amount) internal {
-        require(_isBalanceIncreaseAllowed(_receiver, _amount), ERROR_ASSIGN_BALANCE_INCREASE_NOT_ALLOWED);
-        // Must use transferFrom() as transfer() does not give the token controller full control
-        require(token.transferFrom(this, _receiver, _amount), ERROR_ASSIGN_TRANSFER_FROM_REVERTED);
-    }
-
-    function _mint(address _receiver, uint256 _amount) internal {
-        token.generateTokens(_receiver, _amount); // minime.generateTokens() never returns false
     }
 }

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -196,12 +196,22 @@ contract Voting is IForwarder, AragonApp {
         return canPerform(_sender, CREATE_VOTES_ROLE, arr());
     }
 
+    // Getter fns
+
+    /**
+    * @dev Initialization check is implicitly provided by `voteExists()` as new votes can only be
+    *      created via `newVote(),` which requires initialization
+    */
     function canVote(uint256 _voteId, address _voter) public view voteExists(_voteId) returns (bool) {
         Vote storage vote_ = votes[_voteId];
 
         return _isVoteOpen(vote_) && token.balanceOfAt(_voter, vote_.snapshotBlock) > 0;
     }
 
+    /**
+    * @dev Initialization check is implicitly provided by `voteExists()` as new votes can only be
+    *      created via `newVote(),` which requires initialization
+    */
     function canExecute(uint256 _voteId) public view voteExists(_voteId) returns (bool) {
         Vote storage vote_ = votes[_voteId];
 
@@ -266,6 +276,8 @@ contract Voting is IForwarder, AragonApp {
     function getVoterState(uint256 _voteId, address _voter) public view voteExists(_voteId) returns (VoterState) {
         return votes[_voteId].voters[_voter];
     }
+
+    // Internal fns
 
     function _newVote(bytes _executionScript, string _metadata, bool _castVote, bool _executesIfDecided)
         internal

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -175,7 +175,9 @@ contract Voting is IForwarder, AragonApp {
         _executeVote(_voteId);
     }
 
-    function isForwarder() public pure returns (bool) {
+    // Forwarding fns
+
+    function isForwarder() external pure returns (bool) {
         return true;
     }
 


### PR DESCRIPTION
From https://github.com/aragon/aragon-apps/pull/611#issuecomment-465090647:

> * (info) - voting.sol - access modifiers - consider declaring functions external (optimization)
> * (info) - survey.sol - access modifiers - consider declaring functions external (optimization)

---------

This has mostly cosmetic changes, to make the function grouping based on visibility more clear to reviewers and readers of the code.

The main changes to the contracts are:

- 08420fd: Changes `isForwarder()` to external, now that the interface is declared with `external`
- c46151e: Changes a few public functions in Finance to be external, since they either had internal variants subclasses could use or should not be used by subclasses
- 6ccfaa0: Modernizes the authentication strategy in Survey, to one where only the `external` functionality is protected by modifiers and other sanity checks, and the main logic is executed in `internal` functions