### PR TITLE
Payroll: Fix max allowed tokens length

### DIFF
--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -33,7 +33,7 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
 
     uint128 internal constant ONE = 10 ** 18; // 10^18 is considered 1 in the price feed to allow for decimal calculations
     uint64 internal constant MAX_UINT64 = uint64(-1);
-    uint8 internal constant MAX_ALLOWED_TOKENS = 25; // for loop in `payday()` uses ~220k gas per available token
+    uint8 internal constant MAX_ALLOWED_TOKENS = 20; // for loop in `payday()` uses ~260k gas per available token
     uint256 internal constant MAX_ACCRUED_VALUE = 2**128;
 
     string private constant ERROR_NON_ACTIVE_EMPLOYEE = "PAYROLL_NON_ACTIVE_EMPLOYEE";

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -1,11 +1,11 @@
 pragma solidity 0.4.24;
 
+
 import "@aragon/os/contracts/apps/AragonApp.sol";
 import "@aragon/os/contracts/common/EtherTokenConstant.sol";
 import "@aragon/os/contracts/common/IsContract.sol";
-// import "@aragon/os/contracts/common/IForwarder.sol";
+import "@aragon/os/contracts/common/IForwarder.sol";
 
-import "@aragon/os/contracts/lib/token/ERC20.sol";
 import "@aragon/os/contracts/lib/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/math/SafeMath64.sol";
 import "@aragon/os/contracts/lib/math/SafeMath8.sol";
@@ -18,7 +18,7 @@ import "@aragon/apps-finance/contracts/Finance.sol";
 /**
  * @title Payroll in multiple currencies
  */
