### PR TITLE
Fix ganache-cli.sh on Ubuntu

### DIFF
--- a/shared/test-helpers/ganache-cli.sh
+++ b/shared/test-helpers/ganache-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Exit script as soon as a command fails.
-set -o errexit -o pipefail
+set -o errexit
 
 # Executes cleanup function at script exit.
 trap cleanup EXIT


### PR DESCRIPTION
I was getting:

```
./node_modules/@aragon/test-helpers/ganache-cli.sh: 4: set: Illegal option -o pipefail
```

I supposed is not a portable option.