### PR TITLE
Finance: test revert strings

### DIFF
--- a/apps/agent/test/agent.js
+++ b/apps/agent/test/agent.js
@@ -1,6 +1,6 @@
 const Agent = artifacts.require('Agent')
 
-const { assertRevert, assertInvalidOpcode } = require('@aragon/test-helpers/assertThrow')
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { hash: namehash } = require('eth-ens-namehash')
 const ethUtil = require('ethereumjs-util')
 const getBalance = require('@aragon/test-helpers/balance')(web3)

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -1,5 +1,5 @@
 const assertEvent = require('@aragon/test-helpers/assertEvent')
-const { assertRevert, assertInvalidOpcode } = require('@aragon/test-helpers/assertThrow')
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const getBalance = require('@aragon/test-helpers/balance')(web3)
 
 const Finance = artifacts.require('FinanceMock')

--- a/apps/finance/test/finance.js
+++ b/apps/finance/test/finance.js
@@ -183,31 +183,27 @@ contract('Finance App', accounts => {
     })
 
     it('fails on reinitialization', async () => {
-        await assertRevert(async () => {
-            await finance.initialize(vault.address, PERIOD_DURATION)
-        }, errors.INIT_ALREADY_INITIALIZED)
+        await assertRevert(finance.initialize(vault.address, PERIOD_DURATION), errors.INIT_ALREADY_INITIALIZED)
     })
 
     it('cannot initialize base app', async () => {
         const newFinance = await Finance.new()
         assert.isTrue(await newFinance.isPetrified())
-        await assertRevert(async () => {
-            await newFinance.initialize(vault.address, PERIOD_DURATION)
-        }, errors.INIT_ALREADY_INITIALIZED)
+        await assertRevert(newFinance.initialize(vault.address, PERIOD_DURATION), errors.INIT_ALREADY_INITIALIZED)
     })
 
     it('fails on initializing with no vault', async () => {
         const { financeApp } = await newProxyFinance()
 
-        await assertRevert(() => financeApp.initialize(0, PERIOD_DURATION), errors.FINANCE_VAULT_NOT_CONTRACT)
-        await assertRevert(() => financeApp.initialize(withdrawAddr, PERIOD_DURATION), errors.FINANCE_VAULT_NOT_CONTRACT)
+        await assertRevert(financeApp.initialize(0, PERIOD_DURATION), errors.FINANCE_VAULT_NOT_CONTRACT)
+        await assertRevert(financeApp.initialize(withdrawAddr, PERIOD_DURATION), errors.FINANCE_VAULT_NOT_CONTRACT)
     })
 
     it('fails on initializing with less than one day period', async () => {
         const badPeriod = 60 * 60 * 24 - 1
         const { financeApp } = await newProxyFinance()
 
-        await assertRevert(() => financeApp.initialize(vault.address, badPeriod), errors.FINANCE_INIT_PERIOD_TOO_SHORT)
+        await assertRevert(financeApp.initialize(vault.address, badPeriod), errors.FINANCE_INIT_PERIOD_TOO_SHORT)
     })
 
     it('adds new token to budget', async () => {
@@ -289,9 +285,7 @@ contract('Finance App', accounts => {
             })
 
             it('fails on no value deposits', async () => {
-                await assertRevert(() => {
-                  return finance.deposit(tokenInstance.address, 0, 'ref')
-                }, errors.FINANCE_DEPOSIT_AMOUNT_ZERO)
+                await assertRevert(finance.deposit(tokenInstance.address, 0, 'ref'), errors.FINANCE_DEPOSIT_AMOUNT_ZERO)
             })
         })
     }
@@ -375,16 +369,12 @@ contract('Finance App', accounts => {
             })
 
             it('fail to be recovered using AragonApp#transferToVault', async () => {
-                await assertRevert(() => (
-                    finance.transferToVault(tokenInstance.address)
-                ), errors.RECOVER_DISALLOWED)
+                await assertRevert(finance.transferToVault(tokenInstance.address), errors.RECOVER_DISALLOWED)
             })
 
             it('fail to be recovered if token balance is 0', async () => {
                 // if current balance is zero, it reverts
-                await assertRevert(async () => (
-                    finance.recoverToVault(token2.address)
-                ), errors.FINANCE_RECOVER_AMOUNT_ZERO)
+                await assertRevert(finance.recoverToVault(token2.address), errors.FINANCE_RECOVER_AMOUNT_ZERO)
             })
         })
     }
