### PR TITLE
Finance: fix naming of status parameter in ChangePaymentState event

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -116,7 +116,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     event SetBudget(address indexed token, uint256 amount, bool hasBudget);
     event NewPayment(uint256 indexed paymentId, address indexed recipient, uint64 maxRepeats, string reference);
     event NewTransaction(uint256 indexed transactionId, bool incoming, address indexed entity, uint256 amount, string reference);
-    event ChangePaymentState(uint256 indexed paymentId, bool inactive);
+    event ChangePaymentState(uint256 indexed paymentId, bool active);
     event ChangePeriodDuration(uint64 newDuration);
     event PaymentFailure(uint256 paymentId);
 


### PR DESCRIPTION
The event is actually being [emitted with whether the payment is active or not](https://github.com/aragon/aragon-apps/blob/master/apps/finance/contracts/Finance.sol#L351).

This is a breaking change for frontend clients relying on this parameter name, but to my knowledge nobody is using this parameter.