### PR TITLE
Token Manager: remove unused storage mapping

### DIFF
--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -56,7 +56,6 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     // We are mimicing an array in the inner mapping, we use a mapping instead to make app upgrade more graceful
     mapping (address => mapping (uint256 => TokenVesting)) internal vestings;
     mapping (address => uint256) public vestingsLengths;
-    mapping (address => bool) public everHeld;
 
     // Other token specific events can be watched on the token address directly (avoids duplication)
     event NewVesting(address indexed receiver, uint256 vestingId, uint256 amount);


### PR DESCRIPTION
Seems like we forgot to remove this earlier. Shouldn't cause an issue with any upgrades since we weren't using the storage anyway.