### PR TITLE
Survey: change PCT_BASE to uint64

### DIFF
--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -19,7 +19,7 @@ contract Survey is AragonApp {
     bytes32 public constant CREATE_SURVEYS_ROLE = keccak256("CREATE_SURVEYS_ROLE");
     bytes32 public constant MODIFY_PARTICIPATION_ROLE = keccak256("MODIFY_PARTICIPATION_ROLE");
 
-    uint256 public constant PCT_BASE = 10 ** 18; // 0% = 0; 1% = 10^16; 100% = 10^18
+    uint64 public constant PCT_BASE = 10 ** 18; // 0% = 0; 1% = 10^16; 100% = 10^18
     uint256 public constant ABSTAIN_VOTE = 0;
 
     string private constant ERROR_MIN_PARTICIPATION = "SURVEY_MIN_PARTICIPATION";


### PR DESCRIPTION
Looks like this change was reverted in https://github.com/aragon/aragon-apps/pull/473 by accident.

Although using `uint64` is a _little_ bit more expensive (applies a `uint64` mask on the value each time it's used), it's safer to use since the compiler will complain if we accidentally change this value and set a value that's too big.