### PR TITLE
Finance: explicitly include core-js@2

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -10,6 +10,7 @@
     "@aragon/ui": "^0.37.0",
     "@babel/polyfill": "^7.0.0",
     "bn.js": "^4.11.8",
+    "core-js": "^2.6.5",
     "date-fns": "2.0.0-alpha.22",
     "downloadjs": "^1.4.7",
     "lodash.throttle": "^4.1.1",


### PR DESCRIPTION
Babel@7.4.0 is deprecating core-js@2 and `@babel/polyfill`, so it will by default try to select `core-js@3`.

Luckily for Finance, we had another module that used core-js@2 so we got the correct version. This introduces an explicit dependency for this until we want to upgrade to core-js@3 (unfortunately it produces a bigger bundle 😦)