### PR TITLE
Voting: skip unnecessary renderings

### DIFF
--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { Main, SidePanel } from '@aragon/ui'
+import { Main } from '@aragon/ui'
 
 import EmptyState from './screens/EmptyState'
 import Votes from './screens/Votes'
-import VotePanelContent from './components/VotePanelContent'
-import NewVotePanelContent from './components/NewVotePanelContent'
+import VotePanel from './components/VotePanel'
+import NewVotePanel from './components/NewVotePanel'
 import AppLayout from './components/AppLayout'
 import NewVoteIcon from './components/NewVoteIcon'
 
@@ -40,39 +40,17 @@ function App() {
           )}
         </AppLayout>
 
-        <SidePanel
-          title={
-            selectedVote
-              ? `Vote #${selectedVote.voteId} (${
-                  selectedVote.data.open ? 'Open' : 'Closed'
-                })`
-              : ''
-          }
-          opened={selectedVotePanel.visible}
-          onClose={selectedVotePanel.requestClose}
-          onTransitionEnd={selectedVotePanel.onTransitionEnd}
-        >
-          {selectedVote && (
-            <VotePanelContent
-              vote={selectedVote}
-              onVote={actions.vote}
-              onExecute={actions.execute}
-              panelOpened={selectedVotePanel.didOpen}
-            />
-          )}
-        </SidePanel>
+        <VotePanel
+          vote={selectedVote}
+          onExecute={actions.execute}
+          onVote={actions.vote}
+          panelState={selectedVotePanel}
+        />
 
-        <SidePanel
-          title="New Vote"
-          opened={newVotePanel.visible}
-          onClose={newVotePanel.requestClose}
-          onTransitionEnd={newVotePanel.onTransitionEnd}
-        >
-          <NewVotePanelContent
-            onCreateVote={actions.createVote}
-            panelOpened={newVotePanel.didOpen}
-          />
-        </SidePanel>
+        <NewVotePanel
+          onCreateVote={actions.createVote}
+          panelState={newVotePanel}
+        />
       </Main>
     </div>
   )

