### PR TITLE
Payroll: Improve timestamps mocking

### DIFF
--- a/future-apps/payroll/contracts/test/mocks/PayrollMock.sol
+++ b/future-apps/payroll/contracts/test/mocks/PayrollMock.sol
@@ -1,18 +1,11 @@
 pragma solidity 0.4.24;
 
 import "../../Payroll.sol";
+import "@aragon/test-helpers/contracts/TimeHelpersMock.sol";
 
 
-contract PayrollMock is Payroll {
-    uint64 private _mockTime = uint64(now);
-
-    function mockUpdateTimestamp() public { _mockTime = uint64(now); }
-    function mockSetTimestamp(uint64 i) public { _mockTime = i; }
-    function mockAddTimestamp(uint64 i) public { _mockTime += i; require(_mockTime >= i); }
-    function getTimestampPublic() public view returns (uint64) { return _mockTime; }
-    function getMaxAccruedValue() public view returns (uint256) { return MAX_UINT256; }
-    function getMaxAllowedTokens() public view returns (uint256) { return MAX_ALLOWED_TOKENS; }
+contract PayrollMock is Payroll, TimeHelpersMock {
+    function getMaxAccruedValue() public pure returns (uint256) { return MAX_UINT256; }
+    function getMaxAllowedTokens() public pure returns (uint256) { return MAX_ALLOWED_TOKENS; }
     function getAllowedTokensArrayLength() public view returns (uint256) { return allowedTokensArray.length; }
-    function getTimestamp() internal view returns (uint256) { return uint256(_mockTime); }
-    function getTimestamp64() internal view returns (uint64) { return _mockTime; }
 }

--- a/future-apps/payroll/contracts/test/mocks/PriceFeedMock.sol
+++ b/future-apps/payroll/contracts/test/mocks/PriceFeedMock.sol
@@ -1,16 +1,16 @@
 pragma solidity ^0.4.24;
 
 import "@aragon/ppf-contracts/contracts/IFeed.sol";
+import "@aragon/test-helpers/contracts/TimeHelpersMock.sol";
 
 
-contract PriceFeedMock is IFeed {
-    uint private _mockTime = now;
+contract PriceFeedMock is IFeed, TimeHelpersMock {
 
     event PriceFeedLogSetRate(address sender, address token, uint128 value);
 
     function get(address base, address quote) external view returns (uint128 xrt, uint64 when) {
         xrt = toInt(quote);
-        when = uint64(_mockTime);
+        when = getTimestamp64();
 
         emit PriceFeedLogSetRate(msg.sender, quote, xrt);
     }
@@ -24,15 +24,6 @@ contract PriceFeedMock is IFeed {
         else
             j = j * 10**18;
         i = uint128(j);
-    }
-
-    function mockSetTimestamp(uint _time) public {
-        _mockTime = _time;
-    }
-
-    function mockAddTimestamp(uint64 time) public {
-        _mockTime += time;
-        require(_mockTime >= time);
     }
 
 }

--- a/future-apps/payroll/test/contracts/Payroll_forwarding.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_forwarding.test.js
@@ -68,7 +68,7 @@ contract('Payroll forwarding,', ([owner, employee, anotherEmployee, anyone]) => 
         context('when the employee was already terminated', () => {
           beforeEach('terminate employee', async () => {
             await payroll.terminateEmployeeNow(employeeId, { from: owner })
-            await payroll.mockAddTimestamp(ONE_MONTH + 1)
+            await payroll.mockIncreaseTime(ONE_MONTH + 1)
           })
 
           it('returns true', async () => {
@@ -127,7 +127,7 @@ contract('Payroll forwarding,', ([owner, employee, anotherEmployee, anyone]) => 
         context('when the employee was already terminated', () => {
           beforeEach('terminate employee', async () => {
             await payroll.terminateEmployeeNow(employeeId, { from: owner })
-            await payroll.mockAddTimestamp(ONE_MONTH + 1)
+            await payroll.mockIncreaseTime(ONE_MONTH + 1)
           })
 
           it('executes the given script', async () =>  {

--- a/future-apps/payroll/test/contracts/Payroll_modify_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_modify_employee.test.js
@@ -55,10 +55,10 @@ contract('Payroll employees modification', ([owner, employee, anotherEmployee, a
               })
 
               it('adds previous owed salary to the accrued value', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
 
                 await payroll.setEmployeeSalary(employeeId, newSalary, { from })
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
 
                 const accruedValue = (await payroll.getEmployee(employeeId))[2]
                 assert.equal(accruedValue.toString(), previousSalary * ONE_MONTH, 'accrued value does not match')
@@ -90,7 +90,7 @@ contract('Payroll employees modification', ([owner, employee, anotherEmployee, a
           context('when the given employee is not active', () => {
             beforeEach('terminate employee', async () => {
               await payroll.terminateEmployeeNow(employeeId, { from: owner })
-              await payroll.mockAddTimestamp(ONE_MONTH)
+              await payroll.mockIncreaseTime(ONE_MONTH)
             })
 
             it('reverts', async () => {
@@ -198,7 +198,7 @@ contract('Payroll employees modification', ([owner, employee, anotherEmployee, a
         context('when the given employee is not active', () => {
           beforeEach('terminate employee', async () => {
             await payroll.terminateEmployeeNow(employeeId, { from: owner })
-            await payroll.mockAddTimestamp(ONE_MONTH)
+            await payroll.mockIncreaseTime(ONE_MONTH)
           })
 
           itHandlesChangingEmployeeAddressSuccessfully()

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -57,7 +57,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
 
             context('when the employee has some pending salary', () => {
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               const assertTransferredAmounts = () => {
@@ -109,8 +109,8 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
 
                   await payroll.payday({ from })
 
-                  await payroll.mockAddTimestamp(ONE_MONTH)
-                  await priceFeed.mockAddTimestamp(ONE_MONTH)
+                  await payroll.mockIncreaseTime(ONE_MONTH)
+                  await priceFeed.mockIncreaseTime(ONE_MONTH)
                   await payroll.payday({ from })
 
                   const currentDenominationTokenBalance = await denominationToken.balanceOf(employee)
@@ -220,7 +220,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
           context('when the employee did not set any token allocations yet', () => {
             context('when the employee has some pending salary', () => {
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               it('reverts', async () => {
@@ -303,7 +303,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
 
             context('when the employee has some pending salary', () => {
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               itRevertsToWithdrawPayroll(nonExpiredRatesReason, expiredRatesReason)
@@ -317,7 +317,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
           context('when the employee did not set any token allocations yet', () => {
             context('when the employee has some pending salary', () => {
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               itRevertsToWithdrawPayroll('PAYROLL_NOTHING_PAID', 'PAYROLL_NOTHING_PAID')
@@ -400,7 +400,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
               const owedSalary = salary * ONE_MONTH
 
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               const assertTransferredAmounts = (requestedAmount, expectedRequestedAmount = requestedAmount) => {
@@ -452,8 +452,8 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
 
                   await payroll.partialPayday(requestedAmount, { from })
 
-                  await payroll.mockAddTimestamp(ONE_MONTH)
-                  await priceFeed.mockAddTimestamp(ONE_MONTH)
+                  await payroll.mockIncreaseTime(ONE_MONTH)
+                  await priceFeed.mockIncreaseTime(ONE_MONTH)
                   await payroll.partialPayday(requestedAmount, { from })
 
                   const currentDenominationTokenBalance = await denominationToken.balanceOf(employee)
@@ -682,7 +682,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
               const owedSalary = salary * ONE_MONTH
 
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               context('when the requested amount is less than the total owed salary', () => {
@@ -787,7 +787,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
           const itRevertsAnyAttemptToWithdrawPartialPayroll = () => {
             context('when the employee has some pending salary', () => {
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               context('when the requested amount is greater than zero', () => {
@@ -858,7 +858,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
               const owedSalary = maxUint256()
 
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               context('when the requested amount is zero', () => {
@@ -919,8 +919,8 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
 
                     await payroll.partialPayday(requestedAmount, { from })
 
-                    await payroll.mockAddTimestamp(ONE_MONTH)
-                    await priceFeed.mockAddTimestamp(ONE_MONTH)
+                    await payroll.mockIncreaseTime(ONE_MONTH)
+                    await priceFeed.mockIncreaseTime(ONE_MONTH)
                     await payroll.partialPayday(requestedAmount, { from })
 
                     const currentDenominationTokenBalance = await denominationToken.balanceOf(employee)
@@ -1032,7 +1032,7 @@ contract('Payroll payday', ([owner, employee, anotherEmployee, anyone]) => {
               const owedSalary = maxUint256()
 
               beforeEach('accumulate some pending salary', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
               })
 
               context('when the requested amount is zero', () => {

--- a/future-apps/payroll/test/contracts/Payroll_reimbursements.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_reimbursements.test.js
@@ -88,7 +88,7 @@ contract('Payroll reimbursements', ([owner, employee, anotherEmployee, anyone]) 
           context('when the given employee is not active', () => {
             beforeEach('terminate employee', async () => {
               await payroll.terminateEmployeeNow(employeeId, { from: owner })
-              await payroll.mockAddTimestamp(ONE_MONTH)
+              await payroll.mockIncreaseTime(ONE_MONTH)
             })
 
             it('reverts', async () => {
@@ -141,7 +141,7 @@ contract('Payroll reimbursements', ([owner, employee, anotherEmployee, anyone]) 
           const receipt = await payroll.addEmployeeNow(employee, salary, 'Boss')
           employeeId = getEventArgument(receipt, 'AddEmployee', 'employeeId')
 
-          await payroll.mockAddTimestamp(ONE_MONTH)
+          await payroll.mockIncreaseTime(ONE_MONTH)
         })
 
         context('when the employee has already set some token allocations', () => {
@@ -335,7 +335,7 @@ contract('Payroll reimbursements', ([owner, employee, anotherEmployee, anyone]) 
           const receipt = await payroll.addEmployeeNow(employee, salary, 'Boss')
           employeeId = getEventArgument(receipt, 'AddEmployee', 'employeeId')
 
-          await payroll.mockAddTimestamp(ONE_MONTH)
+          await payroll.mockIncreaseTime(ONE_MONTH)
         })
 
         context('when the employee has already set some token allocations', () => {

--- a/future-apps/payroll/test/contracts/Payroll_terminate_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_terminate_employee.test.js
@@ -73,14 +73,14 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
               await payroll.determineAllocation([denominationToken.address], [100], { from: employee })
 
               // Accrue some salary and extras
-              await payroll.mockAddTimestamp(ONE_MONTH)
+              await payroll.mockIncreaseTime(ONE_MONTH)
               const owedSalary = salary.mul(ONE_MONTH)
               const accruedValue = 1000
               await payroll.addAccruedValue(employeeId, accruedValue, { from: owner })
 
               // Terminate employee and travel some time in the future
               await payroll.terminateEmployeeNow(employeeId, { from })
-              await payroll.mockAddTimestamp(ONE_MONTH)
+              await payroll.mockIncreaseTime(ONE_MONTH)
 
               // Request owed money
               await payroll.payday({ from: employee })
@@ -94,11 +94,11 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
 
             it('can re-add a removed employee', async () => {
               await payroll.determineAllocation([denominationToken.address], [100], { from: employee })
-              await payroll.mockAddTimestamp(ONE_MONTH)
+              await payroll.mockIncreaseTime(ONE_MONTH)
 
               // Terminate employee and travel some time in the future
               await payroll.terminateEmployeeNow(employeeId, { from })
-              await payroll.mockAddTimestamp(ONE_MONTH)
+              await payroll.mockIncreaseTime(ONE_MONTH)
 
               // Request owed money
               await payroll.payday({ from: employee })
@@ -120,7 +120,7 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
           context('when the employee was already terminated', () => {
             beforeEach('terminate employee', async () => {
               await payroll.terminateEmployeeNow(employeeId, { from })
-              await payroll.mockAddTimestamp(ONE_MONTH + 1)
+              await payroll.mockIncreaseTime(ONE_MONTH + 1)
             })
 
             it('reverts', async () => {
@@ -210,14 +210,14 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
                 await payroll.determineAllocation([denominationToken.address], [100], { from: employee })
 
                 // Accrue some salary and extras
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
                 const owedSalary = salary.times(ONE_MONTH)
                 const accruedValue = 1000
                 await payroll.addAccruedValue(employeeId, accruedValue, { from: owner })
 
                 // Terminate employee and travel some time in the future
                 await payroll.terminateEmployee(employeeId, endDate, { from })
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
 
                 // Request owed money
                 await payroll.payday({ from: employee })
@@ -231,11 +231,11 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
 
               it('can re-add a removed employee', async () => {
                 await payroll.determineAllocation([denominationToken.address], [100], { from: employee })
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
 
                 // Terminate employee and travel some time in the future
                 await payroll.terminateEmployee(employeeId, endDate, { from })
-                await payroll.mockAddTimestamp(ONE_MONTH)
+                await payroll.mockIncreaseTime(ONE_MONTH)
 
                 // Request owed money
                 await payroll.payday({ from: employee })
@@ -257,7 +257,7 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
             context('when the given end date is in the past', () => {
               beforeEach('set future end date', async () => {
                 endDate = await currentTimestamp()
-                await payroll.mockAddTimestamp(ONE_MONTH + 1)
+                await payroll.mockIncreaseTime(ONE_MONTH + 1)
               })
 
               it('reverts', async () => {
@@ -283,7 +283,7 @@ contract('Payroll employees termination', ([owner, employee, anotherEmployee, an
 
             context('when the previous end date was reached', () => {
               beforeEach('travel in the future', async () => {
-                await payroll.mockAddTimestamp(ONE_MONTH + 1)
+                await payroll.mockIncreaseTime(ONE_MONTH + 1)
               })
 
               it('reverts', async () => {

--- a/future-apps/payroll/test/contracts/Payroll_token_allocations.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_token_allocations.test.js
@@ -178,7 +178,7 @@ contract('Payroll token allocations', ([owner, employee, anotherEmployee, anyone
         context('when the employee is not active', () => {
           beforeEach('terminate employee', async () => {
             await payroll.terminateEmployeeNow(employeeId, { from: owner })
-            await payroll.mockAddTimestamp(ONE_MONTH)
+            await payroll.mockIncreaseTime(ONE_MONTH)
           })
 
           itShouldHandleAllocationsProperly()
@@ -292,7 +292,7 @@ contract('Payroll token allocations', ([owner, employee, anotherEmployee, anyone
         context('when the employee is not active', () => {
           beforeEach('terminate employee', async () => {
             await payroll.terminateEmployeeNow(employeeId, { from: owner })
-            await payroll.mockAddTimestamp(ONE_MONTH)
+            await payroll.mockIncreaseTime(ONE_MONTH)
           })
 
           itShouldAnswerAllocationsProperly()

--- a/shared/test-helpers/contracts/TimeHelpersMock.sol
+++ b/shared/test-helpers/contracts/TimeHelpersMock.sol
@@ -1,0 +1,67 @@
+pragma solidity ^0.4.24;
+
+import "@aragon/os/contracts/common/TimeHelpers.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
+import "@aragon/os/contracts/lib/math/SafeMath64.sol";
+
+
+contract TimeHelpersMock is TimeHelpers {
+    using SafeMath for uint256;
+    using SafeMath64 for uint64;
+
+    uint256 mockedTimestamp;
+    uint256 mockedBlockNumber;
+
+    /**
+    * @dev Sets a mocked timestamp value, used only for testing purposes
+    */
+    function mockSetTimestamp(uint256 _timestamp) public {
+        mockedTimestamp = _timestamp;
+    }
+
+    /**
+    * @dev Increases the mocked timestamp value, used only for testing purposes
+    */
+    function mockIncreaseTime(uint256 _seconds) public {
+        if (mockedTimestamp != 0) mockedTimestamp = mockedTimestamp.add(_seconds);
+        else mockedTimestamp = block.timestamp.add(_seconds);
+    }
+
+    /**
+    * @dev Advances the mocked block number value, used only for testing purposes
+    */
+    function mockAdvanceBlocks(uint256 _number) public {
+        if (mockedBlockNumber != 0) mockedBlockNumber = mockedBlockNumber.add(_number);
+        else mockedBlockNumber = block.number.add(_number);
+    }
+
+    /**
+    * @dev Returns the mocked timestamp value
+    */
+    function getTimestampPublic() public view returns (uint64) {
+        return getTimestamp64();
+    }
+
+    /**
+    * @dev Returns the mocked block number value
+    */
+    function getBlockNumberPublic() public view returns (uint256) {
+        return getBlockNumber();
+    }
+
+    /**
+    * @dev Returns the mocked timestamp if it was set, or current `block.timestamp`
+    */
+    function getTimestamp() internal view returns (uint256) {
+        if (mockedTimestamp != 0) return mockedTimestamp;
+        return super.getTimestamp();
+    }
+
+    /**
+    * @dev Returns the mocked block number if it was set, or current `block.number`
+    */
+    function getBlockNumber() internal view returns (uint256) {
+        if (mockedBlockNumber != 0) return mockedBlockNumber;
+        return super.getBlockNumber();
+    }
+}


### PR DESCRIPTION
This PR improves timestamp mocking in a more consistent way and provides a new common mocking contract that can be easily re-used. 