### PR TITLE
fix: update usage of @aragon'ui's Main component to use relative asset paths

### DIFF
--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -109,7 +109,7 @@ class App extends React.Component {
 
     return (
       <div css="min-width: 320px">
-        <Main>
+        <Main assetsUrl="./aragon-ui">
           <AppLayout
             title="Finance"
             onMenuOpen={this.handleMenuPanelOpen}

--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -108,7 +108,7 @@ class App extends React.Component {
     const { assignTokensConfig, sidepanelOpened } = this.state
     return (
       <div css="min-width: 320px">
-        <Main>
+        <Main assetsUrl="./aragon-ui">
           <AppLayout
             title="Token Manager"
             afterTitle={tokenSymbol && <Badge.App>{tokenSymbol}</Badge.App>}

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -216,7 +216,7 @@ class App extends React.Component {
 
     return (
       <div css="min-width: 320px">
-        <Main>
+        <Main assetsUrl="./aragon-ui">
           <AppLayout
             title="Voting"
             onMenuOpen={this.handleMenuPanelOpen}


### PR DESCRIPTION
cc @bpierre should we just make [`Main` default to using relative paths](https://github.com/aragon/aragon-ui/blob/master/src/components/Main/Main.js#L28)? (From @2color).