### PR TITLE
Finance: date filters remove default selection

### DIFF
--- a/apps/finance/app/src/components/DateRange/DatePicker.js
+++ b/apps/finance/app/src/components/DateRange/DatePicker.js
@@ -220,7 +220,7 @@ const DayView = styled.li`
   ${props =>
     props.today &&
     css`
-      border: 1px solid ${theme.disabled};
+      border: 1px solid ${mainColor};
     `}
 
   ${props =>

--- a/apps/finance/app/src/components/DateRange/DateRangeInput.js
+++ b/apps/finance/app/src/components/DateRange/DateRangeInput.js
@@ -15,6 +15,8 @@ import IconCalendar from './Calendar'
 import TextInput from './TextInput'
 import DatePicker from './DatePicker'
 
+const DATE_PLACEHOLDER = '--/--/----'
+
 class DateRangeInput extends React.PureComponent {
   state = {
     showPicker: false,
@@ -31,7 +33,7 @@ class DateRangeInput extends React.PureComponent {
 
     return isDate(startDate)
       ? formatDate(startDate, this.props.format)
-      : '--/--/----'
+      : DATE_PLACEHOLDER
   }
 
   get formattedEndDate() {
@@ -41,7 +43,7 @@ class DateRangeInput extends React.PureComponent {
     return isDate(endDate)
       ? formatDate(endDate, format)
       : startDate
-      ? '--/--/----'
+      ? DATE_PLACEHOLDER
       : formatDate(new Date(), format)
   }
 
@@ -116,6 +118,7 @@ class DateRangeInput extends React.PureComponent {
           adornment={icon}
           adornmentPosition="end"
           height={39}
+          placeholder=""
         />
         {this.state.showPicker && (
           <StyledDatePickersContainer>

--- a/apps/finance/app/src/components/DateRange/DateRangeInput.js
+++ b/apps/finance/app/src/components/DateRange/DateRangeInput.js
@@ -158,7 +158,7 @@ const StyledContainer = styled.div`
 
 const StyledTextInput = styled(TextInput)`
   width: 28ch;
-  fontfamily: ${font({ monospace: true })};
+  ${font({ monospace: true })};
 `
 
 const StyledDatePickersContainer = styled.div`

--- a/apps/finance/app/src/components/DateRange/DateRangeInput.js
+++ b/apps/finance/app/src/components/DateRange/DateRangeInput.js
@@ -31,20 +31,14 @@ class DateRangeInput extends React.PureComponent {
   get formattedStartDate() {
     const { startDate } = this.state
 
-    return isDate(startDate)
-      ? formatDate(startDate, this.props.format)
-      : DATE_PLACEHOLDER
+    return isDate(startDate) ? formatDate(startDate, this.props.format) : ''
   }
 
   get formattedEndDate() {
     const { endDate, startDate } = this.state
     const { format } = this.props
 
-    return isDate(endDate)
-      ? formatDate(endDate, format)
-      : startDate
-      ? DATE_PLACEHOLDER
-      : formatDate(new Date(), format)
+    return isDate(endDate) ? formatDate(endDate, format) : ''
   }
 
   componentWillUnmount() {
@@ -106,6 +100,19 @@ class DateRangeInput extends React.PureComponent {
     ) : (
       <IconCalendar />
     )
+    const value =
+      this.formattedStartDate && this.formattedEndDate
+        ? `${this.formattedStartDate} - ${this.formattedEndDate}`
+        : ''
+    const placeholder = `${
+      this.formattedStartDate ? this.formattedStartDate : DATE_PLACEHOLDER
+    } - ${
+      this.formattedEndDate
+        ? this.formattedEndDate
+        : this.formattedStartDate
+        ? DATE_PLACEHOLDER
+        : formatDate(new Date(), this.props.format)
+    }`
 
     return (
       <StyledContainer
@@ -113,12 +120,12 @@ class DateRangeInput extends React.PureComponent {
         onClick={this.handleClick}
       >
         <StyledTextInput
-          value={`${this.formattedStartDate} - ${this.formattedEndDate}`}
+          value={value}
           readOnly
           adornment={icon}
           adornmentPosition="end"
           height={39}
-          placeholder=""
+          placeholder={placeholder}
         />
         {this.state.showPicker && (
           <StyledDatePickersContainer>

--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -206,7 +206,7 @@ class Transfers extends React.PureComponent {
                 )} to ${formatDate(selectedDateRange.end)}) selection. `}
               {filtersActive && (
                 <a role="button" onClick={this.handleResetFilters}>
-                  Clear filters
+                  Clear filters
                 </a>
               )}
             </p>