-contract Payroll is EtherTokenConstant, IsContract, AragonApp { //, IForwarder { // makes coverage crash (removes pure and interface doesnt match)
+contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
     using SafeMath for uint256;
     using SafeMath64 for uint64;
     using SafeMath8 for uint8;
@@ -369,6 +369,12 @@ contract Payroll is EtherTokenConstant, IsContract, AragonApp { //, IForwarder {
         emit ChangeAddressByEmployee(employeeId, oldAddress, _newAddress);
     }
 
+    function isForwarder() external pure returns (bool) {
+        return true;
+    }
+
+    // Getter fns
+
     /**
      * @dev Return all information for employee by their address
      * @param _accountAddress Employee's address to receive payments
@@ -459,14 +465,12 @@ contract Payroll is EtherTokenConstant, IsContract, AragonApp { //, IForwarder {
         runScript(_evmScript, input, blacklist);
     }
 
-    function isForwarder() public pure returns (bool) {
-        return true;
-    }
-
     function canForward(address _sender, bytes) public view returns (bool) {
         // Check employee exists (and matches)
         return (employees[employeeIds[_sender]].accountAddress == _sender);
     }
+
+    // Internal fns
 
     function _addEmployee(
         address _accountAddress,

--- a/future-apps/payroll/package.json
+++ b/future-apps/payroll/package.json
@@ -54,6 +54,7 @@
     "ganache-cli": "^6.0.3",
     "ethereumjs-abi": "^0.6.5",
     "solidity-coverage": "0.5.11",
-    "solium": "^1.1.8"
+    "solium": "^1.1.8",
+    "truffle": "4.1.14"
   }
 }

--- a/future-apps/payroll/test/payroll_allowed_tokens.js
+++ b/future-apps/payroll/test/payroll_allowed_tokens.js
@@ -1,7 +1,6 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 
 const getContract = name => artifacts.require(name)
-const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.event == event)[0].args[arg] }
 
 contract('Payroll, allowed tokens,', function(accounts) {
   const [owner, employee] = accounts
@@ -74,15 +73,13 @@ contract('Payroll, allowed tokens,', function(accounts) {
 
     const startDate = parseInt(await payroll.getTimestampPublic.call(), 10) - 2628005 // now minus 1/12 year
     // add employee
-    const receipt = await payroll.addEmployee(employee, SALARY, "Kakaroto", 'Saiyajin', startDate)
+    await payroll.addEmployee(employee, SALARY, "Kakaroto", 'Saiyajin', startDate)
   })
 
   it('fails adding one more token', async () => {
     const erc20Token = await deployErc20TokenAndDeposit(owner, finance, vault, 'Extra token', ERC20_TOKEN_DECIMALS)
 
-    return assertRevert(async () => {
-      await payroll.addAllowedToken(erc20Token.address)
-    })
+    return assertRevert(() => payroll.addAllowedToken(erc20Token.address))
   })
 
   it('tests payday and ensures that it does not run out of gas', async () => {

--- a/future-apps/payroll/test/payroll_gascosts.js
+++ b/future-apps/payroll/test/payroll_gascosts.js
@@ -62,7 +62,7 @@ contract('Payroll, payday gas costs,', function(accounts) {
 
       const { receipt: { cumulativeGasUsed } } = await payroll.payday({ from: employee })
 
-      assert(cumulativeGasUsed > 312000 && cumulativeGasUsed < 317000, 'payout gas cost for a single allowed token should be ~314k')
+      assert.isBelow(cumulativeGasUsed, 317000, 'payout gas cost for a single allowed token should be ~314k')
     })
   })
 
@@ -79,7 +79,7 @@ contract('Payroll, payday gas costs,', function(accounts) {
       const { receipt: { cumulativeGasUsed: anotherEmployeePayoutGasUsed } } = await payroll.payday({ from: anotherEmployee })
 
       const gasPerAllowedToken = anotherEmployeePayoutGasUsed - employeePayoutGasUsed
-      assert.isTrue(gasPerAllowedToken > 250000 && gasPerAllowedToken < 270000, 'payout gas cost increment per allowed token should be ~260k')
+      assert.isBelow(gasPerAllowedToken, 270000, 'payout gas cost increment per allowed token should be ~260k')
     })
   })
 })

--- a/future-apps/payroll/test/payroll_gascosts.js
+++ b/future-apps/payroll/test/payroll_gascosts.js
@@ -1,0 +1,85 @@
+const getContract = name => artifacts.require(name)
+
+contract('Payroll, payday gas costs,', function(accounts) {
+  const ETH = '0x0'
+  const USD_DECIMALS = 18
+  const USD_PRECISION = 10 ** USD_DECIMALS
+  const SECONDS_IN_A_YEAR = 31557600 // 365.25 days
+  const RATE_EXPIRATION_TIME = 1000
+
+  let payroll, payrollBase, priceFeed, dao, finance, startDate, vault
+  let usdToken, erc20Token1, erc20Token2, erc20Token1ExchangeRate, erc20Token2ExchangeRate, etherExchangeRate
+
+  const [owner, employee, anotherEmployee] = accounts
+  const { deployErc20TokenAndDeposit, addAllowedTokens, redistributeEth, getDaoFinanceVault, initializePayroll } = require('./helpers.js')(owner)
+
+  const erc20Token1Decimals = 20
+  const erc20Token2Decimals = 16;
+
+  const nowMock = new Date().getTime()
+
+  before(async () => {
+    payrollBase = await getContract('PayrollMock').new()
+
+    const daoAndFinance = await getDaoFinanceVault()
+
+    dao = daoAndFinance.dao
+    finance = daoAndFinance.finance
+    vault = daoAndFinance.vault
+
+    usdToken = await deployErc20TokenAndDeposit(owner, finance, vault, 'USD', USD_DECIMALS)
+    priceFeed = await getContract('PriceFeedMock').new()
+    priceFeed.mockSetTimestamp(nowMock)
+
+    // Deploy ERC 20 Tokens
+    erc20Token1 = await deployErc20TokenAndDeposit(owner, finance, vault, 'Token 1', erc20Token1Decimals)
+    erc20Token2 = await deployErc20TokenAndDeposit(owner, finance, vault, 'Token 2', erc20Token2Decimals);
+
+    // get exchange rates
+    etherExchangeRate = (await priceFeed.get(usdToken.address, ETH))[0]
+    erc20Token1ExchangeRate = (await priceFeed.get(usdToken.address, erc20Token1.address))[0]
+    erc20Token2ExchangeRate = (await priceFeed.get(usdToken.address, erc20Token2.address))[0]
+
+    // make sure owner and Payroll have enough funds
+    await redistributeEth(accounts, finance)
+  })
+
+  beforeEach(async () => {
+    payroll = await initializePayroll(dao, payrollBase, finance, usdToken, priceFeed, RATE_EXPIRATION_TIME)
+    
+    await payroll.mockSetTimestamp(nowMock)
+    startDate = parseInt(await payroll.getTimestampPublic.call(), 10) - 2628005 // now minus 1/12 year
+
+    const salary = (new web3.BigNumber(10000)).times(USD_PRECISION).dividedToIntegerBy(SECONDS_IN_A_YEAR)
+    await payroll.addEmployee(employee, salary, 'John Doe', 'Boss', startDate)
+    await payroll.addEmployee(anotherEmployee, salary, 'John Doe Jr.', 'Manager', startDate)
+  })
+
+  context('when there are not allowed tokens yet', function () {
+    it('expends ~314k gas for a single allowed token', async () => {
+      await payroll.addAllowedToken(usdToken.address)
+      await payroll.determineAllocation([usdToken.address], [100], { from: employee })
+
+      const { receipt: { cumulativeGasUsed } } = await payroll.payday({ from: employee })
+
+      assert(cumulativeGasUsed > 312000 && cumulativeGasUsed < 317000, 'payout gas cost for a single allowed token should be ~314k')
+    })
+  })
+
+  context('when there are some allowed tokens', function () {
+    beforeEach('allow some tokens', async () => {
+      await addAllowedTokens(payroll, [usdToken, erc20Token1, erc20Token2])
+    })
+
+    it('expends ~260k gas per allowed token', async () => {
+      await payroll.determineAllocation([ETH, usdToken.address, erc20Token1.address], [15, 60, 25], { from: employee })
+      const { receipt: { cumulativeGasUsed: employeePayoutGasUsed } } = await payroll.payday({ from: employee })
+
+      await payroll.determineAllocation([ETH, usdToken.address, erc20Token1.address, erc20Token2.address], [15, 50, 25, 10], { from: anotherEmployee })
+      const { receipt: { cumulativeGasUsed: anotherEmployeePayoutGasUsed } } = await payroll.payday({ from: anotherEmployee })
+
+      const gasPerAllowedToken = anotherEmployeePayoutGasUsed - employeePayoutGasUsed
+      assert.isTrue(gasPerAllowedToken > 250000 && gasPerAllowedToken < 270000, 'payout gas cost increment per allowed token should be ~260k')
+    })
+  })
+})


### PR DESCRIPTION
**MERGE AFTER https://github.com/aragon/aragon-apps/pull/729**

The [test](https://github.com/aragon/aragon-apps/blob/4ae5f2fe558271fc4aa329248b23936d76bcc6d7/future-apps/payroll/test/payroll_allowed_tokens.js#L85-L93) that was trying to ensure that the payroll contract could handle up to 25 tokens was failing. The Finance contract was running out of gas when trying to perform the last transfer.

I added some tests to check how much increases the payout process of the Payroll contract for each new allowed token, which is [~260k](https://github.com/aragon/aragon-apps/commit/4ae5f2fe558271fc4aa329248b23936d76bcc6d7#diff-9335e65fae396b052e4ee57474e4b3c3R82). Having in mind that performing a transaction for a single allowed token costs [~315k](https://github.com/aragon/aragon-apps/commit/4ae5f2fe558271fc4aa329248b23936d76bcc6d7#diff-9335e65fae396b052e4ee57474e4b3c3R65) and that we are using a [max gas usage of 6.5m](https://github.com/aragon/aragon-apps/blob/4ae5f2fe558271fc4aa329248b23936d76bcc6d7/future-apps/payroll/test/payroll_allowed_tokens.js#L30), considering ~260k per token, the payroll contract could handle up to 23 tokens. But given that the Payroll contract also depends on the vault and finance apps, I propose lowing it down to 20 just to be more conservative, which I think it actually means enough alternatives for the employees. 
