### PR TITLE
Finance: fix token fallbacks and error handling

### DIFF
--- a/apps/finance/app/src/components/NewTransfer/Deposit.js
+++ b/apps/finance/app/src/components/NewTransfer/Deposit.js
@@ -149,7 +149,11 @@ class Deposit extends React.Component {
     const token = api.external(address, tokenAbi)
 
     return new Promise(async (resolve, reject) => {
-      const userBalance = await token.balanceOf(connectedAccount).toPromise()
+      const userBalance = await token
+        .balanceOf(connectedAccount)
+        .toPromise()
+        // Assume no balance if the call failed
+        .catch(() => '0')
 
       const decimalsFallback =
         tokenDataFallback(address, 'decimals', network.type) || '0'
@@ -165,7 +169,11 @@ class Deposit extends React.Component {
 
       const [tokenSymbol, tokenDecimals] = await Promise.all([
         getTokenSymbol(api, address).catch(() => {}),
-        token.decimals().toPromise(),
+        token
+          .decimals()
+          .toPromise()
+          .then(decimals => parseInt(decimals, 10))
+          .catch(() => {}),
       ])
 
       // If symbol or decimals are resolved, overwrite the fallbacks
@@ -173,7 +181,7 @@ class Deposit extends React.Component {
         tokenData.symbol = tokenSymbol
       }
       if (tokenDecimals) {
-        tokenData.decimals = parseInt(tokenDecimals, 10)
+        tokenData.decimals = tokenDecimals
       }
 
       resolve(tokenData)

--- a/apps/finance/app/src/components/NewTransfer/Deposit.js
+++ b/apps/finance/app/src/components/NewTransfer/Deposit.js
@@ -134,18 +134,15 @@ class Deposit extends React.Component {
 
     // ETH
     if (addressesEqual(address, ETHER_TOKEN_FAKE_ADDRESS)) {
-      return new Promise((resolve, reject) =>
-        api.web3Eth('getBalance', connectedAccount).subscribe(
-          ethBalance =>
-            resolve({
-              decimals: 18,
-              loading: false,
-              symbol: 'ETH',
-              userBalance: ethBalance,
-            }),
-          reject
-        )
-      )
+      return api
+        .web3Eth('getBalance', connectedAccount)
+        .toPromise()
+        .then(ethBalance => ({
+          decimals: 18,
+          loading: false,
+          symbol: 'ETH',
+          userBalance: ethBalance,
+        }))
     }
 
     // Tokens
@@ -167,7 +164,7 @@ class Deposit extends React.Component {
       }
 
       const [tokenSymbol, tokenDecimals] = await Promise.all([
-        getTokenSymbol(api, address),
+        getTokenSymbol(api, address).catch(() => {}),
         token.decimals().toPromise(),
       ])
 

--- a/apps/finance/app/src/components/NewTransfer/Deposit.js
+++ b/apps/finance/app/src/components/NewTransfer/Deposit.js
@@ -45,7 +45,7 @@ const renderBalanceForSelectedToken = selectedToken => {
     return ''
   }
 
-  return userBalance === -1
+  return userBalance === '-1'
     ? `Your balance could not be found for ${symbol}`
     : `You have ${
         userBalance === '0' ? 'no' : fromDecimals(userBalance, decimals)

--- a/apps/finance/app/src/components/NewTransfer/Deposit.js
+++ b/apps/finance/app/src/components/NewTransfer/Deposit.js
@@ -39,6 +39,19 @@ const TOKEN_ALLOWANCE_WEBSITE = 'https://tokenallowance.io/'
 
 const tokenAbi = [].concat(tokenBalanceOfAbi, tokenDecimalsAbi, tokenSymbolAbi)
 
+const renderBalanceForSelectedToken = selectedToken => {
+  const { decimals, loading, symbol, userBalance } = selectedToken.data
+  if (loading || !userBalance) {
+    return ''
+  }
+
+  return userBalance === -1
+    ? `Your balance could not be found for ${symbol}`
+    : `You have ${
+        userBalance === '0' ? 'no' : fromDecimals(userBalance, decimals)
+      } ${symbol} available`
+}
+
 const initialState = {
   amount: {
     error: NO_ERROR,
@@ -129,63 +142,61 @@ class Deposit extends React.Component {
     const { selectedToken } = this.state
     return selectedToken.value && !selectedToken.data.loading
   }
-  loadTokenData(address) {
+  async loadTokenData(address) {
     const { api, network, connectedAccount } = this.props
 
     // ETH
     if (addressesEqual(address, ETHER_TOKEN_FAKE_ADDRESS)) {
-      return api
+      const userBalance = await api
         .web3Eth('getBalance', connectedAccount)
         .toPromise()
-        .then(ethBalance => ({
-          decimals: 18,
-          loading: false,
-          symbol: 'ETH',
-          userBalance: ethBalance,
-        }))
+        .catch(() => '-1')
+
+      return {
+        decimals: 18,
+        loading: false,
+        symbol: 'ETH',
+        userBalance,
+      }
     }
 
     // Tokens
     const token = api.external(address, tokenAbi)
+    const userBalance = await token
+      .balanceOf(connectedAccount)
+      .toPromise()
+      .catch(() => '-1')
 
-    return new Promise(async (resolve, reject) => {
-      const userBalance = await token
-        .balanceOf(connectedAccount)
+    const decimalsFallback =
+      tokenDataFallback(address, 'decimals', network.type) || '0'
+    const symbolFallback =
+      tokenDataFallback(address, 'symbol', network.type) || ''
+
+    const tokenData = {
+      userBalance,
+      decimals: parseInt(decimalsFallback, 10),
+      loading: false,
+      symbol: symbolFallback,
+    }
+
+    const [tokenSymbol, tokenDecimals] = await Promise.all([
+      getTokenSymbol(api, address).catch(() => ''),
+      token
+        .decimals()
         .toPromise()
-        // Assume no balance if the call failed
-        .catch(() => '0')
+        .then(decimals => parseInt(decimals, 10))
+        .catch(() => ''),
+    ])
 
-      const decimalsFallback =
-        tokenDataFallback(address, 'decimals', network.type) || '0'
-      const symbolFallback =
-        tokenDataFallback(address, 'symbol', network.type) || ''
+    // If symbol or decimals are resolved, overwrite the fallbacks
+    if (tokenSymbol) {
+      tokenData.symbol = tokenSymbol
+    }
+    if (tokenDecimals) {
+      tokenData.decimals = tokenDecimals
+    }
 
-      const tokenData = {
-        userBalance,
-        decimals: parseInt(decimalsFallback, 10),
-        loading: false,
-        symbol: symbolFallback,
-      }
-
-      const [tokenSymbol, tokenDecimals] = await Promise.all([
-        getTokenSymbol(api, address).catch(() => {}),
-        token
-          .decimals()
-          .toPromise()
-          .then(decimals => parseInt(decimals, 10))
-          .catch(() => {}),
-      ])
-
-      // If symbol or decimals are resolved, overwrite the fallbacks
-      if (tokenSymbol) {
-        tokenData.symbol = tokenSymbol
-      }
-      if (tokenDecimals) {
-        tokenData.decimals = tokenDecimals
-      }
-
-      resolve(tokenData)
-    })
+    return tokenData
   }
   validateInputs({ amount, selectedToken } = {}) {
     amount = amount || this.state.amount
@@ -260,16 +271,7 @@ class Deposit extends React.Component {
 
     const selectedTokenIsAddress = isAddress(selectedToken.value)
     const showTokenBadge = selectedTokenIsAddress && selectedToken.coerced
-    const tokenBalanceMessage = selectedToken.data.userBalance
-      ? `You have ${
-          selectedToken.data.userBalance === '0'
-            ? 'no'
-            : fromDecimals(
-                selectedToken.data.userBalance,
-                selectedToken.data.decimals
-              )
-        } ${selectedToken.data.symbol} available`
-      : ''
+    const tokenBalanceMessage = renderBalanceForSelectedToken(selectedToken)
 
     const ethSelected =
       selectedTokenIsAddress &&

--- a/apps/finance/app/src/lib/token-utils.js
+++ b/apps/finance/app/src/lib/token-utils.js
@@ -47,29 +47,31 @@ export const tokenDataFallback = (tokenAddress, fieldName, networkType) => {
 export async function getTokenSymbol(app, address) {
   // Symbol is optional; note that aragon.js doesn't return an error (only an falsey value) when
   // getting this value fails
-  let token = app.external(address, tokenSymbolAbi)
-  let tokenSymbol = await token.symbol().toPromise()
-  if (tokenSymbol) {
-    return tokenSymbol
+  let tokenSymbol
+  try {
+    const token = app.external(address, tokenSymbolAbi)
+    tokenSymbol = await token.symbol().toPromise()
+  } catch (err) {
+    // Some tokens (e.g. DS-Token) use bytes32 as the return type for symbol().
+    const token = app.external(address, tokenSymbolBytesAbi)
+    tokenSymbol = toUtf8(await token.symbol().toPromise())
   }
-  // Some tokens (e.g. DS-Token) use bytes32 as the return type for symbol().
-  token = app.external(address, tokenSymbolBytesAbi)
-  tokenSymbol = await token.symbol().toPromise()
 
-  return tokenSymbol ? toUtf8(tokenSymbol) : null
+  return tokenSymbol || null
 }
 
 export async function getTokenName(app, address) {
   // Name is optional; note that aragon.js doesn't return an error (only an falsey value) when
   // getting this value fails
-  let token = app.external(address, tokenNameAbi)
-  let tokenName = await token.name().toPromise()
-  if (tokenName) {
-    return tokenName
+  let tokenName
+  try {
+    const token = app.external(address, tokenNameAbi)
+    tokenName = await token.name().toPromise()
+  } catch (err) {
+    // Some tokens (e.g. DS-Token) use bytes32 as the return type for name().
+    const token = app.external(address, tokenNameBytesAbi)
+    tokenName = toUtf8(await token.name().toPromise())
   }
-  // Some tokens (e.g. DS-Token) use bytes32 as the return type for name().
-  token = app.external(address, tokenNameBytesAbi)
-  tokenName = await token.name().toPromise()
 
-  return tokenName ? toUtf8(tokenName) : null
+  return tokenName || null
 }


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/734.

With https://github.com/aragon/aragon.js/pull/277 we now get the actual errors back from the RPC when a call goes wrong (e.g. naive `token.symbol()` on DAI) and we need to handle these explicitly.

This PR converts a lot of the token fallback-related bits into simpler Promise-based code and adds explicit handlers for their error cases.