### PR TITLE
Token manager fixes

### DIFF
--- a/apps/token-manager/app/package.json
+++ b/apps/token-manager/app/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@aragon/client": "^1.1.0",
-    "@aragon/ui": "^0.31.0",
+    "@aragon/ui": "^0.32.0",
     "bn.js": "^4.11.6",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/apps/token-manager/app/src/components/HolderRow.js
+++ b/apps/token-manager/app/src/components/HolderRow.js
@@ -9,8 +9,6 @@ import {
   IdentityBadge,
   TableCell,
   TableRow,
-  Viewport,
-  breakpoint,
   theme,
 } from '@aragon/ui'
 import provideNetwork from '../provide-network'
@@ -41,6 +39,7 @@ class HolderRow extends React.Component {
       maxAccountTokens,
       network,
       tokenDecimalsBase,
+      compact,
     } = this.props
 
     const singleToken = balance.eq(tokenDecimalsBase)
@@ -48,33 +47,23 @@ class HolderRow extends React.Component {
 
     return (
       <TableRow>
-        <StyledTableCell>
+        <TableCell css="padding-right: 0">
           <Owner>
-            <Viewport>
-              {({ width, above }) => (
-                <IdentityBadge
-                  entity={address}
-                  networkType={network.type}
-                  shorten={(above('medium') && width < 1000) || width < 590}
-                />
-              )}
-            </Viewport>
-            {isCurrentUser && (
-              <Badge.Identity
-                style={{ fontVariant: 'small-caps' }}
-                title="This is your Ethereum address"
-              >
-                you
-              </Badge.Identity>
-            )}
+            <IdentityBadge entity={address} networkType={network.type} />
+            {isCurrentUser && <You />}
           </Owner>
-        </StyledTableCell>
+        </TableCell>
         {!groupMode && (
-          <TableCell align="right">
+          <TableCell
+            align="right"
+            css={`
+              padding-left: ${compact ? '0' : '20px'};
+            `}
+          >
             {formatBalance(balance, tokenDecimalsBase)}
           </TableCell>
         )}
-        <StyledTableCell align="right">
+        <TableCell align="right" css="padding-left: 0">
           <ContextMenu>
             {canAssign && (
               <ContextMenuItem onClick={this.handleAssignTokens}>
@@ -94,36 +83,18 @@ class HolderRow extends React.Component {
               </ActionLabel>
             </ContextMenuItem>
           </ContextMenu>
-        </StyledTableCell>
+        </TableCell>
       </TableRow>
     )
   }
 }
 
-const StyledTableCell = styled(TableCell)`
-  &&& {
-    border-left-width: 0;
-    border-right-width: 0;
-
-    :first-child,
-    :last-child {
-      border-radius: 0;
-    }
-  }
-
-  ${breakpoint(
-    'medium',
-    `
-      &&& {
-        border-left-width: 1px;
-        border-right-width: 1px;
-
-        :first-child, :last-child {
-          border-radius: 3px;
-        }
-      }
-    `
-  )};
+const You = styled(Badge.Identity).attrs({
+  title: 'This is your Ethereum address',
+  children: 'you',
+})`
+  font-variant: small-caps;
+  margin-left: 10px;
 `
 
 const ActionLabel = styled.span`

--- a/apps/token-manager/app/src/components/HolderRow.js
+++ b/apps/token-manager/app/src/components/HolderRow.js
@@ -58,12 +58,7 @@ class HolderRow extends React.Component {
           </Owner>
         </TableCell>
         {!groupMode && (
-          <TableCell
-            align="right"
-            css={`
-              padding-left: ${compact ? '0' : '20px'};
-            `}
-          >
+          <TableCell align={compact ? 'left' : 'right'}>
             {formatBalance(balance, tokenDecimalsBase)}
           </TableCell>
         )}

--- a/apps/token-manager/app/src/components/HolderRow.js
+++ b/apps/token-manager/app/src/components/HolderRow.js
@@ -49,7 +49,11 @@ class HolderRow extends React.Component {
       <TableRow>
         <TableCell css="padding-right: 0">
           <Owner>
-            <IdentityBadge entity={address} networkType={network.type} />
+            <IdentityBadge
+              entity={address}
+              networkType={network.type}
+              connectedAccount={isCurrentUser}
+            />
             {isCurrentUser && <You />}
           </Owner>
         </TableCell>

--- a/apps/token-manager/app/src/components/HolderRow.js
+++ b/apps/token-manager/app/src/components/HolderRow.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import {
-  Badge,
   ContextMenu,
   ContextMenuItem,
   IconAdd,
@@ -13,6 +12,7 @@ import {
 } from '@aragon/ui'
 import provideNetwork from '../provide-network'
 import { formatBalance } from '../utils'
+import You from './You'
 
 class HolderRow extends React.Component {
   static defaultProps = {
@@ -92,14 +92,6 @@ class HolderRow extends React.Component {
     )
   }
 }
-
-const You = styled(Badge.Identity).attrs({
-  title: 'This is your Ethereum address',
-  children: 'you',
-})`
-  font-variant: small-caps;
-  margin-left: 10px;
-`
 
 const ActionLabel = styled.span`
   margin-left: 15px;

--- a/apps/token-manager/app/src/components/SideBar.js
+++ b/apps/token-manager/app/src/components/SideBar.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { IdentityBadge, Text, Viewport, breakpoint, theme } from '@aragon/ui'
+import { IdentityBadge, Text, breakpoint, theme } from '@aragon/ui'
 import provideNetwork from '../provide-network'
 import { formatBalance, stakesPercentages } from '../utils'
 import TokenBadge from './TokenBadge'

--- a/apps/token-manager/app/src/components/SideBar.js
+++ b/apps/token-manager/app/src/components/SideBar.js
@@ -4,6 +4,7 @@ import { IdentityBadge, Text, Viewport, breakpoint, theme } from '@aragon/ui'
 import provideNetwork from '../provide-network'
 import { formatBalance, stakesPercentages } from '../utils'
 import TokenBadge from './TokenBadge'
+import You from './You'
 
 const DISTRIBUTION_ITEMS_MAX = 7
 const DISTRIBUTION_COLORS = [
@@ -47,6 +48,7 @@ class SideBar extends React.Component {
       tokenName,
       tokenSupply,
       tokenSymbol,
+      userAccount,
       ...rest
     } = this.props
     const stakes = displayedStakes(holders, tokenSupply)
@@ -102,25 +104,22 @@ class SideBar extends React.Component {
               />
             ))}
           </StakesBar>
-          <Viewport>
-            {({ width, above }) => (
-              <ul>
-                {stakes.map(({ name, stake, color }) => (
-                  <StakesListItem key={name}>
-                    <span>
-                      <StakesListBullet style={{ background: color }} />
-                      <IdentityBadge
-                        entity={name}
-                        networkType={network.type}
-                        shorten={above('medium') || width < 520}
-                      />
-                    </span>
-                    <strong>{stake}%</strong>
-                  </StakesListItem>
-                ))}
-              </ul>
-            )}
-          </Viewport>
+          <ul>
+            {stakes.map(({ name, stake, color }) => (
+              <StakesListItem key={name}>
+                <span>
+                  <StakesListBullet style={{ background: color }} />
+                  <IdentityBadge
+                    entity={name}
+                    networkType={network.type}
+                    connectedAccount={name === userAccount}
+                  />
+                  {name === userAccount && <You />}
+                </span>
+                <strong>{stake}%</strong>
+              </StakesListItem>
+            ))}
+          </ul>
         </Part>
       </Main>
     )

--- a/apps/token-manager/app/src/components/You.js
+++ b/apps/token-manager/app/src/components/You.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Badge } from '@aragon/ui'
+
+const You = styled(Badge.Identity).attrs({
+  title: 'This is your Ethereum address',
+  children: 'you',
+})`
+  font-variant: small-caps;
+  margin-left: 10px;
+`
+
+export default You

--- a/apps/token-manager/app/src/screens/Holders.js
+++ b/apps/token-manager/app/src/screens/Holders.js
@@ -40,6 +40,7 @@ class Holders extends React.Component {
       <Viewport>
         {({ below }) => {
           const tabbedNavigation = below('medium')
+          const compactTable = below('medium')
 
           return (
             <TwoPanels>
@@ -62,11 +63,15 @@ class Holders extends React.Component {
                           groupmode={groupMode}
                         />
                         {!groupMode && (
-                          <StyledTableHeader title="Balance" align="right" />
+                          <StyledTableHeader
+                            title={<div css="margin-left: -20px">Balance</div>}
+                            align="right"
+                          />
                         )}
                         <TableHeader title="" />
                       </TableRow>
                     }
+                    noSideBorders={compactTable}
                   >
                     {holders.map(({ address, balance }) => (
                       <HolderRow
@@ -79,6 +84,7 @@ class Holders extends React.Component {
                         tokenDecimalsBase={tokenDecimalsBase}
                         onAssignTokens={onAssignTokens}
                         onRemoveTokens={onRemoveTokens}
+                        compact={compactTable}
                       />
                     ))}
                   </ResponsiveTable>
@@ -111,8 +117,6 @@ class Holders extends React.Component {
 const Screen = ({ selected, children }) => selected && children
 
 const StyledTableHeader = styled(TableHeader)`
-  width: ${({ groupmode }) => (groupmode ? 100 : 50)}%;
-
   ${breakpoint(
     'medium',
     `

--- a/apps/token-manager/app/src/screens/Holders.js
+++ b/apps/token-manager/app/src/screens/Holders.js
@@ -100,6 +100,7 @@ class Holders extends React.Component {
                   tokenSupply={tokenSupply}
                   tokenSymbol={tokenSymbol}
                   tokenTransfersEnabled={tokenTransfersEnabled}
+                  userAccount={userAccount}
                 />
               </Screen>
             </TwoPanels>

--- a/apps/token-manager/app/src/screens/Holders.js
+++ b/apps/token-manager/app/src/screens/Holders.js
@@ -58,17 +58,19 @@ class Holders extends React.Component {
                   <ResponsiveTable
                     header={
                       <TableRow>
-                        <StyledTableHeader
+                        <TableHeader
                           title={groupMode ? 'Owner' : 'Holder'}
                           groupmode={groupMode}
+                          colSpan={groupMode ? '2' : '1'}
                         />
                         {!groupMode && (
-                          <StyledTableHeader
-                            title={<div css="margin-left: -20px">Balance</div>}
-                            align="right"
+                          <TableHeader
+                            title="Balance"
+                            align={compactTable ? 'left' : 'right'}
+                            colSpan={compactTable ? '2' : '1'}
                           />
                         )}
-                        <TableHeader title="" />
+                        {!groupMode && !compactTable && <TableHeader />}
                       </TableRow>
                     }
                     noSideBorders={compactTable}
@@ -92,7 +94,6 @@ class Holders extends React.Component {
               </Main>
               <Screen selected={!tabbedNavigation || selectedTab === 1}>
                 <ResponsiveSideBar
-                  groupMode={groupMode}
                   holders={holders}
                   tokenAddress={tokenAddress}
                   tokenDecimalsBase={tokenDecimalsBase}
@@ -116,15 +117,6 @@ class Holders extends React.Component {
 }
 
 const Screen = ({ selected, children }) => selected && children
-
-const StyledTableHeader = styled(TableHeader)`
-  ${breakpoint(
-    'medium',
-    `
-      width: auto;
-    `
-  )};
-`
 
 const TabBarWrapper = styled.div`
   margin-top: 16px;


### PR DESCRIPTION
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/36158/54622663-41a79000-4a6a-11e9-89a8-ff3d779735fb.png">

Changes:

- Layout fixes to remove the horizontal scrollbar on small viewports (320px).
- Fix the spacing between the “You” badge and the Identity badge.
- Add the “You” badge in the sidebar.
- Upgrade `@aragon/ui` to `0.32.0`.
- IdentityBadge: always shorten + set the `connectedAccount` prop.
- Table: use the `noSideBorders` prop.
