### PR TITLE
Voting: sort same end-time votes by their descending voteIds

### DIFF
--- a/apps/voting/app/src/screens/Votes.js
+++ b/apps/voting/app/src/screens/Votes.js
@@ -5,9 +5,11 @@ import VotingCardGroup from '../components/VotingCard/VotingCardGroup'
 class Votes extends React.PureComponent {
   render() {
     const { votes, onSelectVote } = this.props
-    const sortedVotes = votes.sort((a, b) =>
-      a.data.endDate > b.data.endDate ? -1 : 1
-    )
+    const sortedVotes = votes.sort((a, b) => {
+      const dateDiff = b.data.endDate - a.data.endDate
+      // Order by descending voteId if there's no end date difference
+      return dateDiff !== 0 ? dateDiff : b.voteId - a.voteId
+    })
 
     const openVotes = sortedVotes.filter(vote => vote.data.open)
     const closedVotes = sortedVotes.filter(vote => !openVotes.includes(vote))


### PR DESCRIPTION
Votes can sometimes be created in the same block, and so will have the same start (and end time) attached.

In this case, we should use their `voteId`s for sorting, so that the vote numbers still look correct (as you would expect a "newer" vote, with a larger `voteId`, to have a later end date).