### PR TITLE
Finance, Survey, Token Manager, Voting: Clarify internal protection scheme

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -149,6 +149,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
      * @notice Deposit ETH to the Vault, to avoid locking them in this Finance app forever
      */
     function () external payable isInitialized transitionsPeriod {
+        require(msg.value > 0, ERROR_DEPOSIT_AMOUNT_ZERO);
         _deposit(
             ETH,
             msg.value,
@@ -192,6 +193,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     * @param _reference Reason for payment
     */
     function deposit(address _token, uint256 _amount, string _reference) external payable isInitialized transitionsPeriod {
+        require(_amount > 0, ERROR_DEPOSIT_AMOUNT_ZERO);
         _deposit(
             _token,
             _amount,
@@ -534,7 +536,6 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     // Internal fns
 
     function _deposit(address _token, uint256 _amount, string _reference, address _sender, bool _isExternalDeposit) internal {
-        require(_amount > 0, ERROR_DEPOSIT_AMOUNT_ZERO);
         _recordIncomingTransaction(
             _token,
             _sender,

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -546,15 +546,15 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         // External deposit will be false when the assets were already in the Finance app
         // and just need to be transferred to the vault
         if (_isExternalDeposit) {
-            if (_token != ETH) {
+            if (_token == ETH) {
+                // Ensure that the ETH sent with the transaction equals the amount in the deposit
+                require(msg.value == _amount, ERROR_VALUE_MISMATCH);
+            } else {
                 // Get the tokens to Finance
                 require(
                     ERC20(_token).safeTransferFrom(msg.sender, address(this), _amount),
                     ERROR_TOKEN_TRANSFER_FROM_REVERTED
                 );
-            } else {
-                // Ensure that the ETH sent with the transaction equals the amount in the deposit
-                require(msg.value == _amount, ERROR_VALUE_MISMATCH);
             }
         }
 

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -205,7 +205,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     * @notice Create a new payment of `@tokenAmount(_token, _amount)` to `_receiver``_maxRepeats > 0 ? ', executing ' + _maxRepeats + ' times at intervals of ' + @transformTime(_interval) : ''`, for '`_reference`'
     * @param _token Address of token for payment
     * @param _receiver Address that will receive payment
-    * @param _amount Tokens that are payed every time the payment is due
+    * @param _amount Tokens that are paid every time the payment is due
     * @param _initialPaymentTime Timestamp for when the first payment is done
     * @param _interval Number of seconds that need to pass between payment transactions
     * @param _maxRepeats Maximum instances a payment can be executed
@@ -227,7 +227,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     {
         require(_amount > 0, ERROR_NEW_PAYMENT_AMOUNT_ZERO);
 
-        // Avoid saving payment data for 1 time immediate payments
+        // Avoid saving payment data for one-time immediate payments
         if (_initialPaymentTime <= getTimestamp64() && _maxRepeats == 1) {
             _makePaymentTransaction(
                 _token,
@@ -325,7 +325,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
     }
 
     /**
-    * @dev Always allows receiver of a payment to trigger execution
+    * @dev Always allow receiver of a payment to trigger execution
     * @notice Execute pending payment #`_paymentId`
     * @param _paymentId Identifier for payment
     */
@@ -571,8 +571,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         RecurringPayment storage payment = recurringPayments[_paymentId];
         require(!payment.inactive, ERROR_RECURRING_PAYMENT_INACTIVE);
 
-        uint64 payed = 0;
-        while (_nextPaymentTime(_paymentId) <= getTimestamp64() && payed < MAX_RECURRING_PAYMENTS_PER_TX) {
+        uint64 paid = 0;
+        while (_nextPaymentTime(_paymentId) <= getTimestamp64() && paid < MAX_RECURRING_PAYMENTS_PER_TX) {
             if (!_canMakePayment(payment.token, payment.amount)) {
                 emit PaymentFailure(_paymentId);
                 return;
@@ -580,7 +580,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
 
             // The while() predicate prevents these two from ever overflowing
             payment.repeats += 1;
-            payed += 1;
+            paid += 1;
 
             _makePaymentTransaction(
                 payment.token,

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -237,7 +237,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
                 _amount,
                 NO_RECURRING_PAYMENT,   // unrelated to any payment id; it isn't created
                 0,   // also unrelated to any payment repeats
-                _reference
+                _reference,
+                false
             );
             return;
         }
@@ -589,7 +590,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
                 payment.amount,
                 _paymentId,
                 payment.repeats,
-                ""
+                "",
+                true
             );
         }
     }
@@ -600,11 +602,15 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         uint256 _amount,
         uint256 _paymentId,
         uint64 _paymentRepeatNumber,
-        string _reference
+        string _reference,
+        bool _skipChecks
     )
         internal
     {
-        require(_getRemainingBudget(_token) >= _amount, ERROR_REMAINING_BUDGET);
+        if (!_skipChecks) {
+            require(_getRemainingBudget(_token) >= _amount, ERROR_REMAINING_BUDGET);
+        }
+
         _recordTransaction(
             false,
             _token,

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -567,26 +567,6 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         }
     }
 
-    function _newPeriod(uint64 _startTime) internal returns (Period storage) {
-        // There should be no way for this to overflow since each period is at least one day
-        uint64 newPeriodId = periodsLength++;
-
-        Period storage period = periods[newPeriodId];
-        period.startTime = _startTime;
-
-        // Be careful here to not overflow; if startTime + periodDuration overflows, we set endTime
-        // to MAX_UINT64 (let's assume that's the end of time for now).
-        uint64 endTime = _startTime + settings.periodDuration - 1;
-        if (endTime < _startTime) { // overflowed
-            endTime = MAX_UINT64;
-        }
-        period.endTime = endTime;
-
-        emit NewPeriod(newPeriodId, period.startTime, period.endTime);
-
-        return period;
-    }
-
     function _executePayment(uint256 _paymentId) internal {
         RecurringPayment storage payment = recurringPayments[_paymentId];
         require(!payment.inactive, ERROR_RECURRING_PAYMENT_INACTIVE);
@@ -635,6 +615,26 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         );
 
         vault.transfer(_token, _receiver, _amount);
+    }
+
+    function _newPeriod(uint64 _startTime) internal returns (Period storage) {
+        // There should be no way for this to overflow since each period is at least one day
+        uint64 newPeriodId = periodsLength++;
+
+        Period storage period = periods[newPeriodId];
+        period.startTime = _startTime;
+
+        // Be careful here to not overflow; if startTime + periodDuration overflows, we set endTime
+        // to MAX_UINT64 (let's assume that's the end of time for now).
+        uint64 endTime = _startTime + settings.periodDuration - 1;
+        if (endTime < _startTime) { // overflowed
+            endTime = MAX_UINT64;
+        }
+        period.endTime = endTime;
+
+        emit NewPeriod(newPeriodId, period.startTime, period.endTime);
+
+        return period;
     }
 
     function _recordIncomingTransaction(

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -240,8 +240,8 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
             return;
         }
 
-        // Budget must allow at least one instance of this payment each period, or not be set at all
-        require(settings.budgets[_token] >= _amount || !settings.hasBudget[_token], ERROR_BUDGET);
+        // Token budget must not be set at all or allow at least one instance of this payment each period
+        require(!settings.hasBudget[_token] || settings.budgets[_token] >= _amount, ERROR_BUDGET);
 
         paymentId = paymentsNextIndex++;
         emit NewPayment(paymentId, _receiver, _maxRepeats, _reference);

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -684,6 +684,24 @@ contract('Finance App', accounts => {
                 })
             })
 
+            it('fails to create a new one-time payment without enough budget', async () => {
+                const budget = 10
+                await finance.setBudget(token1.address, budget)
+
+                return assertRevert(async () => {
+                    await finance.newPayment(token1.address, recipient, budget + 1, time, 1, 1, '')
+                })
+            })
+
+            it('fails to create a new one-time payment without enough funds', async () => {
+                const vaultBalance = await vault.balance(token1.address)
+                await finance.removeBudget(token1.address) // clear any budget restrictions
+
+                return assertRevert(async () => {
+                    await finance.newPayment(token1.address, recipient, vaultBalance + 1, time, 1, 1, '')
+                })
+            })
+
             it('fails when non-receiver attempts to execute a payment', async () => {
                 await finance.mock_setTimestamp(time + 1)
 

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -168,6 +168,7 @@ contract Survey is AragonApp {
         external
         surveyExists(_surveyId)
     {
+        require(_optionIds.length == _stakes.length && _optionIds.length > 0, ERROR_VOTE_WRONG_INPUT);
         require(canVote(_surveyId, msg.sender), ERROR_CAN_NOT_VOTE);
 
         _voteOptions(_surveyId, _optionIds, _stakes);
@@ -300,8 +301,6 @@ contract Survey is AragonApp {
     * @dev Assumes the survey exists and that msg.sender can vote
     */
     function _voteOptions(uint256 _surveyId, uint256[] _optionIds, uint256[] _stakes) internal {
-        require(_optionIds.length == _stakes.length && _optionIds.length > 0, ERROR_VOTE_WRONG_INPUT);
-
         SurveyStruct storage survey = surveys[_surveyId];
         MultiOptionVote storage senderVotes = survey.votes[msg.sender];
 

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -103,6 +103,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     * @param _amount Number of tokens minted
     */
     function mint(address _receiver, uint256 _amount) external authP(MINT_ROLE, arr(_receiver, _amount)) {
+        require(_isBalanceIncreaseAllowed(_receiver, _amount), ERROR_MINT_BALANCE_INCREASE_NOT_ALLOWED);
         _mint(_receiver, _amount);
     }
 
@@ -325,10 +326,6 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     }
 
     function _mint(address _receiver, uint256 _amount) internal {
-        // Max balance doesn't apply to the token manager itself
-        if (_receiver != address(this)) {
-            require(_isBalanceIncreaseAllowed(_receiver, _amount), ERROR_MINT_BALANCE_INCREASE_NOT_ALLOWED);
-        }
         token.generateTokens(_receiver, _amount); // minime.generateTokens() never returns false
     }
 

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -103,7 +103,6 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     * @param _amount Number of tokens minted
     */
     function mint(address _receiver, uint256 _amount) external authP(MINT_ROLE, arr(_receiver, _amount)) {
-        require(_isBalanceIncreaseAllowed(_receiver, _amount), ERROR_MINT_BALANCE_INCREASE_NOT_ALLOWED);
         _mint(_receiver, _amount);
     }
 
@@ -326,6 +325,10 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     }
 
     function _mint(address _receiver, uint256 _amount) internal {
+        // Max balance doesn't apply to the token manager itself
+        if (_receiver != address(this)) {
+            require(_isBalanceIncreaseAllowed(_receiver, _amount), ERROR_MINT_BALANCE_INCREASE_NOT_ALLOWED);
+        }
         token.generateTokens(_receiver, _amount); // minime.generateTokens() never returns false
     }
 

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -171,8 +171,7 @@ contract Voting is IForwarder, AragonApp {
     * @param _voteId Id for vote
     */
     function executeVote(uint256 _voteId) external voteExists(_voteId) {
-        require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);
-        _executeVote(_voteId);
+        _executeVote(_voteId, false);
     }
 
     // Forwarding fns
@@ -307,11 +306,15 @@ contract Voting is IForwarder, AragonApp {
         emit CastVote(_voteId, _voter, _supports, voterStake);
 
         if (_executesIfDecided && _canExecute(_voteId)) {
-            _executeVote(_voteId);
+            _executeVote(_voteId, true);
         }
     }
 
-    function _executeVote(uint256 _voteId) internal {
+    function _executeVote(uint256 _voteId, bool _skipChecks) internal {
+        if (!_skipChecks) {
+            require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);
+        }
+
         Vote storage vote_ = votes[_voteId];
 
         vote_.executed = true;

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -171,7 +171,7 @@ contract Voting is IForwarder, AragonApp {
     * @param _voteId Id for vote
     */
     function executeVote(uint256 _voteId) external voteExists(_voteId) {
-        _executeVote(_voteId, false);
+        _executeVote(_voteId);
     }
 
     // Forwarding fns
@@ -306,15 +306,20 @@ contract Voting is IForwarder, AragonApp {
         emit CastVote(_voteId, _voter, _supports, voterStake);
 
         if (_executesIfDecided && _canExecute(_voteId)) {
-            _executeVote(_voteId, true);
+            // We've already checked if the vote can be executed with `_canExecute()`
+            _unsafeExecuteVote(_voteId);
         }
     }
 
-    function _executeVote(uint256 _voteId, bool _skipChecks) internal {
-        if (!_skipChecks) {
-            require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);
-        }
+    function _executeVote(uint256 _voteId) internal {
+        require(_canExecute(_voteId), ERROR_CAN_NOT_EXECUTE);
+        _unsafeExecuteVote(_voteId);
+    }
 
+    /**
+    * @dev Unsafe version of _executeVote that assumes you have already checked if the vote can be executed
+    */
+    function _unsafeExecuteVote(uint256 _voteId) internal {
         Vote storage vote_ = votes[_voteId];
 
         vote_.executed = true;


### PR DESCRIPTION
Builds on https://github.com/aragon/aragon-apps/pull/702.

An attempt at an answer to https://github.com/aragon/aragon-apps/pull/686#discussion_r259411928.

This will be added as a guideline to hack.aragon.org (soon), but in short, my current thoughts on where to place security modifiers in Aragon apps:

- "Lowest" in the call stack:
  - Place internal state assertions as close as possible to where they're required or used
  - Place external call assertions as close as possible to where the call happened
- "Highest" in the call stack:
  - Place authentication assertions as close as possible to the start of the externally accessible function
  - Place parameter assertions as close as possible to the start of the externally accessible function
- In places where an expensive state assertion will be repeated because a caller wants to branch based on the assertion (rather than allowing it to revert), add an "unsafe" version of the internal call that skips checks