### PR TITLE
Finance - use updated app API with caching and init

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@aragon/api": "^1.0.0",
-    "@aragon/api-react": "^1.0.0-beta.2",
+    "@aragon/api": "^2.0.0-beta.2",
+    "@aragon/api-react": "^2.0.0-beta.1",
     "@aragon/templates-tokens": "^1.2.0",
-    "@aragon/ui": "^0.37.0",
+    "@aragon/ui": "^0.40.0",
     "@babel/polyfill": "^7.0.0",
     "bn.js": "^4.11.8",
     "core-js": "^2.6.5",
@@ -20,7 +20,7 @@
     "react-display-name": "^0.2.3",
     "react-dom": "^16.8.4",
     "react-spring": "^7.2.8",
-    "rxjs": "^6.2.1",
+    "rxjs": "^6.5.2",
     "styled-components": "4.1.3",
     "web3-utils": "^1.0.0-beta.30"
   },

--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { EmptyStateCard, Main, SidePanel } from '@aragon/ui'
+import { SyncIndicator, EmptyStateCard, Main, SidePanel } from '@aragon/ui'
 import { useAragonApi } from '@aragon/api-react'
 import Balances from './components/Balances'
 import NewTransferPanelContent from './components/NewTransfer/PanelContent'
@@ -19,6 +19,7 @@ class App extends React.Component {
     appState: PropTypes.object,
   }
   static defaultProps = {
+    isSyncing: true,
     balances: [],
     transactions: [],
     tokens: [],
@@ -86,7 +87,7 @@ class App extends React.Component {
   }
 
   render() {
-    const { appState } = this.props
+    const { appState, isSyncing } = this.props
     const { newTransferOpened } = this.state
     const { balances, transactions, tokens, proxyAddress } = appState
 
@@ -97,6 +98,7 @@ class App extends React.Component {
             onResolve={this.handleResolveLocalIdentity}
             onShowLocalIdentityModal={this.handleShowLocalIdentityModal}
           >
+            <SyncIndicator visible={isSyncing} />
             <AppLayout
               title="Finance"
               mainButton={{
@@ -120,17 +122,19 @@ class App extends React.Component {
                   />
                 </SpacedBlock>
               )}
-              {balances.length === 0 && transactions.length === 0 && (
-                <EmptyScreen>
-                  <EmptyStateCard
-                    icon={<img src={addFundsIcon} alt="" />}
-                    title="There are no funds yet"
-                    text="Create a new transfer to get started."
-                    actionText="New transfer"
-                    onActivate={this.handleNewTransferOpen}
-                  />
-                </EmptyScreen>
-              )}
+              {!isSyncing &&
+                balances.length === 0 &&
+                transactions.length === 0 && (
+                  <EmptyScreen>
+                    <EmptyStateCard
+                      icon={<img src={addFundsIcon} alt="" />}
+                      title="There are no funds yet"
+                      text="Create a new transfer to get started."
+                      actionText="New transfer"
+                      onActivate={this.handleNewTransferOpen}
+                    />
+                  </EmptyScreen>
+                )}
             </AppLayout>
             <SidePanel
               opened={newTransferOpened}
@@ -168,5 +172,5 @@ const SpacedBlock = styled.div`
 
 export default () => {
   const { api, appState } = useAragonApi()
-  return <App api={api} appState={appState} />
+  return <App api={api} appState={appState} isSyncing={appState.isSyncing} />
 }

--- a/apps/finance/app/src/script.js
+++ b/apps/finance/app/src/script.js
@@ -187,15 +187,13 @@ async function loadTokenBalances(state, settings) {
     return newState
   }
 
-  for (let i = 0; i < newState.balances.length; i++) {
-    const balance = newState.balances[i]
-    const amount = await loadTokenBalance(balance.address, settings)
-    newState.balances[i] = {
-      ...balance,
-      amount,
+  const addresses = newState.balances.map(({ address }) => address)
+  for (const address of addresses) {
+    newState = {
+      ...newState,
+      balances: await updateBalances(newState, address, settings),
     }
   }
-
   return newState
 }
 

--- a/apps/finance/app/src/script.js
+++ b/apps/finance/app/src/script.js
@@ -121,6 +121,7 @@ async function initialize(vaultAddress, ethAddress) {
 
       if (addressesEqual(eventAddress, vault.address)) {
         // Vault event
+        // TODO: Load balances for known token only once syncing past state has completed
         nextState = await vaultLoadBalance(nextState, event, settings)
       } else {
         // Finance event

--- a/apps/finance/app/src/script.js
+++ b/apps/finance/app/src/script.js
@@ -172,10 +172,31 @@ const initializeState = settings => async () => {
     ),
     vaultAddress: settings.vault.address,
   }
-
-  const withTestnetState = await loadTestnetState(newState, settings)
+  const withTokenBalances = await loadTokenBalances(newState, settings)
+  const withTestnetState = await loadTestnetState(withTokenBalances, settings)
   const withEthBalance = await loadEthBalance(withTestnetState, settings)
+
   return withEthBalance
+}
+
+async function loadTokenBalances(state, settings) {
+  let newState = {
+    ...state,
+  }
+  if (!newState.balances) {
+    return newState
+  }
+
+  for (let i = 0; i < newState.balances.length; i++) {
+    const balance = newState.balances[i]
+    const amount = await loadTokenBalance(balance.address, settings)
+    newState.balances[i] = {
+      ...balance,
+      amount,
+    }
+  }
+
+  return newState
 }
 
 async function vaultLoadBalance(state, { returnValues: { token } }, settings) {

--- a/apps/finance/app/src/script.js
+++ b/apps/finance/app/src/script.js
@@ -121,7 +121,6 @@ async function initialize(vaultAddress, ethAddress) {
 
       if (addressesEqual(eventAddress, vault.address)) {
         // Vault event
-        // TODO: Load balances for known token only once syncing past state has completed
         nextState = await vaultLoadBalance(nextState, event, settings)
       } else {
         // Finance event

--- a/apps/finance/app/src/script.js
+++ b/apps/finance/app/src/script.js
@@ -1,4 +1,4 @@
-import Aragon from '@aragon/api'
+import Aragon, { events } from '@aragon/api'
 import { first } from 'rxjs/operators'
 import { getTestTokenAddresses } from './testnet'
 import {
@@ -125,6 +125,12 @@ async function initialize(vaultAddress, ethAddress) {
       } else {
         // Finance event
         switch (eventName) {
+          case events.SYNC_STATUS_SYNCING:
+            nextState.isSyncing = true
+            break
+          case events.SYNC_STATUS_SYNCED:
+            nextState.isSyncing = false
+            break
           case 'ChangePeriodDuration':
             nextState.periodDuration = marshallDate(
               event.returnValues.newDuration
@@ -165,8 +171,10 @@ async function initialize(vaultAddress, ethAddress) {
  *                     *
  ***********************/
 
-const initializeState = settings => async () => {
+const initializeState = settings => async cachedState => {
   const newState = {
+    ...cachedState,
+    isSyncing: true,
     periodDuration: marshallDate(
       await app.call('getPeriodDuration').toPromise()
     ),


### PR DESCRIPTION
## What
- Replace the `INITIALIZATION_TRIGGER` with an init function (part of the [new API](https://github.com/aragon/aragon.js/pull/297))
- Pass the external vault contract and its `initializationBlock` to the api to leverage caching
- Loading/Syncing indicator

## Dependency PR
- https://github.com/aragon/aragon.js/pull/297