### PR TITLE
chore: increase travis cache timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 language: node_js
 cache:
+  timeout: 600
   directories:
     - node_modules
     - apps/agent/node_modules


### PR DESCRIPTION
Looks like the store cache was timing out with the default of 3min.