### PR TITLE
Voting: mock time in tests rather than use timetravel

### DIFF
--- a/apps/voting/contracts/test/mocks/VotingMock.sol
+++ b/apps/voting/contracts/test/mocks/VotingMock.sol
@@ -4,7 +4,7 @@ import "../../Voting.sol";
 
 
 contract VotingMock is Voting {
-    uint64 mockTime = uint64(now);
+    uint64 mockTime;
 
     function mock_setTimestamp(uint64 i) public { mockTime = i; }
     function getTimestamp64() internal view returns (uint64) { return mockTime; }

--- a/apps/voting/contracts/test/mocks/VotingMock.sol
+++ b/apps/voting/contracts/test/mocks/VotingMock.sol
@@ -4,6 +4,11 @@ import "../../Voting.sol";
 
 
 contract VotingMock is Voting {
+    uint64 mockTime = uint64(now);
+
+    function mock_setTimestamp(uint64 i) public { mockTime = i; }
+    function getTimestamp64() internal view returns (uint64) { return mockTime; }
+
     /* Ugly hack to work around this issue:
      * https://github.com/trufflesuite/truffle/issues/569
      * https://github.com/trufflesuite/truffle/issues/737


### PR DESCRIPTION
Must've forgot to do this back when we migrated to aragonOS@4 😅. `timeTravel()` isn't supported outside of Ganache, so we generally use the built-in time mocks in `AragonApp`.