### PR TITLE
Finance: _tryTransitionAccountPeriod should take uint64 argument

### DIFF
--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -692,7 +692,7 @@ contract Finance is EtherTokenConstant, IsContract, AragonApp {
         emit NewTransaction(transactionId, _incoming, _entity, _amount, _reference);
     }
 
-    function _tryTransitionAccountingPeriod(uint256 _maxTransitions) internal returns (bool success) {
+    function _tryTransitionAccountingPeriod(uint64 _maxTransitions) internal returns (bool success) {
         Period storage currentPeriod = periods[_currentPeriodId()];
         uint64 timestamp = getTimestamp64();
 


### PR DESCRIPTION
See https://github.com/aragon/aragon-apps/pull/611#discussion_r266640876.

Periods are numbered as `uint64`s, so it will never make sense to transition more. Related external methods for transitioning periods already use `uint64`.