--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -6,7 +6,6 @@ import {
   format,
   isWithinInterval,
   startOfDay,
-  subDays,
 } from 'date-fns'
 import {
   Button,
@@ -31,8 +30,6 @@ const TRANSFER_TYPES = [
 const TRANSFERS_PER_PAGE = 10
 const TRANSFER_TYPES_STRING = TRANSFER_TYPES.map(TransferTypes.convertToString)
 
-const DEFAULT_DAYS_SELECTED = 90
-
 const formatDate = date => format(date, 'dd/MM/yy')
 
 const reduceTokenDetails = (details, { address, decimals, symbol }) => {
@@ -45,8 +42,8 @@ const reduceTokenDetails = (details, { address, decimals, symbol }) => {
 
 const initialState = {
   selectedDateRange: {
-    start: subDays(new Date(), DEFAULT_DAYS_SELECTED),
-    end: new Date(),
+    start: null,
+    end: null,
   },
   selectedToken: 0,
   selectedTransferType: 0,
@@ -75,9 +72,10 @@ class Transfers extends React.PureComponent {
     })
   }
   handleResetFilters = () => {
-    this.setState({
+    this.setState(({ selectedDateRange }) => ({
       ...initialState,
-    })
+      selectedDateRange,
+    }))
   }
   handleDateRangeChange = selectedDateRange => {
     this.setState({ selectedDateRange })
@@ -136,10 +134,11 @@ class Transfers extends React.PureComponent {
     const transferType = TRANSFER_TYPES[selectedTransferType]
     return transactions.filter(
       ({ token, isIncoming, date }) =>
-        isWithinInterval(new Date(date), {
-          start: startOfDay(selectedDateRange.start),
-          end: endOfDay(selectedDateRange.end),
-        }) &&
+        (!selectedDateRange.start || !selectedDateRange.end ||
+          isWithinInterval(new Date(date), {
+            start: startOfDay(selectedDateRange.start),
+            end: endOfDay(selectedDateRange.end),
+          })) &&
         (selectedToken === 0 ||
           addressesEqual(token, tokens[selectedToken - 1].address)) &&
         (transferType === TransferTypes.All ||
@@ -200,12 +199,14 @@ class Transfers extends React.PureComponent {
         {filteredTransfers.length === 0 ? (
           <NoTransfers compactMode={compactMode}>
             <p css="text-align: center">
-              No transfers match your filter and period (
-              {formatDate(selectedDateRange.start)} to{' '}
-              {formatDate(selectedDateRange.end)}) selection.{' '}
+              No transfers match your filter{' '}
+              {selectedDateRange.start &&
+                `and period (${formatDate(
+                  selectedDateRange.start
+                )} to ${formatDate(selectedDateRange.end)}) selection. `}
               {filtersActive && (
                 <a role="button" onClick={this.handleResetFilters}>
-                  Clear filters
+                  Clear filters
                 </a>
               )}
             </p>

--- a/apps/finance/app/src/components/TransfersFilters.js
+++ b/apps/finance/app/src/components/TransfersFilters.js
@@ -131,8 +131,6 @@ const Filters = styled.div`
           width: 100%;
           margin: 0;
           justify-content: space-between;
-          margin-left: 0;
-          margin-right: 0;
 
           /* Easier than passing compactMode to every Filter & FilterLabel */
           ${Filter} {


### PR DESCRIPTION
These changes:

- Placeholder for dates: `--/--/----`
- When no range is selected today's date is used as placeholder for `endDate`
- When `startDate` is selected but no `endDate`, then `endDate` uses the placeholder
- Date range filter is applied when the user clicks outside of the date range picker instead of when clicking on dates as before
- Modified today's border to main color
- Uses monospaced font so that placeholder uses same char width as actual dates and uses `ch` units to define container's size

Refs: #809 and https://github.com/aragon/aragon-apps/pull/767#discussion_r274326591