@@ -420,18 +410,14 @@ contract('Finance App', accounts => {
         })
 
         it('fails to be recovered using AragonApp#transferToVault', async () => {
-            await assertRevert(() => (
-                finance.transferToVault(ETH)
-            ), errors.RECOVER_DISALLOWED)
+            await assertRevert(finance.transferToVault(ETH), errors.RECOVER_DISALLOWED)
         })
 
         it('fails to be recovered if ETH balance is 0', async () => {
             await finance.recoverToVault(ETH)
 
             // if current balance is zero, it reverts
-            await assertRevert(async () => (
-                finance.recoverToVault(ETH)
-            ), errors.FINANCE_RECOVER_AMOUNT_ZERO)
+            await assertRevert(finance.recoverToVault(ETH), errors.FINANCE_RECOVER_AMOUNT_ZERO)
         })
     })
 
@@ -471,12 +457,8 @@ contract('Finance App', accounts => {
             // executes up to 10 times every 2 seconds
             await finance.newScheduledPayment(token1.address, recipient, amount, time, 2, 10, 'ref')
 
-            await assertRevert(async () => {
-                await finance.getPayment(0)
-            }, errors.FINANCE_NO_SCHEDULED_PAYMENT)
-            await assertRevert(async () => {
-                await finance.getPayment(2)
-            }, errors.FINANCE_NO_SCHEDULED_PAYMENT)
+            await assertRevert(finance.getPayment(0), errors.FINANCE_NO_SCHEDULED_PAYMENT)
+            await assertRevert(finance.getPayment(2), errors.FINANCE_NO_SCHEDULED_PAYMENT)
         })
 
         it('fails trying to get transaction out of bounds', async () => {
@@ -484,9 +466,7 @@ contract('Finance App', accounts => {
             // executes up to 10 times every 2 seconds
             await finance.newScheduledPayment(token1.address, recipient, amount, time, 2, 10, 'ref')
 
-            await assertRevert(async () => {
-                await finance.getTransaction(2)
-            }, errors.FINANCE_NO_TRANSACTION)
+            await assertRevert(finance.getTransaction(2), errors.FINANCE_NO_TRANSACTION)
         })
 
         it('can create single payment transaction', async () => {
@@ -573,9 +553,7 @@ contract('Finance App', accounts => {
         it('doesnt record payment for single payment transaction', async () => {
             const receipt = await finance.newImmediatePayment(token1.address, recipient, 1, '')
             assertEvent(receipt, 'NewPayment', 0)
-            await assertRevert(async () => {
-                await finance.getPayment(1)
-            }, errors.FINANCE_NO_SCHEDULED_PAYMENT)
+            await assertRevert(finance.getPayment(1), errors.FINANCE_NO_SCHEDULED_PAYMENT)
         })
 
         context('multitransaction period', async () => {
@@ -621,9 +599,7 @@ contract('Finance App', accounts => {
                 await finance.tryTransitionAccountingPeriod(1)
 
                 const currentPeriodId = await finance.currentPeriodId()
-                await assertRevert(async () => {
-                    await finance.getPeriod(currentPeriodId + 1)
-                }, errors.FINANCE_NO_PERIOD)
+                await assertRevert(finance.getPeriod(currentPeriodId + 1), errors.FINANCE_NO_PERIOD)
             })
         })
 
@@ -638,14 +614,13 @@ contract('Finance App', accounts => {
 
             it('fails when too many period transitions are needed', async () => {
                 // Normal payments
-                await assertRevert(async () => {
-                    await finance.newImmediatePayment(token1.address, recipient, 10, '')
-                }, errors.FINANCE_COMPLETE_TRANSITION)
+                await assertRevert(
+                    finance.newImmediatePayment(token1.address, recipient, 10, ''),
+                    errors.FINANCE_COMPLETE_TRANSITION
+                )
 
                 // Direct ETH transfers
-                await assertRevert(async () => {
-                    await finance.send(10, { gas: 3e5 })
-                }, errors.FINANCE_COMPLETE_TRANSITION)
+                await assertRevert(finance.send(10, { gas: 3e5 }), errors.FINANCE_COMPLETE_TRANSITION)
             })
 
             it('can transition periods externally to remove deadlock for payments', async () => {
@@ -692,27 +667,30 @@ contract('Finance App', accounts => {
             })
 
             it('fails to create a zero-amount single payment', async () => {
-                await assertRevert(async () => {
-                    await finance.newImmediatePayment(token1.address, recipient, 0, '')
-                }, errors.FINANCE_NEW_PAYMENT_AMOUNT_ZERO)
+                await assertRevert(
+                    finance.newImmediatePayment(token1.address, recipient, 0, ''),
+                    errors.FINANCE_NEW_PAYMENT_AMOUNT_ZERO
+                )
             })
 
             it('fails to create a single payment too high for the current budget', async () => {
                 const budget = 10
                 await finance.setBudget(token1.address, budget)
 
-                await assertRevert(() => {
-                    return finance.newImmediatePayment(token1.address, recipient, budget + 1, '')
-                }, errors.FINANCE_REMAINING_BUDGET)
+                await assertRevert(
+                    finance.newImmediatePayment(token1.address, recipient, budget + 1, ''),
+                    errors.FINANCE_REMAINING_BUDGET
+                )
             })
 
             it('fails to execute a single payment without enough funds', async () => {
                 const vaultBalance = await vault.balance(token1.address)
                 await finance.removeBudget(token1.address) // clear any budget restrictions
 
-                await assertRevert(async () => {
-                    await finance.newImmediatePayment(token1.address, recipient, vaultBalance + 1, '')
-                }, errors.VAULT_TOKEN_TRANSFER_REVERTED)
+                await assertRevert(
+                    finance.newImmediatePayment(token1.address, recipient, vaultBalance + 1, ''),
+                    errors.VAULT_TOKEN_TRANSFER_REVERTED
+                )
             })
         })
 
@@ -746,30 +724,34 @@ contract('Finance App', accounts => {
             })
 
             it('fails to create a zero-amount payment', async () => {
-                await assertRevert(async () => {
-                    await finance.newScheduledPayment(token1.address, recipient, 0, time + 1, 1, 2, '')
-                }, errors.FINANCE_NEW_PAYMENT_AMOUNT_ZERO)
+                await assertRevert(
+                    finance.newScheduledPayment(token1.address, recipient, 0, time + 1, 1, 2, ''),
+                    errors.FINANCE_NEW_PAYMENT_AMOUNT_ZERO
+                )
             })
 
             it('fails to create a no-interval payment', async () => {
-                await assertRevert(async () => {
-                    await finance.newScheduledPayment(token1.address, recipient, 1, time + 1, 0, 2, '')
-                }, errors.FINANCE_NEW_PAYMENT_INTRVL_ZERO)
+                await assertRevert(
+                    finance.newScheduledPayment(token1.address, recipient, 1, time + 1, 0, 2, ''),
+                    errors.FINANCE_NEW_PAYMENT_INTRVL_ZERO
+                )
             })
 
             it('fails to create a no-executions payment', async () => {
-                await assertRevert(async () => {
-                    await finance.newScheduledPayment(token1.address, recipient, 1, time + 1, 1, 0, '')
-                }, errors.FINANCE_NEW_PAYMENT_EXECS_ZERO)
+                await assertRevert(
+                    finance.newScheduledPayment(token1.address, recipient, 1, time + 1, 1, 0, ''),
+                    errors.FINANCE_NEW_PAYMENT_EXECS_ZERO
+                )
             })
 
             it('fails to create a new one-time payment without enough budget', async () => {
                 const budget = 10
                 await finance.setBudget(token1.address, budget)
 
-                await assertRevert(async () => {
-                    await finance.newScheduledPayment(token1.address, recipient, budget + 1, time, 1, 1, '')
-                }, errors.FINANCE_BUDGET)
+                await assertRevert(
+                    finance.newScheduledPayment(token1.address, recipient, budget + 1, time, 1, 1, ''),
+                    errors.FINANCE_BUDGET
+                )
             })
 
             it('fails to create a new one-time payment without enough funds', async () => {
@@ -777,15 +759,14 @@ contract('Finance App', accounts => {
                 await finance.removeBudget(token1.address) // clear any budget restrictions
 
                 // TODO
-                await assertRevert(async () => {
-                    await finance.newScheduledPayment(token1.address, recipient, vaultBalance + 1, time, 1, 1, '')
-                })
+                await assertRevert(finance.newScheduledPayment(token1.address, recipient, vaultBalance + 1, time, 1, 1, ''))
             })
 
             it('fails to create an immediate single payment', async () => {
-                await assertRevert(async () => {
-                    await finance.newScheduledPayment(token1.address, recipient, 1, time - 1, 1, 1, '')
-                }, errors.FINANCE_NEW_PAYMENT_IMMEDIATE)
+                await assertRevert(
+                    finance.newScheduledPayment(token1.address, recipient, 1, time - 1, 1, 1, ''),
+                    errors.FINANCE_NEW_PAYMENT_IMMEDIATE
+                )
             })
 
             it('fails to create a scheduled payment too high for the current budget', async () => {
@@ -836,30 +817,44 @@ contract('Finance App', accounts => {
                 it('fails when non-receiver attempts to execute a payment', async () => {
                     await finance.mock_setTimestamp(time + 1)
 
-                    await assertRevert(async () => {
-                        await finance.receiverExecutePayment(paymentId)
-                    }, errors.FINANCE_PAYMENT_RECEIVER)
+                    await assertRevert(finance.receiverExecutePayment(paymentId), errors.FINANCE_PAYMENT_RECEIVER)
                 })
 
                 it('fails to execute a scheduled payment before next available time', async () => {
-                    await assertRevert(async () => {
-                        await finance.executePayment(paymentId, { from: recipient })
-                    }, errors.FINANCE_EXECUTE_PAYMENT_TIME)
+                    await assertRevert(
+                        finance.executePayment(paymentId, { from: recipient }),
+                        errors.FINANCE_EXECUTE_PAYMENT_TIME
+                    )
                 })
 
                 it('fails to execute a scheduled payment by receiver before next available time', async () => {
-                    await assertRevert(async () => {
-                        await finance.receiverExecutePayment(paymentId, { from: recipient })
-                    }, errors.FINANCE_EXECUTE_PAYMENT_TIME)
+                    await assertRevert(
+                        finance.receiverExecutePayment(paymentId, { from: recipient }),
+                        errors.FINANCE_EXECUTE_PAYMENT_TIME
+                    )
+                })
+
+                it('fails to execute a recurring payment without enough funds', async () => {
+                    const vaultBalance = await vault.balance(token1.address)
+                    await finance.removeBudget(token1.address) // clear any budget restrictions
+
+                    const receipt = await finance.newScheduledPayment(token1.address, recipient, vaultBalance + 1, time, 1, 2, '')
+                    const newScheduledPaymentId = getEventData(receipt, 'NewPayment', 'paymentId')
+
+                    await assertRevert(
+                        finance.executePayment(newScheduledPaymentId, { from: recipient }),
+                        errors.FINANCE_EXECUTE_PAYMENT_NUM
+                    )
                 })
 
                 it('fails to execute inactive scheduled payment', async () => {
                     await finance.setPaymentStatus(paymentId, false)
                     await finance.mock_setTimestamp(time + 1)
 
-                    await assertRevert(async () => {
-                        await finance.executePayment(paymentId, { from: recipient })
-                    }, errors.FINANCE_PAYMENT_INACTIVE)
+                    await assertRevert(
+                        finance.executePayment(paymentId, { from: recipient }),
+                        errors.FINANCE_PAYMENT_INACTIVE
+                    )
                 })
 
                 it('succeeds payment after setting payment status to active', async () => {
@@ -935,9 +930,10 @@ contract('Finance App', accounts => {
             const time = 22
             await nonInit.mock_setTimestamp(time)
 
-            await assertRevert(async() => {
-                await nonInit.newScheduledPayment(token1.address, recipient, amount, time, 1, 2, 'ref')
-            }, errors.APP_AUTH_FAILED)
+            await assertRevert(
+                nonInit.newScheduledPayment(token1.address, recipient, amount, time, 1, 2, 'ref'),
+                errors.APP_AUTH_FAILED
+            )
         })
 
         it('fails to create new single payment transaction', async() => {
@@ -946,22 +942,19 @@ contract('Finance App', accounts => {
             const time = 22
             await nonInit.mock_setTimestamp(time)
 
-            await assertRevert(async() => {
-                await nonInit.newImmediatePayment(token1.address, recipient, amount, 'ref')
-            }, errors.APP_AUTH_FAILED)
+            await assertRevert(
+                nonInit.newImmediatePayment(token1.address, recipient, amount, 'ref'),
+                errors.APP_AUTH_FAILED
+            )
         })
 
         it('fails to deposit ERC20 tokens', async() => {
             await token1.approve(nonInit.address, 5)
-            await assertRevert(async() => {
-                await nonInit.deposit(token1.address, 5, 'ref')
-            }, errors.INIT_NOT_INITIALIZED)
+            await assertRevert(nonInit.deposit(token1.address, 5, 'ref'), errors.INIT_NOT_INITIALIZED)
         })
 
         it('fails to deposit ETH', async() => {
-            await assertRevert(async() => {
-                await nonInit.send(10, { gas: 3e5 })
-            }, errors.INIT_NOT_INITIALIZED)
+            await assertRevert(nonInit.send(10, { gas: 3e5 }), errors.INIT_NOT_INITIALIZED)
         })
 
         context('locked ERC20', () => {
@@ -983,9 +976,7 @@ contract('Finance App', accounts => {
             })
 
             it('fails to be recovered using Finance#recoverToVault', async () => {
-                await assertRevert(async () => (
-                    finance.recoverToVault(token1.address)
-                ), errors.INIT_NOT_INITIALIZED)
+                await assertRevert(finance.recoverToVault(token1.address), errors.INIT_NOT_INITIALIZED)
             })
         })
 
@@ -1008,9 +999,7 @@ contract('Finance App', accounts => {
             })
 
             it('fails to be recovered using Finance#recoverToVault', async () => {
-                await assertRevert(async () => (
-                    await nonInit.recoverToVault(ETH)
-                ), errors.INIT_NOT_INITIALIZED)
+                await assertRevert(nonInit.recoverToVault(ETH), errors.INIT_NOT_INITIALIZED)
             })
         })
     })

--- a/apps/survey/test/survey.js
+++ b/apps/survey/test/survey.js
@@ -1,4 +1,4 @@
-const { assertInvalidOpcode, assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
 const timeTravel = require('@aragon/test-helpers/timeTravel')(web3)
 

--- a/apps/vault/test/vault_shared.js
+++ b/apps/vault/test/vault_shared.js
@@ -1,4 +1,4 @@
-const { assertRevert, assertInvalidOpcode } = require('@aragon/test-helpers/assertThrow')
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { hash } = require('eth-ens-namehash')
 const getBalanceFn = require('@aragon/test-helpers/balance')
 

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -682,7 +682,7 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
                 // Divide by 100 for the allocation and by ONE for the exchange rate
                 tokenAmount = tokenAmount / (100 * ONE);
                 address employeeAddress = employee.accountAddress;
-                finance.newPayment(token, employeeAddress, tokenAmount, 0, 0, 1, _reference);
+                finance.newImmediatePayment(token, employeeAddress, tokenAmount, _reference);
                 emit SendPayment(employeeAddress, token, tokenAmount, _reference);
                 somethingPaid = true;
             }

--- a/shared/test-helpers/utils.js
+++ b/shared/test-helpers/utils.js
@@ -1,0 +1,16 @@
+module.exports = {
+  makeErrorMappingProxy (target) {
+    return new Proxy(target, {
+      get (target, property) {
+        if (property in target) {
+          return target[property]
+        }
+
+        throw new Error(`Could not find error ${property} in error mapping`)
+      },
+      set () {
+        throw new Error('Unexpected set to error mapping')
+      }
+    })
+  }
+}


### PR DESCRIPTION
Builds on #739, but should be merged separately.

Cherry-picks the change by @facuspagnuolo in https://github.com/aragon/aragon-apps/pull/736/commits/6964450e3d56159fd8049d6a3c7a4a4bf2de79a1 (to place it in `next`) and builds off of it.

Found a few previously broken tests with the revert strings 😄.