### PR TITLE
chore: remove unnecessary dependencies

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -36,12 +36,10 @@
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
     "ethereumjs-util": "^6.1.0",
-    "solidity-coverage": "0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1",
-    "web3-eth-abi": "^1.0.0-beta.38",
-    "webpack": "3.10.0"
+    "web3-eth-abi": "^1.0.0-beta.38"
   },
   "dependencies": {
     "@aragon/apps-vault": "4.1.0",

--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -42,11 +42,9 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
-    "solidity-coverage": "0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
-    "truffle-extract": "^1.2.1",
-    "webpack": "3.10.0"
+    "truffle-extract": "^1.2.1"
   },
   "dependencies": {
     "@aragon/apps-vault": "^4.0.0",

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -36,11 +36,9 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
-    "solidity-coverage": "0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
-    "truffle-extract": "^1.2.1",
-    "webpack": "3.10.0"
+    "truffle-extract": "^1.2.1"
   },
   "dependencies": {
     "@aragon/apps-shared-minime": "1.0.0",

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -42,11 +42,9 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
-    "solidity-coverage": "0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
-    "truffle-extract": "^1.2.1",
-    "webpack": "3.10.0"
+    "truffle-extract": "^1.2.1"
   },
   "dependencies": {
     "@aragon/apps-shared-minime": "1.0.0",

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -39,7 +39,6 @@
     "@aragon/test-helpers": "^1.1.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.1.1",
-    "solidity-coverage": "0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1"

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -43,12 +43,10 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.5",
-    "solidity-coverage": "0.5.11",
     "solidity-sha3": "^0.4.1",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
-    "truffle-extract": "^1.2.1",
-    "webpack": "3.10.0"
+    "truffle-extract": "^1.2.1"
   },
   "dependencies": {
     "@aragon/apps-shared-minime": "1.0.0",


### PR DESCRIPTION
cc @facuspagnuolo 

Hopefully this will get travis to run a bit faster with a lighter cache. Might be some other cache improvements we can make... somehow the cache on travis is yuge at 16GB:

<img width="108" alt="Screen Shot 2019-04-18 at 9 22 53 AM" src="https://user-images.githubusercontent.com/4166642/56343627-92222280-61bb-11e9-8052-2f0992568c88.png">
