### PR TITLE
Tests: Enhance events assertions

### DIFF
--- a/apps/token-manager/test/tokenmanager.js
+++ b/apps/token-manager/test/tokenmanager.js
@@ -1,4 +1,5 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
 const getBalance = require('@aragon/test-helpers/balance')(web3)
 
 const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
@@ -47,13 +48,13 @@ contract('Token Manager', ([root, holder, holder2, anyone]) => {
 
     beforeEach(async () => {
         const r = await daoFact.newDAO(root)
-        const dao = Kernel.at(r.logs.filter(l => l.event == 'DeployDAO')[0].args.dao)
+        const dao = Kernel.at(getEventArgument(r, 'DeployDAO', 'dao'))
         const acl = ACL.at(await dao.acl())
 
         await acl.createPermission(root, dao.address, APP_MANAGER_ROLE, root, { from: root })
 
         const receipt = await dao.newAppInstance('0x1234', tokenManagerBase.address, '0x', false, { from: root })
-        tokenManager = TokenManager.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+        tokenManager = TokenManager.at(getNewProxyAddress(receipt))
         tokenManager.mockSetTimestamp(NOW)
 
         await acl.createPermission(ANY_ADDR, tokenManager.address, MINT_ROLE, root, { from: root })

--- a/apps/vault/test/vault_shared.js
+++ b/apps/vault/test/vault_shared.js
@@ -1,5 +1,6 @@
-const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { hash } = require('eth-ens-namehash')
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
 const getBalanceFn = require('@aragon/test-helpers/balance')
 
 // Allow for sharing this test across other vault implementations and subclasses
@@ -12,7 +13,6 @@ module.exports = (
   }
 ) => {
   const getBalance = getBalanceFn(web3)
-  const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.event == event)[0].args[arg] }
 
   const ACL = artifacts.require('ACL')
   const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
@@ -56,7 +56,7 @@ module.exports = (
 
     beforeEach(async () => {
       const r = await daoFact.newDAO(root)
-      const dao = Kernel.at(getEvent(r, 'DeployDAO', 'dao'))
+      const dao = Kernel.at(getEventArgument(r, 'DeployDAO', 'dao'))
       const acl = ACL.at(await dao.acl())
 
       await acl.createPermission(root, dao.address, APP_MANAGER_ROLE, root, { from: root })
@@ -65,8 +65,7 @@ module.exports = (
       vaultId = hash(`${vaultName.toLowerCase()}.aragonpm.test`)
 
       const vaultReceipt = await dao.newAppInstance(vaultId, vaultBase.address, '0x', false)
-      const vaultProxyAddress = getEvent(vaultReceipt, 'NewAppProxy', 'proxy')
-      vault = VaultLike.at(vaultProxyAddress)
+      vault = VaultLike.at(getNewProxyAddress(vaultReceipt))
 
       await acl.createPermission(ANY_ENTITY, vault.address, TRANSFER_ROLE, root, { from: root })
 
@@ -237,8 +236,7 @@ module.exports = (
 
         // Create a new vault and set that vault as the default vault in the kernel
         const defaultVaultReceipt = await kernel.newAppInstance(vaultId, vaultBase.address, '0x', true)
-        const defaultVaultAddress = getEvent(defaultVaultReceipt, 'NewAppProxy', 'proxy')
-        defaultVault = VaultLike.at(defaultVaultAddress)
+        defaultVault = VaultLike.at(getNewProxyAddress(defaultVaultReceipt))
         await defaultVault.initialize()
 
         await kernel.setRecoveryVaultAppId(vaultId)

--- a/apps/voting/test/voting.js
+++ b/apps/voting/test/voting.js
@@ -1,4 +1,6 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
+const { getEventAt, getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
 const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
 const { encodeCallScript, EMPTY_SCRIPT } = require('@aragon/test-helpers/evmScript')
 const ExecutionTarget = artifacts.require('ExecutionTarget')
@@ -14,8 +16,7 @@ const MiniMeToken = artifacts.require('@aragon/apps-shared-minime/contracts/Mini
 const getContract = name => artifacts.require(name)
 const bigExp = (x, y) => new web3.BigNumber(x).times(new web3.BigNumber(10).toPower(y))
 const pct16 = x => bigExp(x, 16)
-const startVoteEvent = receipt => receipt.logs.filter(x => x.event == 'StartVote')[0].args
-const createdVoteId = receipt => startVoteEvent(receipt).voteId
+const createdVoteId = receipt => getEventArgument(receipt, 'StartVote', 'voteId')
 
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -51,13 +52,13 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
     beforeEach(async () => {
         const r = await daoFact.newDAO(root)
-        const dao = Kernel.at(r.logs.filter(l => l.event == 'DeployDAO')[0].args.dao)
+        const dao = Kernel.at(getEventArgument(r, 'DeployDAO', 'dao'))
         const acl = ACL.at(await dao.acl())
 
         await acl.createPermission(root, dao.address, APP_MANAGER_ROLE, root, { from: root })
 
         const receipt = await dao.newAppInstance('0x1234', votingBase.address, '0x', false, { from: root })
-        voting = Voting.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+        voting = Voting.at(getNewProxyAddress(receipt))
         await voting.mockSetTimestamp(NOW)
 
         await acl.createPermission(ANY_ADDR, voting.address, CREATE_VOTES_ROLE, root, { from: root })
@@ -93,9 +94,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
         it('can change required support', async () => {
             const receipt = await voting.changeSupportRequiredPct(neededSupport.add(1))
-            const events = receipt.logs.filter(x => x.event == 'ChangeSupportRequired')
+            assertAmountOfEvents(receipt, 'ChangeSupportRequired')
 
-            assert.equal(events.length, 1, 'should have emitted ChangeSupportRequired event')
             assert.equal((await voting.supportRequiredPct()).toString(), neededSupport.add(1).toString(), 'should have changed required support')
         })
 
@@ -110,9 +110,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
         it('can change minimum acceptance quorum', async () => {
             const receipt = await voting.changeMinAcceptQuorumPct(1)
-            const events = receipt.logs.filter(x => x.event == 'ChangeMinQuorum')
+            assertAmountOfEvents(receipt, 'ChangeMinQuorum')
 
-            assert.equal(events.length, 1, 'should have emitted ChangeMinQuorum event')
             assert.equal(await voting.minAcceptQuorumPct(), 1, 'should have changed acceptance quorum')
         })
 
@@ -184,10 +183,11 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                 beforeEach(async () => {
                     const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
                     script = encodeCallScript([action, action])
-                    const startVote = startVoteEvent(await voting.newVoteExt(script, 'metadata', false, false, { from: holder51 }))
-                    voteId = startVote.voteId
-                    creator = startVote.creator
-                    metadata = startVote.metadata
+
+                    const receipt = await voting.newVoteExt(script, 'metadata', false, false, { from: holder51 });
+                    voteId = getEventArgument(receipt, 'StartVote', 'voteId')
+                    creator = getEventArgument(receipt, 'StartVote', 'creator')
+                    metadata = getEventArgument(receipt, 'StartVote', 'metadata')
                 })
 
                 it('has correct state', async () => {

--- a/future-apps/payroll/test/contracts/Payroll_add_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_add_employee.test.js
@@ -1,5 +1,5 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../helpers/events')
+const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
 const { USD, deployDAI } = require('../helpers/tokens')(artifacts, web3)
 const { NOW, TWO_MONTHS, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { MAX_UINT64, annualSalaryPerSecond } = require('../helpers/numbers')(web3)

--- a/future-apps/payroll/test/contracts/Payroll_add_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_add_employee.test.js
@@ -1,5 +1,5 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
 const { USD, deployDAI } = require('../helpers/tokens')(artifacts, web3)
 const { NOW, TWO_MONTHS, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { MAX_UINT64, annualSalaryPerSecond } = require('../helpers/numbers')(web3)

--- a/future-apps/payroll/test/contracts/Payroll_allowed_tokens.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_allowed_tokens.test.js
@@ -1,6 +1,6 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
-const { getEventAt } = require('../../../../shared/test-helpers/events')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { assertEvent } = require('@aragon/test-helpers/assertEvent')(web3)
 const { annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)
@@ -33,9 +33,7 @@ contract('Payroll allowed tokens,', ([owner, employee, anyone]) => {
         context('when it does not reach the maximum amount allowed', () => {
           it('can allow a token', async () => {
             const receipt = await payroll.addAllowedToken(DAI.address, { from })
-
-            const event = getEventAt(receipt, 'AddAllowedToken')
-            assert.equal(event.token, DAI.address, 'denomination token address should match')
+            assertEvent(receipt, 'AddAllowedToken', { token: DAI.address })
 
             assert.equal(await payroll.getAllowedTokensArrayLength(), 1, 'allowed tokens length does not match')
             assert(await payroll.isTokenAllowed(DAI.address), 'denomination token should be allowed')
@@ -43,9 +41,7 @@ contract('Payroll allowed tokens,', ([owner, employee, anyone]) => {
 
           it('can allow a the zero address', async () => {
             const receipt = await payroll.addAllowedToken(ZERO_ADDRESS, { from })
-
-            const event = getEventAt(receipt, 'AddAllowedToken')
-            assert.equal(event.token, ZERO_ADDRESS, 'denomination token address should match')
+            assertEvent(receipt, 'AddAllowedToken', { token: ZERO_ADDRESS })
 
             assert.equal(await payroll.getAllowedTokensArrayLength(), 1, 'allowed tokens length does not match')
             assert(await payroll.isTokenAllowed(ZERO_ADDRESS), 'zero address token should be allowed')

--- a/future-apps/payroll/test/contracts/Payroll_allowed_tokens.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_allowed_tokens.test.js
@@ -1,5 +1,5 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
-const { getEvent } = require('../helpers/events')
+const { getEventAt } = require('../../../../shared/test-helpers/events')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
@@ -34,7 +34,7 @@ contract('Payroll allowed tokens,', ([owner, employee, anyone]) => {
           it('can allow a token', async () => {
             const receipt = await payroll.addAllowedToken(DAI.address, { from })
 
-            const event = getEvent(receipt, 'AddAllowedToken')
+            const event = getEventAt(receipt, 'AddAllowedToken')
             assert.equal(event.token, DAI.address, 'denomination token address should match')
 
             assert.equal(await payroll.getAllowedTokensArrayLength(), 1, 'allowed tokens length does not match')
@@ -44,7 +44,7 @@ contract('Payroll allowed tokens,', ([owner, employee, anyone]) => {
           it('can allow a the zero address', async () => {
             const receipt = await payroll.addAllowedToken(ZERO_ADDRESS, { from })
 
-            const event = getEvent(receipt, 'AddAllowedToken')
+            const event = getEventAt(receipt, 'AddAllowedToken')
             assert.equal(event.token, ZERO_ADDRESS, 'denomination token address should match')
 
             assert.equal(await payroll.getAllowedTokensArrayLength(), 1, 'allowed tokens length does not match')

--- a/future-apps/payroll/test/contracts/Payroll_bonuses.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_bonuses.test.js
@@ -1,6 +1,6 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../helpers/events')
+const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { bn, bigExp, annualSalaryPerSecond, ONE, MAX_UINT256 } = require('../helpers/numbers')(web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_bonuses.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_bonuses.test.js
@@ -1,8 +1,8 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
-const { bn, bigExp, annualSalaryPerSecond, ONE, MAX_UINT256 } = require('../helpers/numbers')(web3)
+const { bn, bigExp, annualSalaryPerSecond, MAX_UINT256 } = require('../helpers/numbers')(web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)
 const { USD, DAI_RATE, ANT_RATE, inverseRate, exchangedAmount, deployDAI, deployANT, setTokenRates } = require('../helpers/tokens')(artifacts, web3)
 

--- a/future-apps/payroll/test/contracts/Payroll_forwarding.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_forwarding.test.js
@@ -1,5 +1,5 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEventArgument } = require('../helpers/events')
+const { getEventArgument } = require('../../../../shared/test-helpers/events')
 const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
 const { annualSalaryPerSecond, bn } = require('../helpers/numbers')(web3)
 const { USD, deployDAI } = require('../helpers/tokens')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_forwarding.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_forwarding.test.js
@@ -1,5 +1,5 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEventArgument } = require('@aragon/test-helpers/events')
 const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
 const { annualSalaryPerSecond, bn } = require('../helpers/numbers')(web3)
 const { USD, deployDAI } = require('../helpers/tokens')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_get_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_get_employee.test.js
@@ -1,6 +1,6 @@
 const { MAX_UINT64 } = require('../helpers/numbers')(web3)
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEventArgument } = require('@aragon/test-helpers/events')
 const { NOW, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { USD, deployDAI } = require('../helpers/tokens')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_get_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_get_employee.test.js
@@ -1,6 +1,6 @@
 const { MAX_UINT64 } = require('../helpers/numbers')(web3)
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEventArgument } = require('../helpers/events')
+const { getEventArgument } = require('../../../../shared/test-helpers/events')
 const { NOW, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { USD, deployDAI } = require('../helpers/tokens')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_modify_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_modify_employee.test.js
@@ -1,6 +1,6 @@
 const { USD } = require('../helpers/tokens')(artifacts, web3)
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { bn, MAX_UINT256, annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_modify_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_modify_employee.test.js
@@ -1,6 +1,6 @@
 const { USD } = require('../helpers/tokens')(artifacts, web3)
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../helpers/events')
+const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { bn, MAX_UINT256, annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -1,6 +1,6 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEventArgument } = require('../helpers/events')
+const { getEventArgument } = require('../../../../shared/test-helpers/events')
 const { bn, ONE, MAX_UINT256, bigExp } = require('../helpers/numbers')(web3)
 const { NOW, ONE_MONTH, TWO_MONTHS, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -1,7 +1,8 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEventArgument } = require('../../../../shared/test-helpers/events')
-const { bn, ONE, MAX_UINT256, bigExp } = require('../helpers/numbers')(web3)
+const { assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
+const { bn, MAX_UINT256, bigExp } = require('../helpers/numbers')(web3)
 const { NOW, ONE_MONTH, TWO_MONTHS, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)
 const { USD, DAI_RATE, ANT_RATE, inverseRate, exchangedAmount, deployDAI, deployANT, setTokenRates } = require('../helpers/tokens')(artifacts, web3)
@@ -78,8 +79,8 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
               it('emits one event per allocated token', async () => {
                 const receipt = await payroll.payday(PAYMENT_TYPES.PAYROLL, requestedAmount, { from })
 
-                const events = receipt.logs.filter(l => l.event === 'SendPayment')
-                assert.equal(events.length, 2, 'should have emitted two events')
+                assertAmountOfEvents(receipt, 'SendPayment', 2)
+                const events = getEvents(receipt, 'SendPayment')
 
                 const eventDAI = events.find(e => e.args.token === DAI.address).args
                 assert.equal(eventDAI.employeeId.toString(), employeeId.toString(), 'employee id does not match')
@@ -640,14 +641,14 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                     it('emits one event per allocated token', async () => {
                       const receipt = await payroll.payday(PAYMENT_TYPES.PAYROLL, requestedAmount, { from })
 
-                      const events = receipt.logs.filter(l => l.event === 'SendPayment')
-                      assert.equal(events.length, 2, 'should have emitted two events')
+                      assertAmountOfEvents(receipt, 'SendPayment', 2)
+                      const events = getEvents(receipt, 'SendPayment')
 
                       const eventDAI = events.find(e => e.args.token === DAI.address).args
                       assert.equal(eventDAI.employeeId.toString(), employeeId.toString(), 'employee id does not match')
                       assert.equal(eventDAI.accountAddress, employee, 'employee address does not match')
                       assert.equal(eventDAI.token, DAI.address, 'DAI address does not match')
-                      assert.equal(eventDAI.amount.toString(), requestedDAI, 'payment amount does not match')
+                      assert.equal(eventDAI.amount.toString(), requestedDAI.toString(), 'payment amount does not match')
                       assert.equal(eventDAI.exchangeRate.toString(), inverseRate(DAI_RATE).toString(), 'payment exchange rate does not match')
                       assert.equal(eventDAI.paymentReference, 'Employee salary', 'payment reference does not match')
 
@@ -655,7 +656,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                       assert.equal(eventANT.employeeId.toString(), employeeId.toString(), 'employee id does not match')
                       assert.equal(eventANT.accountAddress, employee, 'employee address does not match')
                       assert.equal(eventANT.token, ANT.address, 'ANT address does not match')
-                      assert.equal(eventANT.amount.toString(), requestedANT, 'payment amount does not match')
+                      assert.equal(eventANT.amount.toString(), requestedANT.toString(), 'payment amount does not match')
                       assert.equal(eventANT.exchangeRate.toString(), inverseRate(ANT_RATE).toString(), 'payment exchange rate does not match')
                       assert.equal(eventANT.paymentReference, 'Employee salary', 'payment reference does not match')
                     })

--- a/future-apps/payroll/test/contracts/Payroll_rates.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_rates.test.js
@@ -1,4 +1,4 @@
-const { getEvents } = require('../../../../shared/test-helpers/events')
+const { getEvents } = require('@aragon/test-helpers/events')
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { bigExp, ONE } = require('../helpers/numbers')(web3)
 const { NOW, TWO_MINUTES, RATE_EXPIRATION_TIME } = require('../helpers/time')

--- a/future-apps/payroll/test/contracts/Payroll_rates.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_rates.test.js
@@ -1,4 +1,4 @@
-const { getEvents } = require('../helpers/events')
+const { getEvents } = require('../../../../shared/test-helpers/events')
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { bigExp, ONE } = require('../helpers/numbers')(web3)
 const { NOW, TWO_MINUTES, RATE_EXPIRATION_TIME } = require('../helpers/time')

--- a/future-apps/payroll/test/contracts/Payroll_reimbursements.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_reimbursements.test.js
@@ -1,6 +1,6 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../helpers/events')
+const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)
 const { ONE, bn, bigExp, annualSalaryPerSecond, MAX_UINT256 } = require('../helpers/numbers')(web3)

--- a/future-apps/payroll/test/contracts/Payroll_reimbursements.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_reimbursements.test.js
@@ -1,9 +1,9 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)
-const { ONE, bn, bigExp, annualSalaryPerSecond, MAX_UINT256 } = require('../helpers/numbers')(web3)
+const { bn, bigExp, annualSalaryPerSecond, MAX_UINT256 } = require('../helpers/numbers')(web3)
 const { USD, DAI_RATE, ANT_RATE, inverseRate, exchangedAmount, deployDAI, deployANT, setTokenRates } = require('../helpers/tokens')(artifacts, web3)
 
 contract('Payroll reimbursements', ([owner, employee, anyone]) => {

--- a/future-apps/payroll/test/contracts/Payroll_settings.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_settings.test.js
@@ -1,5 +1,5 @@
 const { USD } = require('../helpers/tokens')(artifacts, web3)
-const { getEvents } = require('../helpers/events')
+const { getEvents } = require('../../../../shared/test-helpers/events')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { NOW, ONE_MINUTE, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_settings.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_settings.test.js
@@ -1,5 +1,5 @@
 const { USD } = require('../helpers/tokens')(artifacts, web3)
-const { getEvents } = require('../../../../shared/test-helpers/events')
+const { getEvents } = require('@aragon/test-helpers/events')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { NOW, ONE_MINUTE, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_terminate_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_terminate_employee.test.js
@@ -1,6 +1,6 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../helpers/events')
+const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { USD, DAI_RATE, exchangedAmount, deployDAI, setTokenRate } = require('../helpers/tokens')(artifacts, web3)
 const { ONE, bn, bigExp, MAX_UINT64, annualSalaryPerSecond } = require('../helpers/numbers')(web3)

--- a/future-apps/payroll/test/contracts/Payroll_terminate_employee.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_terminate_employee.test.js
@@ -1,9 +1,9 @@
 const PAYMENT_TYPES = require('../helpers/payment_types')
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
-const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { USD, DAI_RATE, exchangedAmount, deployDAI, setTokenRate } = require('../helpers/tokens')(artifacts, web3)
-const { ONE, bn, bigExp, MAX_UINT64, annualSalaryPerSecond } = require('../helpers/numbers')(web3)
+const { bn, bigExp, MAX_UINT64, annualSalaryPerSecond } = require('../helpers/numbers')(web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)
 
 contract('Payroll employees termination', ([owner, employee, anyone]) => {

--- a/future-apps/payroll/test/contracts/Payroll_token_allocations.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_token_allocations.test.js
@@ -1,6 +1,6 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { annualSalaryPerSecond } = require('../helpers/numbers')(web3)
-const { getEvents, getEventArgument } = require('../helpers/events')
+const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { USD, deployDAI, deployTokenAndDeposit } = require('../helpers/tokens')(artifacts, web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/contracts/Payroll_token_allocations.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_token_allocations.test.js
@@ -1,6 +1,6 @@
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { annualSalaryPerSecond } = require('../helpers/numbers')(web3)
-const { getEvents, getEventArgument } = require('../../../../shared/test-helpers/events')
+const { getEvents, getEventArgument } = require('@aragon/test-helpers/events')
 const { NOW, ONE_MONTH, RATE_EXPIRATION_TIME } = require('../helpers/time')
 const { USD, deployDAI, deployTokenAndDeposit } = require('../helpers/tokens')(artifacts, web3)
 const { deployContracts, createPayrollAndPriceFeed } = require('../helpers/deploy')(artifacts, web3)

--- a/future-apps/payroll/test/helpers/deploy.js
+++ b/future-apps/payroll/test/helpers/deploy.js
@@ -1,7 +1,7 @@
 module.exports = (artifacts, web3) => {
   const { bigExp } = require('./numbers')(web3)
-  const { getEventArgument } = require('@aragon/test-helpers/events')
   const { SECONDS_IN_A_YEAR } = require('./time')
+  const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
 
   const getContract = name => artifacts.require(name)
 
@@ -48,7 +48,7 @@ module.exports = (artifacts, web3) => {
 
     // finance
     const financeReceipt = await dao.newAppInstance('0x5678', financeBase.address, '0x', false, { from: owner })
-    const finance = Finance.at(getEventArgument(financeReceipt, 'NewAppProxy', 'proxy'))
+    const finance = Finance.at(getNewProxyAddress(financeReceipt))
 
     await acl.createPermission(ANY_ENTITY, finance.address, CREATE_PAYMENTS_ROLE, owner, { from: owner })
     await acl.createPermission(ANY_ENTITY, finance.address, CHANGE_PERIOD_ROLE, owner, { from: owner })
@@ -57,7 +57,7 @@ module.exports = (artifacts, web3) => {
     await acl.createPermission(ANY_ENTITY, finance.address, MANAGE_PAYMENTS_ROLE, owner, { from: owner })
 
     const vaultReceipt = await dao.newAppInstance('0x1234', vaultBase.address, '0x', false, { from: owner })
-    const vault = Vault.at(getEventArgument(vaultReceipt, 'NewAppProxy', 'proxy'))
+    const vault = Vault.at(getNewProxyAddress(vaultReceipt))
     await acl.createPermission(finance.address, vault.address, TRANSFER_ROLE, owner, { from: owner })
     await vault.initialize()
 
@@ -70,7 +70,7 @@ module.exports = (artifacts, web3) => {
 
   async function createPayrollAndPriceFeed(dao, payrollBase, owner, currentTimestamp) {
     const receipt = await dao.newAppInstance('0x4321', payrollBase.address, '0x', false, { from: owner })
-    const payroll = Payroll.at(getEventArgument(receipt, 'NewAppProxy', 'proxy'))
+    const payroll = Payroll.at(getNewProxyAddress(receipt))
 
     const acl = ACL.at(await dao.acl())
 

--- a/future-apps/payroll/test/helpers/deploy.js
+++ b/future-apps/payroll/test/helpers/deploy.js
@@ -1,6 +1,6 @@
 module.exports = (artifacts, web3) => {
   const { bigExp } = require('./numbers')(web3)
-  const { getEventArgument } = require('./events')
+  const { getEventArgument } = require('@aragon/test-helpers/events')
   const { SECONDS_IN_A_YEAR } = require('./time')
 
   const getContract = name => artifacts.require(name)

--- a/future-apps/payroll/test/helpers/events.js
+++ b/future-apps/payroll/test/helpers/events.js
@@ -1,9 +1,0 @@
-const getEvent = (receipt, event) => getEvents(receipt, event)[0].args
-const getEvents = (receipt, event) => receipt.logs.filter(l => l.event === event)
-const getEventArgument = (receipt, event, arg) => getEvent(receipt, event)[arg]
-
-module.exports = {
-  getEvent,
-  getEvents,
-  getEventArgument,
-}

--- a/shared/test-helpers/assertEvent.js
+++ b/shared/test-helpers/assertEvent.js
@@ -1,5 +1,28 @@
-module.exports = (receipt, eventName, instances = 1) => {
-  const events = receipt.logs.filter(x => x.event == eventName)
-  assert.equal(events.length, instances, `'${eventName}' event should have been fired ${instances} times`)
-  return events
+const { getEventAt, getEvents } = require('./events')
+
+module.exports = web3 => {
+  const assertEvent = (receipt, eventName, expectedArgs = {}, index = 0) => {
+    const event = getEventAt(receipt, eventName, index)
+    assert(typeof event === 'object', `could not find an emitted ${eventName} event ${index === 0 ? '' : `at index ${index}`}`)
+
+    for (const arg of Object.keys(expectedArgs)) {
+      let foundArg = event.args[arg]
+      if (foundArg instanceof web3.BigNumber) foundArg = foundArg.toString()
+
+      let expectedArg = expectedArgs[arg]
+      if (expectedArg instanceof web3.BigNumber) expectedArg = expectedArg.toString()
+
+      assert.equal(foundArg, expectedArg, `${eventName} event ${arg} value does not match`)
+    }
+  }
+
+  const assertAmountOfEvents = (receipt, eventName, expectedAmount = 1) => {
+    const events = getEvents(receipt, eventName)
+    assert.equal(events.length, expectedAmount, `number of ${eventName} events does not match`)
+  }
+
+  return {
+    assertEvent,
+    assertAmountOfEvents
+  }
 }

--- a/shared/test-helpers/events.js
+++ b/shared/test-helpers/events.js
@@ -1,0 +1,11 @@
+const getEvents = ({ logs = [] }, event) => logs.filter(l => l.event === event)
+const getEventAt = (receipt, event, index = 0) => getEvents(receipt, event)[index]
+const getEventArgument = (receipt, event, arg, index = 0) => getEventAt(receipt, event, index).args[arg]
+const getNewProxyAddress = (receipt) => getEventArgument(receipt, 'NewAppProxy', 'proxy')
+
+module.exports = {
+  getEvents,
+  getEventAt,
+  getEventArgument,
+  getNewProxyAddress
+}


### PR DESCRIPTION
Borrowing events helpers and assert methods from aragonOS to improve the way we are dealing with those in the apps tests, at least until we release a new version exporting those new libraries.