### PR TITLE
Custom labels local observable

### DIFF
--- a/apps/finance/app/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
+++ b/apps/finance/app/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
@@ -7,7 +7,7 @@ import { IdentityContext } from '../IdentityManager/IdentityManager'
 
 const CustomLabelIdentityBadge = ({ address, ...props }) => {
   const { resolve } = React.useContext(IdentityContext)
-  const { showCustomLabelModal, modifyObservable } = React.useContext(
+  const { showCustomLabelModal, updates$ } = React.useContext(
     CustomLabelModalContext
   )
   const [label, setLabel] = React.useState()
@@ -28,7 +28,7 @@ const CustomLabelIdentityBadge = ({ address, ...props }) => {
   }
   React.useEffect(() => {
     handleResolve(address)
-    const subscription = modifyObservable.subscribe(addr => {
+    const subscription = updates$.subscribe(addr => {
       if (addr === address) {
         handleResolve(address)
       }

--- a/apps/finance/app/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
+++ b/apps/finance/app/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
@@ -7,7 +7,9 @@ import { IdentityContext } from '../IdentityManager/IdentityManager'
 
 const CustomLabelIdentityBadge = ({ address, ...props }) => {
   const { resolve } = React.useContext(IdentityContext)
-  const { showCustomLabelModal } = React.useContext(CustomLabelModalContext)
+  const { showCustomLabelModal, modifyObservable } = React.useContext(
+    CustomLabelModalContext
+  )
   const [label, setLabel] = React.useState()
   const handleResolve = async () => {
     try {
@@ -26,6 +28,12 @@ const CustomLabelIdentityBadge = ({ address, ...props }) => {
   }
   React.useEffect(() => {
     handleResolve(address)
+    modifyObservable.on('event', addr => {
+      if (addr === address) {
+        handleResolve(address)
+      }
+    })
+    return () => modifyObservable.off('event')
   }, [])
 
   return (

--- a/apps/finance/app/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
+++ b/apps/finance/app/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
@@ -28,12 +28,12 @@ const CustomLabelIdentityBadge = ({ address, ...props }) => {
   }
   React.useEffect(() => {
     handleResolve(address)
-    modifyObservable.on('event', addr => {
+    const subscription = modifyObservable.subscribe(addr => {
       if (addr === address) {
         handleResolve(address)
       }
     })
-    return () => modifyObservable.off('event')
+    return () => subscription.unsubscribe()
   }, [])
 
   return (

--- a/apps/finance/app/src/components/CustomLabelModal/CustomLabelModalManager.js
+++ b/apps/finance/app/src/components/CustomLabelModal/CustomLabelModalManager.js
@@ -1,12 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import EventEmitter from 'events'
+
+const modifyObservable = new EventEmitter()
 
 const CustomLabelModalContext = React.createContext({})
 
 const CustomLabelModalProvider = ({ onShowCustomLabelModal, children }) => {
+  const hookedShowCustomLabelModal = data => {
+    return onShowCustomLabelModal(data)
+      .then(() => modifyObservable.emit('event', data))
+      .catch(e => null)
+  }
+
   return (
     <CustomLabelModalContext.Provider
-      value={{ showCustomLabelModal: onShowCustomLabelModal }}
+      value={{
+        showCustomLabelModal: hookedShowCustomLabelModal,
+        modifyObservable,
+      }}
     >
       {children}
     </CustomLabelModalContext.Provider>

--- a/apps/finance/app/src/components/CustomLabelModal/CustomLabelModalManager.js
+++ b/apps/finance/app/src/components/CustomLabelModal/CustomLabelModalManager.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Subject } from 'rxjs'
-const modifyObservable = new Subject()
+
+const updates$ = new Subject()
 
 const CustomLabelModalContext = React.createContext({})
 
 const CustomLabelModalProvider = ({ onShowCustomLabelModal, children }) => {
   const hookedShowCustomLabelModal = address => {
     return onShowCustomLabelModal(address)
-      .then(() => modifyObservable.next(address))
+      .then(() => updates$.next(address))
       .catch(e => null)
   }
 
@@ -16,7 +17,7 @@ const CustomLabelModalProvider = ({ onShowCustomLabelModal, children }) => {
     <CustomLabelModalContext.Provider
       value={{
         showCustomLabelModal: hookedShowCustomLabelModal,
-        modifyObservable,
+        updates$,
       }}
     >
       {children}

--- a/apps/finance/app/src/components/CustomLabelModal/CustomLabelModalManager.js
+++ b/apps/finance/app/src/components/CustomLabelModal/CustomLabelModalManager.js
@@ -1,15 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import EventEmitter from 'events'
-
-const modifyObservable = new EventEmitter()
+import { Subject } from 'rxjs'
+const modifyObservable = new Subject()
 
 const CustomLabelModalContext = React.createContext({})
 
 const CustomLabelModalProvider = ({ onShowCustomLabelModal, children }) => {
-  const hookedShowCustomLabelModal = data => {
-    return onShowCustomLabelModal(data)
-      .then(() => modifyObservable.emit('event', data))
+  const hookedShowCustomLabelModal = address => {
+    return onShowCustomLabelModal(address)
+      .then(() => modifyObservable.next(address))
       .catch(e => null)
   }
 


### PR DESCRIPTION
These changes make it possible to re-render extended `IdentityBadge`s for the same address when one updates its custom label:

<img src="https://user-images.githubusercontent.com/3072458/54601234-d1374980-4a3e-11e9-92ba-71635e217124.gif" height="400" />


