### PR TITLE
Agent: fix copying an extra byte in popFirstByte

### DIFF
--- a/apps/agent/contracts/SignatureValidator.sol
+++ b/apps/agent/contracts/SignatureValidator.sol
@@ -91,13 +91,17 @@ library SignatureValidator {
 
         output = new bytes(inputLength - 1);
 
+        if (output.length == 0) {
+            return output;
+        }
+
         uint256 inputPointer;
         uint256 outputPointer;
         assembly {
             inputPointer := add(input, 0x21)
             outputPointer := add(output, 0x20)
         }
-        memcpy(outputPointer, inputPointer, inputLength);
+        memcpy(outputPointer, inputPointer, output.length);
     }
 
     function safeIsValidSignature(address validator, bytes32 hash, bytes memory signature) private view returns (bool) {


### PR DESCRIPTION
Issue raised by ANSP in https://github.com/aragon/aragon-apps/pull/611#discussion_r261743914

- We were always copying one extra garbage byte (the full length of the input bytes array) when copying to the output array. Tested in all of the combined ERC1271 -> EthSign and ERC712 tests.
- Also avoid copying altogether in case that the input array only has one byte. Tested in the standalone ERC1271 tests