### PR TITLE
chore: fix solidity-coverage in apps

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -36,6 +36,8 @@
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
     "ethereumjs-util": "^6.1.0",
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1",

--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -42,6 +42,8 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1"

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -36,6 +36,8 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1"

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -42,6 +42,8 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.1",
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1"

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -39,6 +39,8 @@
     "@aragon/test-helpers": "^1.1.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.1.1",
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-extract": "^1.2.1"

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -43,6 +43,8 @@
     "@aragon/cli": "^5.6.0",
     "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.5",
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
     "solidity-sha3": "^0.4.1",
     "solium": "^1.2.3",
     "truffle": "4.1.14",

--- a/future-apps/payroll/package.json
+++ b/future-apps/payroll/package.json
@@ -25,17 +25,18 @@
     "test": "TRUFFLE_TEST=true npm run ganache-cli:test",
     "test:gas": "GAS_REPORTER=true npm test",
     "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
-    "truffle:dev": "node_modules/.bin/truffle dev",
+    "truffle:dev": "truffle dev",
     "ganache-cli:test": "./node_modules/@aragon/test-helpers/ganache-cli.sh",
     "prepare": "npx apps-shared-scripts-prepare",
     "install:frontend": "cd app && npm install",
-    "prepublishOnly": "truffle compile --all"
+    "abi:extract": "truffle-extract --output abi/ --keys abi",
+    "prepublishOnly": "truffle compile --all && npm run abi:extract -- --no-compile"
   },
   "files": [
+    "/abi",
     "/arapp.json",
     "/build",
     "/contracts",
-    "/scripts",
     "/test"
   ],
   "dependencies": {
@@ -49,12 +50,12 @@
     "@aragon/apps-shared-scripts": "^1.0.0",
     "@aragon/apps-vault": "4.0.0",
     "@aragon/cli": "^5.1.0",
-    "@aragon/test-helpers": "^1.0.1",
+    "@aragon/test-helpers": "^1.1.0",
     "eth-gas-reporter": "^0.1.12",
-    "ganache-cli": "^6.0.3",
-    "ethereumjs-abi": "^0.6.5",
-    "solidity-coverage": "0.5.11",
-    "solium": "^1.1.8",
-    "truffle": "4.1.14"
+    "ganache-cli": "^6.4.3",
+    "solidity-coverage": "^0.5.11",
+    "solium": "^1.2.3",
+    "truffle": "4.1.14",
+    "truffle-extract": "^1.2.1"
   }
 }

--- a/shared/test-helpers/package.json
+++ b/shared/test-helpers/package.json
@@ -8,6 +8,10 @@
     "*.sh",
     "/contracts"
   ],
+  "peerDependencies": {
+    "ganache-cli": "^6.0.0",
+    "solidity-coverage": "^0.5.11"
+  },
   "devDependencies": {
     "ethereumjs-abi": "^0.6.4"
   }


### PR DESCRIPTION
Oops, `npx` doesn't like nested binaries 🤦‍♂️.

We have to manually make sure the binaries are installed, otherwise `npx` might not find them (e.g. `testrpc-sc`, which isn't a package by itself but is exposed by `solidity-coverage`). This was causing the CI to fail on the coverage tests.

Todo:

- [x] Publish new version of `@aragon/test-helpers` with the new peer dependencies