### PR TITLE
Prevent RangeError when .toLocaleString() is used

### DIFF
--- a/apps/finance/app/src/lib/utils.js
+++ b/apps/finance/app/src/lib/utils.js
@@ -1,17 +1,30 @@
 import { round } from './math-utils'
 
-export const formatTokenAmount = (
+export function formatDecimals(value, digits) {
+  try {
+    return value.toLocaleString('latn', {
+      style: 'decimal',
+      maximumFractionDigits: digits,
+    })
+  } catch (err) {
+    if (err.name === 'RangeError') {
+      // Fallback to Number.prototype.toString()
+      // if the language tag is not supported.
+      return value.toString()
+    }
+    throw err
+  }
+}
+
+export function formatTokenAmount(
   amount,
   isIncoming,
   decimals = 0,
   displaySign = false,
   { rounding = 2 } = {}
-) =>
-  (displaySign ? (isIncoming ? '+' : '-') : '') +
-  Number(round(amount / Math.pow(10, decimals), rounding)).toLocaleString(
-    'latn',
-    {
-      style: 'decimal',
-      maximumFractionDigits: 18,
-    }
+) {
+  return (
+    (displaySign ? (isIncoming ? '+' : '-') : '') +
+    formatDecimals(round(amount / Math.pow(10, decimals), rounding), 18)
   )
+}


### PR DESCRIPTION
Prevents the app to crash on the current Firefox Nightly.

I couldn’t find any other use of `toLocaleString()` in `aragon/aragon-apps` / `aragon/aragon` / `aragon/aragon-ui` / `aragon/aragon.js` / `aragon/apm.js` so it should be the only change needed.

Thanks to @dizzypaty for reporting this issue! :1st_place_medal: 