### PR TITLE
Finance, TokenManager: move auth modifier to after state sanity checks

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -315,8 +315,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     */
     function executePayment(uint256 _paymentId)
         external
-        authP(EXECUTE_PAYMENTS_ROLE, arr(_paymentId, recurringPayments[_paymentId].amount))
         recurringPaymentExists(_paymentId)
+        authP(EXECUTE_PAYMENTS_ROLE, arr(_paymentId, recurringPayments[_paymentId].amount))
         transitionsPeriod
     {
         require(nextPaymentTime(_paymentId) <= getTimestamp64(), ERROR_EXECUTE_PAYMENT_TIME);
@@ -347,8 +347,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     */
     function setPaymentStatus(uint256 _paymentId, bool _active)
         external
-        authP(MANAGE_PAYMENTS_ROLE, arr(_paymentId, uint256(_active ? 1 : 0)))
         recurringPaymentExists(_paymentId)
+        authP(MANAGE_PAYMENTS_ROLE, arr(_paymentId, uint256(_active ? 1 : 0)))
     {
         recurringPayments[_paymentId].inactive = !_active;
         emit ChangePaymentState(_paymentId, _active);

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -179,8 +179,8 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     */
     function revokeVesting(address _holder, uint256 _vestingId)
         external
-        authP(REVOKE_VESTINGS_ROLE, arr(_holder))
         vestingExists(_holder, _vestingId)
+        authP(REVOKE_VESTINGS_ROLE, arr(_holder))
     {
         TokenVesting storage v = vestings[_holder][_vestingId];
         require(v.revokable, ERROR_VESTING_NOT_REVOKABLE);


### PR DESCRIPTION
Reorders `authP()` checks so that they're only applied after sanity checking state.

This is important so that the error message we provide is accurate in the case of parameterized permissions; if the state we expect to use as a parameter is non-existent, that should be the error instead of an authentication error.