### PR TITLE
Token Manager: use TimeHelpers and mock time in tests

### DIFF
--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -190,7 +190,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
 
         uint256 nonVested = _calculateNonVestedTokens(
             v.amount,
-            getTimestamp64(),
+            getTimestamp(),
             v.start,
             v.cliff,
             v.vesting
@@ -249,7 +249,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     * @return False if the controller does not authorize the transfer
     */
     function onTransfer(address _from, address _to, uint256 _amount) public onlyToken returns (bool) {
-        return _isBalanceIncreaseAllowed(_to, _amount) && _transferableBalance(_from, getTimestamp64()) >= _amount;
+        return _isBalanceIncreaseAllowed(_to, _amount) && _transferableBalance(_from, getTimestamp()) >= _amount;
     }
 
     /**
@@ -296,10 +296,10 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     }
 
     function spendableBalanceOf(address _holder) public view isInitialized returns (uint256) {
-        return _transferableBalance(_holder, getTimestamp64());
+        return _transferableBalance(_holder, getTimestamp());
     }
 
-    function transferableBalance(address _holder, uint64 _time) public view isInitialized returns (uint256) {
+    function transferableBalance(address _holder, uint256 _time) public view isInitialized returns (uint256) {
         return _transferableBalance(_holder, _time);
     }
 
@@ -389,7 +389,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         return tokens.sub(vestedTokens);
     }
 
-    function _transferableBalance(address _holder, uint64 _time) internal view returns (uint256) {
+    function _transferableBalance(address _holder, uint256 _time) internal view returns (uint256) {
         uint256 transferable = token.balanceOf(_holder);
 
         // This check is not strictly necessary for the current version of this contract, as

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -19,7 +19,6 @@ import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 contract TokenManager is ITokenController, IForwarder, AragonApp {
     using SafeMath for uint256;
-    using Uint256Helpers for uint256;
 
     bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
     bytes32 public constant ISSUE_ROLE = keccak256("ISSUE_ROLE");
@@ -250,7 +249,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     * @return False if the controller does not authorize the transfer
     */
     function onTransfer(address _from, address _to, uint256 _amount) public onlyToken returns (bool) {
-        return _isBalanceIncreaseAllowed(_to, _amount) && _transferableBalance(_from, now) >= _amount;
+        return _isBalanceIncreaseAllowed(_to, _amount) && _transferableBalance(_from, getTimestamp64()) >= _amount;
     }
 
     /**
@@ -297,10 +296,10 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
     }
 
     function spendableBalanceOf(address _holder) public view isInitialized returns (uint256) {
-        return _transferableBalance(_holder, now);
+        return _transferableBalance(_holder, getTimestamp64());
     }
 
-    function transferableBalance(address _holder, uint256 _time) public view isInitialized returns (uint256) {
+    function transferableBalance(address _holder, uint64 _time) public view isInitialized returns (uint256) {
         return _transferableBalance(_holder, _time);
     }
 
@@ -390,7 +389,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
         return tokens.sub(vestedTokens);
     }
 
-    function _transferableBalance(address _holder, uint256 _time) internal view returns (uint256) {
+    function _transferableBalance(address _holder, uint64 _time) internal view returns (uint256) {
         uint256 transferable = token.balanceOf(_holder);
 
         // This check is not strictly necessary for the current version of this contract, as
@@ -404,7 +403,7 @@ contract TokenManager is ITokenController, IForwarder, AragonApp {
                 TokenVesting storage v = vestings[_holder][i];
                 uint256 nonTransferable = _calculateNonVestedTokens(
                     v.amount,
-                    _time.toUint64(),
+                    _time,
                     v.start,
                     v.cliff,
                     v.vesting

--- a/apps/token-manager/contracts/test/mocks/TokenManagerMock.sol
+++ b/apps/token-manager/contracts/test/mocks/TokenManagerMock.sol
@@ -4,8 +4,8 @@ import "../../TokenManager.sol";
 
 
 contract TokenManagerMock is TokenManager {
-    uint64 mockTime = uint64(now);
+    uint256 mockTime;
 
-    function mock_setTimestamp(uint64 i) public { mockTime = i; }
-    function getTimestamp64() internal view returns (uint64) { return mockTime; }
+    function mock_setTimestamp(uint256 i) public { mockTime = i; }
+    function getTimestamp() internal view returns (uint256) { return mockTime; }
 }

--- a/apps/token-manager/contracts/test/mocks/TokenManagerMock.sol
+++ b/apps/token-manager/contracts/test/mocks/TokenManagerMock.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.4.24;
+
+import "../../TokenManager.sol";
+
+
+contract TokenManagerMock is TokenManager {
+    uint64 mockTime = uint64(now);
+
+    function mock_setTimestamp(uint64 i) public { mockTime = i; }
+    function getTimestamp64() internal view returns (uint64) { return mockTime; }
+}


### PR DESCRIPTION
Builds on #734, but should be merged separately.

Similar to #737, we should use the built-in `TimeHelpers` and time mocking instead of relying on `now` and `timeTravel()`.