### PR TITLE
Payroll: Avoid payout overflow

### DIFF
--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -517,15 +517,7 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
     }
 
     function _addAccruedValue(uint256 _employeeId, uint256 _amount) internal {
-        Employee storage employee = employees[_employeeId];
-
-        // if the result would overflow, set it to max int
-        uint256 result = employee.accruedValue +_amount;
-        if (result >= _amount) {
-            employee.accruedValue = result;
-        } else {
-            employee.accruedValue = MAX_UINT256;
-        }
+        employees[_employeeId].accruedValue = employees[_employeeId].accruedValue.add(_amount);
 
         emit AddEmployeeAccruedValue(_employeeId, _amount);
     }

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -554,8 +554,11 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
             toDate = timestamp;
         }
 
-        // Compute owed amount
-        uint256 owed = employee.accruedValue.add(_getOwedSalary(_employeeId, toDate));
+        // Compute owed amount, set to max int in case of overflow
+        uint256 owed = employee.accruedValue + _getOwedSalary(_employeeId, toDate);
+        if (owed < employee.accruedValue) {
+            owed = MAX_UINT256;
+        }
         if (owed == 0 || owed < _amount) {
             return false;
         }

--- a/future-apps/payroll/contracts/test/mocks/PayrollMock.sol
+++ b/future-apps/payroll/contracts/test/mocks/PayrollMock.sol
@@ -31,7 +31,7 @@ contract PayrollMock is Payroll {
     function mockSetTimestamp(uint64 i) public { _mockTime = i; }
     function mockAddTimestamp(uint64 i) public { _mockTime += i; require(_mockTime >= i); }
     function getTimestampPublic() public view returns (uint64) { return _mockTime; }
-    function getMaxAccruedValue() public view returns (uint256) { return MAX_ACCRUED_VALUE; }
+    function getMaxAccruedValue() public view returns (uint256) { return MAX_UINT256; }
     function getMaxAllowedTokens() public view returns (uint8) { return MAX_ALLOWED_TOKENS; }
     function getAllowedTokensArrayLength() public view returns (uint256) { return allowedTokensArray.length; }
     function getTimestamp64() internal view returns (uint64) { return _mockTime; }

--- a/future-apps/payroll/test/payroll_accrued_value.js
+++ b/future-apps/payroll/test/payroll_accrued_value.js
@@ -1,104 +1,521 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const getContract = name => artifacts.require(name)
-const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.event == event)[0].args[arg] }
 
