### PR TITLE
Payroll: remove unnecessary variable in internal method

### DIFF
--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -344,7 +344,7 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
             }
 
             paymentAmount = _ensurePaymentAmount(totalOwedSalary, _requestedAmount);
-            _updateEmployeeAccountingBasedOnPaidSalary(employeeId, paymentAmount, currentOwedSalary);
+            _updateEmployeeAccountingBasedOnPaidSalary(employeeId, paymentAmount);
         } else if (_type == PaymentType.Reimbursement) {
             uint256 owedReimbursements = employee.reimbursements;
             paymentAmount = _ensurePaymentAmount(owedReimbursements, _requestedAmount);
@@ -658,9 +658,8 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
      *      their currently owed salary since last payroll date
      * @param _employeeId Employee's identifier
      * @param _paymentAmount Amount being paid to the employee
-     * @param _currentOwedSalary Owed salary for the employee since their last payroll date
      */
-    function _updateEmployeeAccountingBasedOnPaidSalary(uint256 _employeeId, uint256 _paymentAmount, uint256 _currentOwedSalary) internal {
+    function _updateEmployeeAccountingBasedOnPaidSalary(uint256 _employeeId, uint256 _paymentAmount) internal {
         Employee storage employee = employees[_employeeId];
         uint256 accruedSalary = employee.accruedSalary;
 


### PR DESCRIPTION
🙈 Oops, forgot to remove this as part of https://github.com/aragon/aragon-apps/pull/834/commits/3eab68a8b10c25d936ebb6e74647f6daf0295c84.

It's not needed anymore, because we calculate the last payroll date based on the actual amount paid rather than short circuiting it to `now` if it's the same as the currently owed amount.