### PR TITLE
Travis: optimizations and refactor to use build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,25 +31,42 @@ jobs:
   include:
     - stage: tests
       script: npm run lint
+      name: "Lint"
     - script: npm run test:agent
+      name: "Agent"
     - script: npm run test:finance
+      name: "Finance"
     - script: npm run test:payroll
+      name: "Payroll"
     - script: npm run test:survey
+      name: "Survey"
     - script: npm run test:token-manager
+      name: "Token Manager"
     - script: npm run test:token-manager:app
+      name: "Token Manager frontend"
       env:
         - INSTALL_FRONTEND=true
     - script: npm run test:vault
+      name: "Vault"
     - script: npm run test:voting
+      name: "Voting"
     - script: npm run test:shared
+      name: "Shared"
 
     - stage: coverage
       script: npm run coverage:agent
+      name: "Agent"
     - script: npm run coverage:finance
+      name: "Finance"
     - script: npm run coverage:payroll
+      name: "Payroll"
     - script: npm run coverage:survey
+      name: "Survey"
     - script: npm run coverage:token-manager
+      name: "Token Manager"
     - script: npm run coverage:vault
+      name: "Vault"
     - script: npm run coverage:voting
+      name: "Voting"
 after_success:
   - ./node_modules/.bin/lcov-result-merger 'apps/*/coverage/lcov.info' | ./node_modules/.bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: required
 language: node_js
-branches:
-  only:
-    - master
-    - next
 cache:
   timeout: 600
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: required
 language: node_js
+branches:
+  only:
+    - master
+    - next
 cache:
   timeout: 600
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ env:
 matrix:
   allow_failures:
     - env: TASK=coverage:agent
-    - env: TASK=coverage:finance
     - env: TASK=coverage:payroll
 install:
   - travis_wait 60 npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,31 +26,34 @@ node_js:
 env:
   global:
     - INSTALL_FRONTEND=false
-  matrix:
-    - TASK=lint
-    - TASK=test:agent
-    - TASK=test:finance
-    - TASK=test:survey
-    - TASK=test:token-manager
-    - TASK=test:token-manager:app INSTALL_FRONTEND=true
-    - TASK=test:vault
-    - TASK=test:voting
-    - TASK=test:payroll
-    - TASK=coverage:agent
-    - TASK=coverage:finance
-    - TASK=coverage:survey
-    - TASK=coverage:token-manager
-    - TASK=coverage:vault
-    - TASK=coverage:voting
-    - TASK=coverage:payroll
-    - TASK=test:shared
-matrix:
-  allow_failures:
-    - env: TASK=coverage:agent
-    - env: TASK=coverage:payroll
 install:
   - travis_wait 60 npm install
-script:
-  - travis_wait 60 npm run $TASK
+jobs:
+  allow_failures:
+    - script: npm run coverage:agent
+    - script: npm run coverage:payroll
+  include:
+    - stage: tests
+      script: npm run lint
+    - script: npm run test:agent
+    - script: npm run test:finance
+    - script: npm run test:payroll
+    - script: npm run test:survey
+    - script: npm run test:token-manager
+    - script: npm run test:token-manager:app
+      env:
+        - INSTALL_FRONTEND=true
+    - script: npm run test:vault
+    - script: npm run test:voting
+    - script: npm run test:shared
+
+    - stage: coverage
+      script: npm run coverage:agent
+    - script: npm run coverage:finance
+    - script: npm run coverage:payroll
+    - script: npm run coverage:survey
+    - script: npm run coverage:token-manager
+    - script: npm run coverage:vault
+    - script: npm run coverage:voting
 after_success:
   - ./node_modules/.bin/lcov-result-merger 'apps/*/coverage/lcov.info' | ./node_modules/.bin/coveralls


### PR DESCRIPTION
Refactors the Travis pipeline to be built in stages, so the longer-running coverage tasks only get kicked off after the tests pass.

It also moves the Finance app's coverage tests away from being expected to fail, because the coverage improvements in https://github.com/aragon/aragon-apps/pull/863 have made the instrumentation much, much faster.