### PR TITLE
[DO NOT MERGE] Finance: revert api incompatibility between v3 and v4

### DIFF
--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -34,10 +34,13 @@ class App extends React.Component {
   }
   handleWithdraw = (tokenAddress, recipient, amount, reference) => {
     // Immediate, one-time payment
-    this.props.api.newImmediatePayment(
+    this.props.api.newPayment(
       tokenAddress,
       recipient,
       amount,
+      0, // initial payment time
+      0, // interval
+      1, // max repeats
       reference
     )
     this.handleNewTransferClose()


### PR DESCRIPTION
Only useful for our staging environment when testing with the 0.6 version of Finance.