### PR TITLE
Payroll: remove .gitignore

### DIFF
--- a/future-apps/payroll/.gitignore
+++ b/future-apps/payroll/.gitignore
@@ -1,3 +1,0 @@
-node_modules/
-build/
-coverageEnv/


### PR DESCRIPTION
Removes the `.gitignore` file in Payroll, which was redundant as everything it ignored was already listed in `aragon-apps/.gitignore`.

The `.gitignore` in `future-apps/payroll` was making the CLI ignore the built frontend.