### PR TITLE
Finance: add uint256 casts for parameters in authP

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -284,7 +284,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         uint256 _amount
     )
         external
-        authP(CHANGE_BUDGETS_ROLE, arr(_token, _amount, settings.budgets[_token], settings.hasBudget[_token] ? 1 : 0))
+        authP(CHANGE_BUDGETS_ROLE, arr(_token, _amount, settings.budgets[_token], uint256(settings.hasBudget[_token] ? 1 : 0)))
         transitionsPeriod
     {
         settings.budgets[_token] = _amount;
@@ -300,7 +300,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     */
     function removeBudget(address _token)
         external
-        authP(CHANGE_BUDGETS_ROLE, arr(_token, uint256(0), settings.budgets[_token], settings.hasBudget[_token] ? 1 : 0))
+        authP(CHANGE_BUDGETS_ROLE, arr(_token, uint256(0), settings.budgets[_token], uint256(settings.hasBudget[_token] ? 1 : 0)))
         transitionsPeriod
     {
         settings.budgets[_token] = 0;


### PR DESCRIPTION
Although not strictly necessary, we use these casts in other places where we convert from a non-uint256 type to be a parameter in `authP()`.