-contract('Payroll, accrued value,', async (accounts) => {
-  const [owner, employee1, _] = accounts
+const getContract = name => artifacts.require(name)
+const getEvent = (receipt, event, arg) => receipt.logs.find(l => l.event === event).args[arg]
+
+contract('Payroll, accrued value', (accounts) => {
+  const DECIMALS = 18
+  const NOW = new Date().getTime()
+  const ONE_MONTH = 60 * 60 * 24 * 31
+  const TWO_MONTHS = ONE_MONTH * 2
+  const PCT_ONE = new web3.BigNumber(1e18)
+
+  const [owner, employee, anyone] = accounts
   const {
     deployErc20TokenAndDeposit,
     addAllowedTokens,
-    getTimePassed,
     redistributeEth,
     getDaoFinanceVault,
     initializePayroll
   } = require('./helpers.js')(owner)
 
-  const USD_DECIMALS = 18
-  const USD_PRECISION = 10**USD_DECIMALS
-  const SECONDS_IN_A_YEAR = 31557600 // 365.25 days
-  const ETH = '0x0'
-  const rateExpiryTime = 1000
-
-  const salary1 = 1000
-  const erc20Token1Decimals = 18
-
-  let payroll
-  let payrollBase
-  let priceFeed
-  let usdToken
-  let erc20Token1
-  let employeeId1
-  let dao
-  let finance
-  let vault
+  let payroll, payrollBase, priceFeed, denominationToken, anotherToken, salary, employeeId, dao, finance, vault
 
   before(async () => {
     payrollBase = await getContract('PayrollMock').new()
 
-    const daoAndFinance = await getDaoFinanceVault()
+    const daoFinanceVault = await getDaoFinanceVault()
+    dao = daoFinanceVault.dao
+    finance = daoFinanceVault.finance
+    vault = daoFinanceVault.vault
 
-    dao = daoAndFinance.dao
-    finance = daoAndFinance.finance
-    vault = daoAndFinance.vault
-
-    usdToken = await deployErc20TokenAndDeposit(owner, finance, vault, "USD", USD_DECIMALS)
-    priceFeed = await getContract('PriceFeedMock').new()
-
-    // Deploy ERC 20 Tokens
-    erc20Token1 = await deployErc20TokenAndDeposit(owner, finance, vault, "Token 1", erc20Token1Decimals)
-
-    // make sure owner and Payroll have enough funds
     await redistributeEth(accounts, finance)
+
+    priceFeed = await getContract('PriceFeedMock').new()
+    await priceFeed.mockSetTimestamp(NOW)
   })
 
-  beforeEach(async () => {
-    payroll = await initializePayroll(dao, payrollBase, finance, usdToken, priceFeed, rateExpiryTime)
+  beforeEach('initialize payroll, tokens and employee', async () => {
+    denominationToken = await deployErc20TokenAndDeposit(owner, finance, vault, "USD", DECIMALS)
+    anotherToken = await deployErc20TokenAndDeposit(owner, finance, vault, "ERC20", DECIMALS)
 
-    // adds allowed tokens
-    await addAllowedTokens(payroll, [usdToken, erc20Token1])
+    payroll = await initializePayroll(dao, payrollBase, finance, denominationToken, priceFeed, TWO_MONTHS)
+    await payroll.mockSetTimestamp(NOW)
+    await addAllowedTokens(payroll, [denominationToken, anotherToken])
 
-    // add employee
-    const receipt = await payroll.addEmployeeShort(employee1, salary1, 'Kakaroto', 'Saiyajin')
-    employeeId1 = getEvent(receipt, 'AddEmployee', 'employeeId')
+    salary = 1000
+    const receipt = await payroll.addEmployeeShort(employee, salary, 'Kakaroto', 'Saiyajin')
+    employeeId = getEvent(receipt, 'AddEmployee', 'employeeId')
   })
 
-  it('adds accrued Value manually', async () => {
+  it('adds accrued value manually', async () => {
     const accruedValue = 50
-    await payroll.addAccruedValue(employeeId1, accruedValue)
-    assert.equal((await payroll.getEmployee(employeeId1))[2].toString(), accruedValue, 'Accrued Value should match')
+    await payroll.addAccruedValue(employeeId, accruedValue)
+    assert.equal((await payroll.getEmployee(employeeId))[2].toString(), accruedValue, 'Accrued Value should match')
   })
 
-  it('fails adding an accrued Value too large', async () => {
-    const accruedValue = new web3.BigNumber(await payroll.getMaxAccruedValue()).plus(1)
-    return assertRevert(async () => {
-      await payroll.addAccruedValue(employeeId1, accruedValue)
+  it('fails adding an accrued value too large', async () => {
+    const maxAccruedValue = await payroll.getMaxAccruedValue()
+    await payroll.addAccruedValue(employeeId, maxAccruedValue)
+
+    await assertRevert(payroll.addAccruedValue(employeeId, 1))
+  })
+
+  it('considers modified salary as accrued value and it can be computed right after the change', async () => {
+    const timeDiff = 864000
+    await payroll.mockAddTimestamp(timeDiff)
+
+    const salary1_1 = salary * 2
+    await payroll.setEmployeeSalary(employeeId, salary1_1)
+
+    await payroll.determineAllocation([denominationToken.address], [100], { from: employee })
+    const initialBalance = await denominationToken.balanceOf(employee)
+    await payroll.reimburse({ from: employee })
+
+    const finalBalance = await denominationToken.balanceOf(employee)
+    const payrollOwed = salary * timeDiff
+    assert.equal(finalBalance - initialBalance, payrollOwed, "Payroll payed doesn't match")
+  })
+
+  it('considers modified salary as accrued value  and it can be computed some time after the change', async () => {
+    const timeDiff = 864000
+    await payroll.mockAddTimestamp(timeDiff)
+
+    const salary1_1 = salary * 2
+    await payroll.setEmployeeSalary(employeeId, salary1_1)
+
+    await payroll.mockAddTimestamp(timeDiff * 2)
+
+    await payroll.determineAllocation([denominationToken.address], [100], { from: employee })
+    const initialBalance = await denominationToken.balanceOf(employee)
+    await payroll.reimburse({ from: employee })
+
+    const finalBalance = await denominationToken.balanceOf(employee)
+    const payrollOwed = salary * timeDiff
+    assert.equal(finalBalance - initialBalance, payrollOwed, "Payroll payed doesn't match")
+  })
+
+  describe('reimburse', function () {
+    context('when the sender is an employee', () => {
+      const from = employee
+
+      beforeEach('mock current timestamp', async () => {
+        await payroll.mockAddTimestamp(ONE_MONTH)
+      })
+
+      context('when the employee has already set some token allocations', () => {
+        beforeEach('set tokens allocation', async () => {
+          await payroll.determineAllocation([denominationToken.address, anotherToken.address], [80, 20], { from })
+        })
+
+        context('when the employee has some pending reimbursements', () => {
+          const accruedValue = 100
+
+          beforeEach('add accrued value', async () => {
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+          })
+
+          const assertTransferredAmounts = () => {
+            it('transfers all the pending reimbursements', async () => {
+              const previousDenominationTokenBalance = await denominationToken.balanceOf(employee)
+              const previousAnotherTokenBalance = await anotherToken.balanceOf(employee)
+
+              await payroll.reimburse({ from })
+
+              const currentDenominationTokenBalance = await denominationToken.balanceOf(employee)
+              assert.equal(currentDenominationTokenBalance.toString(), previousDenominationTokenBalance.plus(80).toString(), 'current USD token balance does not match')
+
+              const currentAnotherTokenBalance = await anotherToken.balanceOf(employee)
+              const anotherTokenRate = (await priceFeed.get(denominationToken.address, anotherToken.address))[0].div(PCT_ONE)
+              const expectedAnotherTokenBalance = anotherTokenRate.mul(20).plus(previousAnotherTokenBalance)
+              assert.equal(currentAnotherTokenBalance.toString(), expectedAnotherTokenBalance.toString(), 'current token balance does not match')
+            })
+
+            it('emits one event per allocated token', async () => {
+              const receipt = await payroll.reimburse({ from })
+
+              const events = receipt.logs.filter(l => l.event === 'SendPayment')
+              assert.equal(events.length, 2, 'should have emitted two events')
+
+              const denominationTokenEvent = events.find(e => e.args.token === denominationToken.address).args
+              assert.equal(denominationTokenEvent.employee, employee, 'employee address does not match')
+              assert.equal(denominationTokenEvent.token, denominationToken.address, 'usd token address does not match')
+              assert.equal(denominationTokenEvent.amount.toString(), 80, 'payment amount does not match')
+              assert.equal(denominationTokenEvent.reference, 'Reimbursement', 'payment reference does not match')
+
+              const anotherTokenRate = (await priceFeed.get(denominationToken.address, anotherToken.address))[0].div(PCT_ONE)
+              const anotherTokenEvent = events.find(e => e.args.token === anotherToken.address).args
+              assert.equal(anotherTokenEvent.employee, employee, 'employee address does not match')
+              assert.equal(anotherTokenEvent.token, anotherToken.address, 'token address does not match')
+              assert.equal(anotherTokenEvent.amount.div(anotherTokenRate).toString(), 20, 'payment amount does not match')
+              assert.equal(anotherTokenEvent.reference, 'Reimbursement', 'payment reference does not match')
+            })
+          }
+
+          const assertEmployeeIsNotRemoved = () => {
+            it('does not remove the employee and resets the accrued value', async () => {
+              await payroll.reimburse({ from })
+
+              const [address, employeeSalary, accruedValue] = await payroll.getEmployee(employeeId)
+
+              assert.equal(address, employee, 'employee address does not match')
+              assert.equal(employeeSalary, salary, 'employee salary does not match')
+              assert.equal(accruedValue, 0, 'accrued value should be zero')
+            })
+          }
+
+          context('when the employee has some pending salary', () => {
+            assertTransferredAmounts()
+            assertEmployeeIsNotRemoved()
+          })
+
+          context('when the employee does not have pending salary', () => {
+            beforeEach('cash out pending salary', async () => {
+              await payroll.payday({ from })
+            })
+
+            context('when the employee is not terminated', () => {
+              assertTransferredAmounts()
+              assertEmployeeIsNotRemoved()
+            })
+
+            context('when the employee is terminated', () => {
+              beforeEach('terminate employee', async () => {
+                await payroll.terminateEmployeeNow(employeeId, { from: owner })
+              })
+
+              assertTransferredAmounts()
+
+              it('removes the employee', async () => {
+                await payroll.reimburse({ from })
+
+                const [address, employeeSalary, accruedValue, payrollTimestamp] = await payroll.getEmployee(employeeId)
+
+                assert.equal(address, 0, 'employee address does not match')
+                assert.equal(employeeSalary, 0, 'employee salary does not match')
+                assert.equal(accruedValue, 0, 'accrued value should be zero')
+                assert.equal(payrollTimestamp, 0, 'accrued value should be zero')
+              })
+            })
+          })
+        })
+
+        context('when the employee does not have pending reimbursements', () => {
+          it('reverts', async () => {
+            await assertRevert(payroll.reimburse({ from }), 'PAYROLL_NOTHING_PAID')
+          })
+        })
+      })
+
+      context('when the employee did not set any token allocations yet', () => {
+        context('when the employee has some pending reimbursements', () => {
+          const accruedValue = 50
+
+          beforeEach('add accrued value', async () => {
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+          })
+
+          it('reverts', async () => {
+            await assertRevert(payroll.reimburse({ from }), 'PAYROLL_NOTHING_PAID')
+          })
+        })
+
+        context('when the employee does not have pending reimbursements', () => {
+          it('reverts', async () => {
+            await assertRevert(payroll.reimburse({ from }), 'PAYROLL_NOTHING_PAID')
+          })
+        })
+      })
+    })
+
+    context('when the sender is not an employee', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(payroll.reimburse({ from }), 'PAYROLL_EMPLOYEE_DOES_NOT_MATCH')
+      })
     })
   })
 
-  it('modifies salary and payroll is computed properly, right after the change', async () => {
-    const salary1_1 = salary1 * 2
-    const timeDiff = 864000
-    await payroll.mockAddTimestamp(timeDiff)
-    await payroll.setEmployeeSalary(employeeId1, salary1_1)
-    await payroll.determineAllocation([usdToken.address], [100], { from: employee1 })
-    const initialBalance = await usdToken.balanceOf(employee1)
-    await payroll.payday({ from: employee1 })
-    const finalBalance = await usdToken.balanceOf(employee1)
-    const payrollOwed = salary1 * timeDiff
-    assert.equal(finalBalance - initialBalance, payrollOwed, "Payroll payed doesn't match")
-  })
+  describe('partialReimburse', function () {
+    context('when the sender is an employee', () => {
+      const from = employee
 
-  it('modifies salary and payroll is computed properly, some time after the change', async () => {
-    const salary1_1 = salary1 * 2
-    const timeDiff = 864000
-    await payroll.mockAddTimestamp(timeDiff)
-    await payroll.setEmployeeSalary(employeeId1, salary1_1)
-    await payroll.mockAddTimestamp(timeDiff * 2)
-    await payroll.determineAllocation([usdToken.address], [100], { from: employee1 })
-    const initialBalance = await usdToken.balanceOf(employee1)
-    await payroll.payday({ from: employee1 })
-    const finalBalance = await usdToken.balanceOf(employee1)
-    const payrollOwed = salary1 * timeDiff + salary1_1 * timeDiff * 2
-    assert.equal(finalBalance - initialBalance, payrollOwed, "Payroll payed doesn't match")
+      beforeEach('mock current timestamp', async () => {
+        await payroll.mockAddTimestamp(ONE_MONTH)
+      })
+
+      context('when the employee has already set some token allocations', () => {
+        const denominationTokenAllocation = 80
+        const anotherTokenAllocation = 20
+
+        beforeEach('set tokens allocation', async () => {
+          await payroll.determineAllocation([denominationToken.address, anotherToken.address], [denominationTokenAllocation, anotherTokenAllocation], { from })
+        })
+
+        context('when the employee has some pending reimbursements', () => {
+          const accruedValue = 100
+
+          beforeEach('add accrued value', async () => {
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+          })
+
+          const assertTransferredAmounts = (requestedAmount, expectedRequestedAmount = requestedAmount) => {
+            const requestedDenominationTokenAmount = parseInt(expectedRequestedAmount * denominationTokenAllocation / 100)
+            const requestedAnotherTokenAmount = expectedRequestedAmount * anotherTokenAllocation / 100
+
+            it('transfers all the pending reimbursements', async () => {
+              const previousDenominationTokenBalance = await denominationToken.balanceOf(employee)
+              const previousAnotherTokenBalance = await anotherToken.balanceOf(employee)
+
+              await payroll.partialReimburse(requestedAmount, { from })
+
+              const currentDenominationTokenBalance = await denominationToken.balanceOf(employee)
+              const expectedDenominationTokenBalance = previousDenominationTokenBalance.plus(requestedDenominationTokenAmount);
+              assert.equal(currentDenominationTokenBalance.toString(), expectedDenominationTokenBalance.toString(), 'current USD token balance does not match')
+
+              const currentAnotherTokenBalance = await anotherToken.balanceOf(employee)
+              const anotherTokenRate = (await priceFeed.get(denominationToken.address, anotherToken.address))[0].div(PCT_ONE)
+              const expectedAnotherTokenBalance = anotherTokenRate.mul(requestedAnotherTokenAmount).plus(previousAnotherTokenBalance).trunc()
+              assert.equal(currentAnotherTokenBalance.toString(), expectedAnotherTokenBalance.toString(), 'current token balance does not match')
+            })
+
+            it('emits one event per allocated token', async () => {
+              const receipt = await payroll.partialReimburse(requestedAmount, { from })
+
+              const events = receipt.logs.filter(l => l.event === 'SendPayment')
+              assert.equal(events.length, 2, 'should have emitted two events')
+
+              const denominationTokenEvent = events.find(e => e.args.token === denominationToken.address).args
+              assert.equal(denominationTokenEvent.employee, employee, 'employee address does not match')
+              assert.equal(denominationTokenEvent.token, denominationToken.address, 'usd token address does not match')
+              assert.equal(denominationTokenEvent.amount.toString(), requestedDenominationTokenAmount, 'payment amount does not match')
+              assert.equal(denominationTokenEvent.reference, 'Reimbursement', 'payment reference does not match')
+
+              const anotherTokenRate = (await priceFeed.get(denominationToken.address, anotherToken.address))[0].div(PCT_ONE)
+              const anotherTokenEvent = events.find(e => e.args.token === anotherToken.address).args
+              assert.equal(anotherTokenEvent.employee, employee, 'employee address does not match')
+              assert.equal(anotherTokenEvent.token, anotherToken.address, 'token address does not match')
+              assert.equal(anotherTokenEvent.amount.div(anotherTokenRate).trunc().toString(), parseInt(requestedAnotherTokenAmount), 'payment amount does not match')
+              assert.equal(anotherTokenEvent.reference, 'Reimbursement', 'payment reference does not match')
+            })
+          }
+
+          const assertEmployeeIsNotRemoved = (requestedAmount, expectedRequestedAmount = requestedAmount) => {
+            it('does not remove the employee and resets the accrued value', async () => {
+              const currentAccruedValue = (await payroll.getEmployee(employeeId))[2]
+              await payroll.partialReimburse(requestedAmount, { from })
+
+              const [address, employeeSalary, accruedValue] = await payroll.getEmployee(employeeId)
+
+              assert.equal(address, employee, 'employee address does not match')
+              assert.equal(employeeSalary, salary, 'employee salary does not match')
+              assert.equal(currentAccruedValue.minus(expectedRequestedAmount).toString(), accruedValue.toString(), 'accrued value does not match')
+            })
+          }
+
+          context('when the requested amount is zero', () => {
+            const requestedAmount = 0
+
+            context('when the employee has some pending salary', () => {
+              assertTransferredAmounts(requestedAmount, accruedValue)
+              assertEmployeeIsNotRemoved(requestedAmount, accruedValue)
+            })
+
+            context('when the employee does not have pending salary', () => {
+              beforeEach('cash out pending salary', async () => {
+                await payroll.payday({ from })
+              })
+
+              context('when the employee is not terminated', () => {
+                assertTransferredAmounts(requestedAmount, accruedValue)
+                assertEmployeeIsNotRemoved(requestedAmount, accruedValue)
+              })
+
+              context('when the employee is terminated', () => {
+                beforeEach('terminate employee', async () => {
+                  await payroll.terminateEmployeeNow(employeeId, { from: owner })
+                })
+
+                assertTransferredAmounts(requestedAmount, accruedValue)
+
+                it('removes the employee', async () => {
+                  await payroll.partialReimburse(requestedAmount, { from })
+
+                  const [address, employeeSalary, accruedValue, payrollTimestamp] = await payroll.getEmployee(employeeId)
+
+                  assert.equal(address, 0, 'employee address does not match')
+                  assert.equal(employeeSalary, 0, 'employee salary does not match')
+                  assert.equal(accruedValue, 0, 'accrued value should be zero')
+                  assert.equal(payrollTimestamp, 0, 'accrued value should be zero')
+                })
+              })
+            })
+          })
+
+          context('when the requested amount is less than the total accrued value', () => {
+              const requestedAmount = accruedValue - 1
+
+            context('when the employee has some pending salary', () => {
+              assertTransferredAmounts(requestedAmount)
+              assertEmployeeIsNotRemoved(requestedAmount)
+            })
+
+            context('when the employee does not have pending salary', () => {
+              beforeEach('cash out pending salary', async () => {
+                await payroll.payday({ from })
+              })
+
+              context('when the employee is not terminated', () => {
+                assertTransferredAmounts(requestedAmount)
+                assertEmployeeIsNotRemoved(requestedAmount)
+              })
+
+              context('when the employee is terminated', () => {
+                beforeEach('terminate employee', async () => {
+                  await payroll.terminateEmployeeNow(employeeId, { from: owner })
+                })
+
+                assertTransferredAmounts(requestedAmount)
+                assertEmployeeIsNotRemoved(requestedAmount)
+              })
+            })
+          })
+
+          context('when the requested amount is equal to the total accrued value', () => {
+            const requestedAmount = accruedValue
+
+            context('when the employee has some pending salary', () => {
+              assertTransferredAmounts(requestedAmount)
+              assertEmployeeIsNotRemoved(requestedAmount)
+            })
+
+            context('when the employee does not have pending salary', () => {
+              beforeEach('cash out pending salary', async () => {
+                await payroll.payday({ from })
+              })
+
+              context('when the employee is not terminated', () => {
+                assertTransferredAmounts(requestedAmount)
+                assertEmployeeIsNotRemoved(requestedAmount)
+              })
+
+              context('when the employee is terminated', () => {
+                beforeEach('terminate employee', async () => {
+                  await payroll.terminateEmployeeNow(employeeId, { from: owner })
+                })
+
+                assertTransferredAmounts(requestedAmount)
+
+                it('removes the employee', async () => {
+                  await payroll.partialReimburse(requestedAmount, { from })
+
+                  const [address, employeeSalary, accruedValue, payrollTimestamp] = await payroll.getEmployee(employeeId)
+
+                  assert.equal(address, 0, 'employee address does not match')
+                  assert.equal(employeeSalary, 0, 'employee salary does not match')
+                  assert.equal(accruedValue, 0, 'accrued value should be zero')
+                  assert.equal(payrollTimestamp, 0, 'accrued value should be zero')
+                })
+              })
+            })
+          })
+
+          context('when the requested amount is greater than the total accrued value', () => {
+            const requestedAmount = accruedValue + 1
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+        })
+
+        context('when the employee does not have pending reimbursements', () => {
+          context('when the requested amount is greater than zero', () => {
+            const requestedAmount = 100
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+
+          context('when the requested amount is zero', () => {
+            const requestedAmount = 0
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+        })
+      })
+
+      context('when the employee did not set any token allocations yet', () => {
+        context('when the employee has some pending reimbursements', () => {
+          const accruedValue = 100
+
+          beforeEach('add accrued value', async () => {
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+            await payroll.addAccruedValue(employeeId, accruedValue / 2, { from: owner })
+          })
+
+          context('when the requested amount is less than the total accrued value', () => {
+            const requestedAmount = accruedValue - 1
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+
+          context('when the requested amount is equal to the total accrued value', () => {
+            const requestedAmount = accruedValue
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+        })
+
+        context('when the employee does not have pending reimbursements', () => {
+          context('when the requested amount is greater than zero', () => {
+            const requestedAmount = 100
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+
+          context('when the requested amount is zero', () => {
+            const requestedAmount = 0
+
+            it('reverts', async () => {
+              await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_NOTHING_PAID')
+            })
+          })
+        })
+      })
+    })
+
+    context('when the sender is not an employee', () => {
+      const from = anyone
+
+      context('when the requested amount is greater than zero', () => {
+        const requestedAmount = 100
+
+        it('reverts', async () => {
+          await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_EMPLOYEE_DOES_NOT_MATCH')
+        })
+      })
+
+      context('when the requested amount is zero', () => {
+        const requestedAmount = 0
+
+        it('reverts', async () => {
+          await assertRevert(payroll.partialReimburse(requestedAmount, { from }), 'PAYROLL_EMPLOYEE_DOES_NOT_MATCH')
+        })
+      })
+    })
   })
 })

--- a/shared/test-helpers/assertThrow.js
+++ b/shared/test-helpers/assertThrow.js
@@ -1,26 +1,29 @@
-function assertError(error, s, message) {
-  assert.isAbove(error.message.search(s), -1, `${message}\n\t(error: ${error})`);
-}
+const THROW_ERROR_PREFIX = 'VM Exception while processing transaction: revert'
 
-async function assertThrows(block, message, errorCode) {
+async function assertThrows(blockOrPromise, expectedErrorCode) {
   try {
-    await block()
-  } catch (e) {
-    return assertError(e, errorCode, message)
+    (typeof blockOrPromise === 'function') ? await blockOrPromise() : await blockOrPromise
+  } catch (error) {
+    assert(error.message.search(expectedErrorCode) > -1, `Expected error code "${expectedErrorCode}" but failed with "${error}" instead.`)
+    return error
   }
-  assert.fail('should have thrown before')
+  assert.fail(`Expected "${expectedErrorCode}" but it did not fail`)
 }
 
 module.exports = {
-  async assertJump(block, message = 'should have failed with invalid JUMP') {
-    return assertThrows(block, message, 'invalid JUMP')
+  async assertJump(blockOrPromise) {
+    return assertThrows(blockOrPromise, 'invalid JUMP')
   },
 
-  async assertInvalidOpcode(block, message = 'should have failed with invalid opcode') {
-    return assertThrows(block, message, 'invalid opcode')
+  async assertInvalidOpcode(blockOrPromise) {
+    return assertThrows(blockOrPromise, 'invalid opcode')
   },
 
-  async assertRevert(block, message = 'should have failed by reverting') {
-    return assertThrows(block, message, 'revert')
+  async assertRevert(blockOrPromise, expectedReason) {
+    const error = await assertThrows(blockOrPromise, 'revert')
+    if (expectedReason) {
+      const foundReason = error.message.replace(THROW_ERROR_PREFIX, '').trim()
+      assert.equal(expectedReason, foundReason, `Expected revert reason "${expectedReason}" but failed with "${foundReason || 'no reason'}" instead.`)
+    }
   },
 }


### PR DESCRIPTION
This PR revives what @bingen has been working on in order to avoid overflows while transferring the payroll + the accrued value ([see here](https://github.com/protofire/aragon-apps/pull/113)). However,  I'm proposing another alternative in order to deal with this edge case. The idea is to split the interface allowing the employees to request their salary or accrued value separately. 

Additionally, I used the verb `reimburse` to refer to the action of paying the accrued value to an employee, please let me know if there is a more suitable way to refer to it (cc @izqui @luisivan).