### PR TITLE
Voting: default decimals to 0 if token contract doesn't specify them

### DIFF
--- a/apps/voting/app/src/math-utils.js
+++ b/apps/voting/app/src/math-utils.js
@@ -16,15 +16,24 @@ export function formatNumber(num, decimals = 2, { truncate = true } = {}) {
     return numString
   }
 
-  const [whole, decimal = ''] = numString.split('.')
+  const exponentialIndex = numString.indexOf('e+')
+  const numWithoutExponents =
+    exponentialIndex > -1 ? numString.substring(0, exponentialIndex) : numString
+
+  const [whole, decimal = ''] = numWithoutExponents.split('.')
   const trimmedDecimals = truncate ? decimal.replace(/0+$/, '') : decimals
-  return trimmedDecimals.length
+  const formattedNumber = trimmedDecimals.length
     ? `${whole}.${
         trimmedDecimals.length > decimals
           ? trimmedDecimals.slice(0, decimals)
           : trimmedDecimals
       }`
     : whole
+
+  // If we were dealing with a yuge number, append the exponent suffix back
+  return exponentialIndex > -1
+    ? `${formattedNumber}${numString.substring(exponentialIndex)}`
+    : formattedNumber
 }
 
 export function percentageList(values, digits = 0) {

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -75,14 +75,14 @@ async function initialize(tokenAddr) {
 
   let tokenDecimals
   try {
-    tokenDecimals = await loadTokenDecimals(token)
+    tokenDecimals = (await loadTokenDecimals(token)) || '0'
   } catch (err) {
     console.err(
       `Failed to load token decimals for token at ${tokenAddr} due to:`,
       err
     )
-    console.err('Defaulting to 18...')
-    tokenDecimals = '18'
+    console.err('Defaulting to 0...')
+    tokenDecimals = '0'
   }
 
   return createStore(token, { decimals: tokenDecimals, symbol: tokenSymbol })


### PR DESCRIPTION
Defaults the token decimals to 0 ("safest" assumption) if the token contract doesn't provide them.

In some cases, this can make the values look quite odd (if they're in the yuge range), and this includes a bit of logic to handle these exponents.

We'll leave the decimal matching as something to tackle with https://github.com/aragon/aragon/issues/589.

Numbers in sci. notation:

<img src="https://user-images.githubusercontent.com/4166642/53516015-94c19f00-3acb-11e9-8a48-b268dcc580f9.png" height=150>