### PR TITLE
 Token Manager: disallow minting and vesting tokens to itself

### DIFF
--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -251,7 +251,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     */
     function onTransfer(address _from, address _to, uint256 _amount) public onlyToken returns (bool) {
         if (_isBalanceIncreaseAllowed(_to, _amount)) {
-            return _spendableBalanceOf(_from) >= _amount;
+            return _transferableBalance(_from, now) >= _amount;
         }
 
         return false;
@@ -301,7 +301,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     }
 
     function spendableBalanceOf(address _holder) public view isInitialized returns (uint256) {
-        return _spendableBalanceOf(_holder);
+        return _transferableBalance(_holder, now);
     }
 
     function transferableBalance(address _holder, uint256 _time) public view isInitialized returns (uint256) {
@@ -392,10 +392,6 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
 
         // tokens - vestedTokens
         return tokens.sub(vestedTokens);
-    }
-
-    function _spendableBalanceOf(address _holder) internal view returns (uint256) {
-        return _transferableBalance(_holder, now);
     }
 
     function _transferableBalance(address _holder, uint256 _time) internal view returns (uint256) {

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -249,8 +249,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     */
     function onTransfer(address _from, address _to, uint256 _amount) public onlyToken returns (bool) {
         if (_isBalanceIncreaseAllowed(_to, _amount)) {
-            // Always allow transfers from the Token Manager itself
-            return (_from == address(this) || _spendableBalanceOf(_from) >= _amount);
+            return _spendableBalanceOf(_from) >= _amount;
         }
 
         return false;

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -250,11 +250,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     * @return False if the controller does not authorize the transfer
     */
     function onTransfer(address _from, address _to, uint256 _amount) public onlyToken returns (bool) {
-        if (_isBalanceIncreaseAllowed(_to, _amount)) {
-            return _transferableBalance(_from, now) >= _amount;
-        }
-
-        return false;
+        return _isBalanceIncreaseAllowed(_to, _amount) && _transferableBalance(_from, now) >= _amount;
     }
 
     /**

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -198,6 +198,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         );
 
         // To make vestingIds immutable over time, we just zero out the revoked vesting
+        // Clearing this out also allows the token transfer back to the Token Manager to succeed
         delete vestings[_holder][_vestingId];
 
         // transferFrom always works as controller
@@ -240,7 +241,8 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     // during initialization.
 
     /*
-    * @dev Notifies the controller about a token transfer allowing the controller to decide whether to allow it or react if desired (only callable from the token)
+    * @dev Notifies the controller about a token transfer allowing the controller to decide whether
+    *      to allow it or react if desired (only callable from the token).
     *      Initialization check is implicitly provided by `onlyToken()`.
     * @param _from The origin of the transfer
     * @param _to The destination of the transfer

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -247,7 +247,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     * @param _amount The amount of the transfer
     * @return False if the controller does not authorize the transfer
     */
-    function onTransfer(address _from, address _to, uint _amount) public onlyToken returns (bool) {
+    function onTransfer(address _from, address _to, uint256 _amount) public onlyToken returns (bool) {
         if (_isBalanceIncreaseAllowed(_to, _amount)) {
             // Always allow transfers from the Token Manager itself
             return (_from == address(this) || _spendableBalanceOf(_from) >= _amount);
@@ -328,7 +328,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         token.generateTokens(_receiver, _amount); // minime.generateTokens() never returns false
     }
 
-    function _isBalanceIncreaseAllowed(address _receiver, uint _inc) internal view returns (bool) {
+    function _isBalanceIncreaseAllowed(address _receiver, uint256 _inc) internal view returns (bool) {
         // Max balance doesn't apply to the token manager itself
         if (_receiver == address(this)) {
             return true;

--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -30,6 +30,7 @@ contract('Token Manager', accounts => {
 
     const root = accounts[0]
     const holder = accounts[1]
+    const holder2 = accounts[2]
 
     before(async () => {
         const kernelBase = await getContract('Kernel').new(true) // petrify immediately
@@ -113,7 +114,7 @@ contract('Token Manager', accounts => {
             await tokenManager.mint(holder, 2000)
 
             return assertRevert(async () => {
-                await token.transfer(accounts[2], 10, { from: holder })
+                await token.transfer(holder2, 10, { from: holder })
             })
         })
 
@@ -169,10 +170,10 @@ contract('Token Manager', accounts => {
             })
         })
 
-        it('can issue unlimited tokens for manager', async () => {
+        it('can issue unlimited tokens to itself', async () => {
             await tokenManager.issue(limit + 100000)
 
-            assert.equal(await token.balanceOf(tokenManager.address), limit + 100000, 'should have tokens')
+            assert.equal(await token.balanceOf(tokenManager.address), limit + 100000, 'should have more tokens than limit')
         })
 
         it('can assign up to limit', async () => {
@@ -187,6 +188,25 @@ contract('Token Manager', accounts => {
 
             return assertRevert(async () => {
                 await tokenManager.assign(holder, limit + 1)
+            })
+        })
+
+        it('can transfer tokens to token manager without regard to token limit', async () => {
+            await tokenManager.issue(limit + 100000)
+            await tokenManager.assign(holder, 5)
+
+            await token.transfer(tokenManager.address, 5, { from: holder })
+
+            assert.equal(await token.balanceOf(tokenManager.address), limit + 100000, 'should have more tokens than limit')
+        })
+
+        it('cannot transfer tokens to an address if it would go over the limit', async () => {
+            await tokenManager.issue(limit * 2)
+            await tokenManager.assign(holder, limit - 1)
+            await tokenManager.assign(holder2, limit - 1)
+
+            return assertRevert(async () => {
+                await token.transfer(holder2, 5, { from: holder })
             })
         })
     })
@@ -259,10 +279,10 @@ contract('Token Manager', accounts => {
             await tokenManager.mint(holder, amount)
 
             // Make sure this callback fails when called out-of-context
-            await assertRevert(() => tokenManager.onTransfer(holder, accounts[2], 10))
+            await assertRevert(() => tokenManager.onTransfer(holder, holder2, 10))
 
             // Make sure the same transfer through the token's context doesn't revert
-            await token.transfer(accounts[2], amount, { from: holder })
+            await token.transfer(holder2, amount, { from: holder })
         })
 
         it("cannot call onApprove() from outside of the token's context", async () => {
@@ -270,10 +290,10 @@ contract('Token Manager', accounts => {
             await tokenManager.mint(holder, amount)
 
             // Make sure this callback fails when called out-of-context
-            await assertRevert(() => tokenManager.onApprove(holder, accounts[2], 10))
+            await assertRevert(() => tokenManager.onApprove(holder, holder2, 10))
 
             // Make sure no allowance was registered
-            assert.equal(await token.allowance(holder, accounts[2]), 0, 'token approval should be 0')
+            assert.equal(await token.allowance(holder, holder2), 0, 'token approval should be 0')
         })
 
         it("cannot call proxyPayment() from outside of the token's context", async () => {
@@ -343,43 +363,43 @@ contract('Token Manager', accounts => {
 
             it('can start transfering on cliff', async () => {
                 await timetravel(cliff)
-                await token.transfer(accounts[2], 10, { from: holder })
-                assert.equal(await token.balanceOf(accounts[2]), 10, 'should have received tokens')
+                await token.transfer(holder2, 10, { from: holder })
+                assert.equal(await token.balanceOf(holder2), 10, 'should have received tokens')
                 assert.equal(await tokenManager.spendableBalanceOf(holder), 0, 'should not be able to spend more tokens')
             })
 
             it('can transfer all tokens after vesting', async () => {
                 await timetravel(vesting)
-                await token.transfer(accounts[2], totalTokens, { from: holder })
-                assert.equal(await token.balanceOf(accounts[2]), totalTokens, 'should have received tokens')
+                await token.transfer(holder2, totalTokens, { from: holder })
+                assert.equal(await token.balanceOf(holder2), totalTokens, 'should have received tokens')
             })
 
             it('can transfer half mid vesting', async () => {
                 await timetravel(start + (vesting - start) / 2)
 
-                await token.transfer(accounts[2], 20, { from: holder })
+                await token.transfer(holder2, 20, { from: holder })
 
                 assert.equal(await tokenManager.spendableBalanceOf(holder), 0, 'should not be able to spend more tokens')
             })
 
             it('cannot transfer non-vested tokens', async () => {
                 return assertRevert(async () => {
-                    await token.transfer(accounts[2], 10, { from: holder })
+                    await token.transfer(holder2, 10, { from: holder })
                 })
             })
 
             it('can approve non-vested tokens but transferFrom fails', async () => {
-                await token.approve(accounts[2], 10, { from: holder })
+                await token.approve(holder2, 10, { from: holder })
 
                 return assertRevert(async () => {
-                    await token.transferFrom(holder, accounts[2], 10, { from: accounts[2] })
+                    await token.transferFrom(holder, holder2, 10, { from: holder2 })
                 })
             })
 
             it('cannot transfer all tokens right before vesting', async () => {
                 await timetravel(vesting - 10)
                 return assertRevert(async () => {
-                    await token.transfer(accounts[2], totalTokens, { from: holder })
+                    await token.transfer(holder2, totalTokens, { from: holder })
                 })
             })
 
@@ -387,10 +407,10 @@ contract('Token Manager', accounts => {
                 await timetravel(cliff)
                 await tokenManager.revokeVesting(holder, 0)
 
-                await token.transfer(accounts[2], 5, { from: holder })
+                await token.transfer(holder2, 5, { from: holder })
 
                 assert.equal(await token.balanceOf(holder), 5, 'should have kept vested tokens')
-                assert.equal(await token.balanceOf(accounts[2]), 5, 'should have kept vested tokens')
+                assert.equal(await token.balanceOf(holder2), 5, 'should have kept vested tokens')
                 assert.equal(await token.balanceOf(tokenManager.address), totalTokens - 10, 'should have received unvested')
             })
 
@@ -411,10 +431,10 @@ contract('Token Manager', accounts => {
                     i--
                 }
                 await timetravel(vesting)
-                await token.transfer(accounts[3], 1) // can transfer
                 return assertRevert(async () => {
                     await tokenManager.assignVested(holder, 1, now + start, now + cliff, now + vesting, false)
                 })
+                await token.transfer(holder23, 1) // can transfer
             })
         })
     })
@@ -422,13 +442,13 @@ contract('Token Manager', accounts => {
     context('app not initialized', async () => {
         it('fails to mint tokens', async() => {
             return assertRevert(async() => {
-                await tokenManager.mint(accounts[1], 1)
+                await tokenManager.mint(holder, 1)
             })
         })
 
         it('fails to assign tokens', async() => {
             return assertRevert(async() => {
-                await tokenManager.assign(accounts[1], 1)
+                await tokenManager.assign(holder, 1)
             })
         })
 
@@ -440,7 +460,7 @@ contract('Token Manager', accounts => {
 
         it('fails to burn tokens', async() => {
             return assertRevert(async() => {
-                await tokenManager.burn(accounts[0], 1)
+                await tokenManager.burn(holder, 1)
             })
         })
     })


### PR DESCRIPTION
This change adds more checks to disallow usage of the `mint()` and `assignVested()` actions for the Token Manager itself:

- `mint()`: you should use `issue()` instead (separate action protected by a separate role)
- `assignVested()`: Assigning vestings to the Token Manager makes the accounting awkward when calculating the spendable balance of the Token Manager itself. The Token Manager itself never has a spending limit (see `onTransfer()`, so the concept of a vesting does not work very well.

This change also modifies the way `_isBalanceIncreaseAllowed()` works, by always allowing increases to the Token Manager's balance.

Previously, using `assign()` with the Token Manager as the recipient would fail if its balance was already over the limit (see [previously failing test](https://github.com/aragon/aragon-apps/pull/734/files#diff-17c8771ab9c99065348cbba1b3fba658R179)). Although this isn't something to really worry about, it does show this check wasn't fully aligned with the balance assumptions (of it not applying to the Token Manager itself).