--- a/apps/voting/app/src/app-logic.js
+++ b/apps/voting/app/src/app-logic.js
@@ -102,15 +102,9 @@ export function useAppLogic() {
   const selectedVotePanel = useSelectedVotePanel(selectedVote, selectVote)
 
   const actions = {
-    createVote: useCreateVoteAction(() => {
-      newVotePanel.requestClose()
-    }),
-    vote: useVoteAction(() => {
-      selectedVotePanel.requestClose()
-    }),
-    execute: useExecuteAction(() => {
-      selectedVotePanel.requestClose()
-    }),
+    createVote: useCreateVoteAction(newVotePanel.requestClose),
+    vote: useVoteAction(selectedVotePanel.requestClose),
+    execute: useExecuteAction(selectedVotePanel.requestClose),
   }
 
   return {
@@ -118,16 +112,21 @@ export function useAppLogic() {
     selectVote,
     selectedVote,
     actions,
-
-    newVotePanel: {
-      ...newVotePanel,
-      // ensure there is only one panel opened at a time
-      visible: newVotePanel.visible && !selectedVotePanel.visible,
-    },
-    selectedVotePanel: {
-      ...selectedVotePanel,
-      visible: selectedVotePanel.visible && !newVotePanel.visible,
-    },
+    newVotePanel: useMemo(
+      () => ({
+        ...newVotePanel,
+        // ensure there is only one panel opened at a time
+        visible: newVotePanel.visible && !selectedVotePanel.visible,
+      }),
+      [newVotePanel, selectedVotePanel.visible]
+    ),
+    selectedVotePanel: useMemo(
+      () => ({
+        ...selectedVotePanel,
+        visible: selectedVotePanel.visible && !newVotePanel.visible,
+      }),
+      [selectedVotePanel, newVotePanel.visible]
+    ),
   }
 }
 

--- a/apps/voting/app/src/components/NewVotePanel.js
+++ b/apps/voting/app/src/components/NewVotePanel.js
@@ -1,13 +1,27 @@
 import React from 'react'
 import styled from 'styled-components'
-import { TabBar, Button, Info, Text, TextInput, Field } from '@aragon/ui'
+import { Button, Field, Info, SidePanel, TabBar, TextInput } from '@aragon/ui'
 
 const initialState = {
   question: '',
   screenIndex: 0,
 }
 
-class NewVotePanelContent extends React.Component {
+const NewVotePanel = React.memo(({ panelState, onCreateVote }) => (
+  <SidePanel
+    title="New Vote"
+    opened={panelState.visible}
+    onClose={panelState.requestClose}
+    onTransitionEnd={panelState.onTransitionEnd}
+  >
+    <NewVotePanelContent
+      onCreateVote={onCreateVote}
+      panelOpened={panelState.didOpen}
+    />
+  </SidePanel>
+))
+
+class NewVotePanelContent extends React.PureComponent {
   static defaultProps = {
     onCreateVote: () => {},
   }
@@ -99,4 +113,4 @@ const Form = styled.form`
   margin-top: 20px;
 `
 
-export default NewVotePanelContent
+export default NewVotePanel

--- a/apps/voting/app/src/components/VotePanel.js
+++ b/apps/voting/app/src/components/VotePanel.js
@@ -7,10 +7,11 @@ import {
   SafeLink,
   SidePanelSeparator,
   SidePanelSplit,
+  SidePanel,
   Text,
   theme,
 } from '@aragon/ui'
-import { useAragonApi } from '@aragon/api-react'
+import { useAppState, useConnectedAccount } from '@aragon/api-react'
 import LocalIdentityBadge from './LocalIdentityBadge/LocalIdentityBadge.js'
 import { format } from 'date-fns'
 import { VOTE_NAY, VOTE_YEA } from '../vote-types'
@@ -30,34 +31,41 @@ const formatDate = date =>
 // styled-component `css` transform doesn’t play well with attached components.
 const Action = Info.Action
 
+const VotePanel = React.memo(({ panelState, vote, onExecute, onVote }) => (
+  <SidePanel
+    title={
+      vote ? `Vote #${vote.voteId} (${vote.data.open ? 'Open' : 'Closed'})` : ''
+    }
+    opened={panelState.visible}
+    onClose={panelState.requestClose}
+    onTransitionEnd={panelState.onTransitionEnd}
+  >
+    {vote && (
+      <VotePanelContent
+        vote={vote}
+        onVote={onVote}
+        onExecute={onExecute}
+        panelOpened={panelState.didOpen}
+      />
+    )}
+  </SidePanel>
+))
+
 const VotePanelContent = React.memo(
   ({ onVote, onExecute, panelOpened, vote }) => {
-    const {
-      connectedAccount,
-      appState: { tokenDecimals, tokenSymbol },
-    } = useAragonApi()
+    const { tokenDecimals, tokenSymbol } = useAppState()
 
-    const { canUserVote, canExecute, userBalance } = useExtendedVoteData(vote)
-
-    const [changeVote, setChangeVote] = useState(false)
-
-    const handleChangeVoteClick = useCallback(() => {
-      setChangeVote(true)
-    }, [])
-
-    const handleNoClick = useCallback(() => {
+    const handleVoteNo = useCallback(() => {
       onVote(vote.voteId, VOTE_NAY)
     }, [onVote, vote.voteId])
 
-    const handleYesClick = useCallback(() => {
+    const handleVoteYes = useCallback(() => {
       onVote(vote.voteId, VOTE_YEA)
     }, [onVote, vote.voteId])
 
-    const handleExecuteClick = useCallback(() => {
+    const handleExecute = useCallback(() => {
       onExecute(vote.voteId)
     }, [onExecute, vote.voteId])
-
-    const hasVoted = [VOTE_YEA, VOTE_NAY].includes(vote.userAccountVote)
 
     if (!vote) {
       return null
@@ -150,100 +158,116 @@ const VotePanelContent = React.memo(
           ready={panelOpened}
         />
 
-        {(() => {
-          if (canExecute) {
-            return (
-              <div>
-                <SidePanelSeparator />
-                <ButtonsContainer>
-                  <Button mode="strong" wide onClick={handleExecuteClick}>
-                    Execute vote
-                  </Button>
-                </ButtonsContainer>
-                <Action>Executing this vote is required to enact it.</Action>
-              </div>
-            )
-          }
-
-          if (canUserVote && hasVoted && !changeVote) {
-            return (
-              <div>
-                <SidePanelSeparator />
-                <ButtonsContainer>
-                  <Button mode="strong" wide onClick={handleChangeVoteClick}>
-                    Change my vote
-                  </Button>
-                </ButtonsContainer>
-                <Action>
-                  <p>
-                    You voted {vote.userAccountVote === VOTE_YEA ? 'yes' : 'no'}{' '}
-                    with{' '}
-                    {userBalance === -1
-                      ? '…'
-                      : pluralize(userBalance, '$ token', '$ tokens')}
-                    , since it was your balance when the vote was created (
-                    {formatDate(vote.data.startDate)}
-                    ).
-                  </p>
-                </Action>
-              </div>
-            )
-          }
-
-          if (canUserVote) {
-            return (
-              <div>
-                <SidePanelSeparator />
-                <ButtonsContainer>
-                  <VotingButton
-                    mode="strong"
-                    emphasis="positive"
-                    wide
-                    onClick={handleYesClick}
-                  >
-                    Yes
-                  </VotingButton>
-                  <VotingButton
-                    mode="strong"
-                    emphasis="negative"
-                    wide
-                    onClick={handleNoClick}
-                  >
-                    No
-                  </VotingButton>
-                </ButtonsContainer>
-                <Action
-                  css={`
-                    & > div {
-                      align-items: flex-start;
-                    }
-                  `}
-                >
-                  {connectedAccount ? (
-                    <div>
-                      <p>
-                        You will cast your vote with{' '}
-                        {userBalance === -1
-                          ? '… tokens'
-                          : pluralize(userBalance, '$ token', '$ tokens')}
-                        , since it was your balance when the vote was created (
-                        {formatDate(vote.data.startDate)}
-                        ).
-                      </p>
-                      <NoTokenCost />
-                    </div>
-                  ) : (
-                    <p>
-                      You will need to connect your account in the next screen.
-                    </p>
-                  )}
-                </Action>
-              </div>
-            )
-          }
-        })()}
+        <VotePanelContentActions
+          onExecute={handleExecute}
+          onVoteNo={handleVoteNo}
+          onVoteYes={handleVoteYes}
+          vote={vote}
+        />
       </React.Fragment>
     )
+  }
+)
+
+const VotePanelContentActions = React.memo(
+  ({ vote, onVoteYes, onVoteNo, onExecute }) => {
+    const connectedAccount = useConnectedAccount()
+    const { canUserVote, canExecute, userBalance } = useExtendedVoteData(vote)
+    const [changeVote, setChangeVote] = useState(false)
+
+    const handleChangeVote = useCallback(() => setChangeVote(true), [])
+
+    const hasVoted = [VOTE_YEA, VOTE_NAY].includes(vote.userAccountVote)
+
+    if (canExecute) {
+      return (
+        <div>
+          <SidePanelSeparator />
+          <ButtonsContainer>
+            <Button mode="strong" wide onClick={onExecute}>
+              Execute vote
+            </Button>
+          </ButtonsContainer>
+          <Action>Executing this vote is required to enact it.</Action>
+        </div>
+      )
+    }
+
+    if (canUserVote && hasVoted && !changeVote) {
+      return (
+        <div>
+          <SidePanelSeparator />
+          <ButtonsContainer>
+            <Button mode="strong" wide onClick={handleChangeVote}>
+              Change my vote
+            </Button>
+          </ButtonsContainer>
+          <Action>
+            <p>
+              You voted {vote.userAccountVote === VOTE_YEA ? 'yes' : 'no'} with{' '}
+              {userBalance === -1
+                ? '…'
+                : pluralize(userBalance, '$ token', '$ tokens')}
+              , since it was your balance when the vote was created (
+              {formatDate(vote.data.startDate)}
+              ).
+            </p>
+          </Action>
+        </div>
+      )
+    }
+
+    if (canUserVote) {
+      return (
+        <div>
+          <SidePanelSeparator />
+          <ButtonsContainer>
+            <VotingButton
+              mode="strong"
+              emphasis="positive"
+              wide
+              onClick={onVoteYes}
+            >
+              Yes
+            </VotingButton>
+            <VotingButton
+              mode="strong"
+              emphasis="negative"
+              wide
+              onClick={onVoteNo}
+            >
+              No
+            </VotingButton>
+          </ButtonsContainer>
+          <Action
+            css={`
+              & > div {
+                align-items: flex-start;
+              }
+            `}
+          >
+            {connectedAccount ? (
+              <div>
+                <p>
+                  You will cast your vote with{' '}
+                  {userBalance === -1
+                    ? '… tokens'
+                    : pluralize(userBalance, '$ token', '$ tokens')}
+                  , since it was your balance when the vote was created (
+                  {formatDate(vote.data.startDate)}
+                  ).
+                </p>
+                <NoTokenCost />
+              </div>
+            ) : (
+              <p>You will need to connect your account in the next screen.</p>
+            )}
+          </Action>
+        </div>
+      )
+    }
+
+    return null
   }
 )
 
@@ -289,4 +313,4 @@ const VotingButton = styled(Button)`
   }
 `
 
-export default VotePanelContent
+export default VotePanel

--- a/apps/voting/app/src/components/VotePanel.js
+++ b/apps/voting/app/src/components/VotePanel.js
@@ -177,7 +177,7 @@ const VotePanelContentActions = React.memo(
 
     const handleChangeVote = useCallback(() => setChangeVote(true), [])
 
-    const hasVoted = [VOTE_YEA, VOTE_NAY].includes(vote.userAccountVote)
+    const hasVoted = [VOTE_YEA, VOTE_NAY].includes(vote.connectedAccountVote)
 
     if (canExecute) {
       return (
@@ -204,7 +204,8 @@ const VotePanelContentActions = React.memo(
           </ButtonsContainer>
           <Action>
             <p>
-              You voted {vote.userAccountVote === VOTE_YEA ? 'yes' : 'no'} with{' '}
+              You voted {vote.connectedAccountVote === VOTE_YEA ? 'yes' : 'no'}{' '}
+              with{' '}
               {userBalance === -1
                 ? '…'
                 : pluralize(userBalance, '$ token', '$ tokens')}

--- a/apps/voting/app/src/components/VotingCard/VotingCard.js
+++ b/apps/voting/app/src/components/VotingCard/VotingCard.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
-import color from 'onecolor'
 import { format } from 'date-fns'
 import { Badge, Countdown, Text, Button, theme } from '@aragon/ui'
 import { VOTE_YEA, VOTE_NAY } from '../../vote-types'

--- a/apps/voting/app/src/screens/Votes.js
+++ b/apps/voting/app/src/screens/Votes.js
@@ -2,44 +2,34 @@ import React from 'react'
 import VotingCard from '../components/VotingCard/VotingCard'
 import VotingCardGroup from '../components/VotingCard/VotingCardGroup'
 
-class Votes extends React.PureComponent {
-  render() {
-    const { votes, onSelectVote } = this.props
-    const sortedVotes = votes.sort((a, b) => {
-      const dateDiff = b.data.endDate - a.data.endDate
-      // Order by descending voteId if there's no end date difference
-      return dateDiff !== 0 ? dateDiff : b.voteId - a.voteId
-    })
+const Votes = React.memo(({ votes, onSelectVote }) => {
+  const sortedVotes = votes.sort((a, b) => {
+    const dateDiff = b.data.endDate - a.data.endDate
+    // Order by descending voteId if there's no end date difference
+    return dateDiff !== 0 ? dateDiff : b.voteId - a.voteId
+  })
 
-    const openVotes = sortedVotes.filter(vote => vote.data.open)
-    const closedVotes = sortedVotes.filter(vote => !openVotes.includes(vote))
-    const votingGroups = [
-      ['Open votes', openVotes],
-      ['Past votes', closedVotes],
-    ]
+  const openVotes = sortedVotes.filter(vote => vote.data.open)
+  const closedVotes = sortedVotes.filter(vote => !openVotes.includes(vote))
+  const votingGroups = [['Open votes', openVotes], ['Past votes', closedVotes]]
 
-    return (
-      <React.Fragment>
-        {votingGroups.map(([groupName, votes]) =>
-          votes.length ? (
-            <VotingCardGroup
-              title={groupName}
-              count={votes.length}
-              key={groupName}
-            >
-              {votes.map(vote => (
-                <VotingCard
-                  key={vote.voteId}
-                  vote={vote}
-                  onOpen={onSelectVote}
-                />
-              ))}
-            </VotingCardGroup>
-          ) : null
-        )}
-      </React.Fragment>
-    )
-  }
-}
+  return (
+    <React.Fragment>
+      {votingGroups.map(([groupName, votes]) =>
+        votes.length ? (
+          <VotingCardGroup
+            title={groupName}
+            count={votes.length}
+            key={groupName}
+          >
+            {votes.map(vote => (
+              <VotingCard key={vote.voteId} vote={vote} onOpen={onSelectVote} />
+            ))}
+          </VotingCardGroup>
+        ) : null
+      )}
+    </React.Fragment>
+  )
+})
 
 export default Votes

--- a/apps/voting/app/src/utils-hooks.js
+++ b/apps/voting/app/src/utils-hooks.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { noop } from './utils'
 
 export function useNow(updateEvery = 1000) {
@@ -65,5 +65,8 @@ export function usePanelState({ onDidOpen = noop, onDidClose = noop } = {}) {
     [onDidClose, onDidOpen, setDidOpen]
   )
 
-  return { requestOpen, requestClose, visible, didOpen, onTransitionEnd }
+  return useMemo(
+    () => ({ requestOpen, requestClose, visible, didOpen, onTransitionEnd }),
+    [requestOpen, requestClose, visible, didOpen, onTransitionEnd]
+  )
 }

--- a/apps/voting/app/src/vote-hooks.js
+++ b/apps/voting/app/src/vote-hooks.js
@@ -15,22 +15,25 @@ export function useVotes() {
   const { votes, connectedAccountVotes } = useAppState()
   const now = useNow()
 
+  const openedStates = (votes || []).map(v => isVoteOpen(v, now))
+  const openedStatesKey = openedStates.join('')
+
   return useMemo(() => {
     if (!votes) {
       return []
     }
-    return votes.map(vote => ({
+    return votes.map((vote, i) => ({
       ...vote,
       data: {
         ...vote.data,
 
         metadata: vote.data.metadata || '',
         description: vote.data.description || '',
-        open: isVoteOpen(vote, now),
+        open: openedStates[i],
       },
       connectedAccountVote: connectedAccountVotes[vote.voteId] || VOTE_ABSENT,
     }))
-  }, [votes, connectedAccountVotes, now])
+  }, [votes, connectedAccountVotes, openedStatesKey])
 }
 
 // Load and returns the token contract, or null if not loaded yet.


### PR DESCRIPTION
Noticeable improvement: the side panels transition should be smoother.

Changes:

- Move panels in their own components, so that the rendering of   SidePanel can be skipped entirely.
- Memoize the object returned by usePanel(), so that it can be compared   using a strict equality.
- Move the voting panel actions in their own component fetching their   data, so that the panel component doesn’t need to render that much   anymore.
- Don’t recreate `votes` every second, instead only do it if any   “opened” status has changed.