### PR TITLE
[WIP] Voting: Single delegation (aka proxy voting)

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -34,6 +34,7 @@
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/cli": "~5.6.0",
     "@aragon/test-helpers": "^1.1.0",
+    "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ethereumjs-util": "^6.1.0",

--- a/apps/voting/contracts/HybridProxyVoting.sol
+++ b/apps/voting/contracts/HybridProxyVoting.sol
@@ -1,0 +1,226 @@
+pragma solidity ^0.4.24;
+
+import "./Voting.sol";
+import "./ProxyVoting.sol";
+import "./VotingHelpers.sol";
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
+import "@aragon/os/contracts/common/IsContract.sol";
+import "@aragon/os/contracts/common/TimeHelpers.sol";
+
+
+contract HybridProxyVoting is ProxyVoting, IsContract {
+
+    constructor(address _principal, uint64 _overruleWindow) ProxyVoting(_principal, _overruleWindow) public {
+        // solium-disable-previous-line no-empty-blocks
+    }
+
+    function setFullRepresentative(address _representative, bool _allowed) public onlyPrincipal {
+        super.setFullRepresentative(_representative, _allowed);
+        if (isContract(_representative)) {
+            HybridRepresentativeProxy(_representative).onSetFullRepresentative(_allowed);
+        }
+    }
+
+    function setInstanceRepresentative(address _representative, address _voting, bool _allowed) public onlyPrincipal {
+        super.setInstanceRepresentative(_representative, _voting, _allowed);
+        if (isContract(_representative)) {
+            HybridRepresentativeProxy(_representative).onSetInstanceRepresentative(_voting, _allowed);
+        }
+    }
+
+    function setVoteRepresentative(address _representative, address _voting, uint256 _voteId, bool _allowed) public onlyPrincipal {
+        super.setVoteRepresentative(_representative, _voting, _voteId, _allowed);
+        if (isContract(_representative)) {
+            HybridRepresentativeProxy(_representative).onSetVoteRepresentative(_voting, _voteId, _allowed);
+        }
+    }
+}
+
+
+contract HybridRepresentativeProxy {
+    using SafeMath for uint256;
+
+    string constant private ERROR_BLACKLISTED_SENDER = "RP_BLACKLISTED_SENDER";
+    string constant private ERROR_PRINCIPAL_CANNOT_VOTE = "RP_PRINCIPAL_CANNOT_VOTE";
+    string constant private ERROR_SENDER_NOT_PROXY_VOTING = "RP_SENDER_NOT_PROXY_VOTING";
+    string constant private ERROR_SENDER_NOT_REPRESENTATIVE = "RP_SENDER_NOT_REPRESENTATIVE";
+
+    address internal representative;
+    ProxyVotingRegistry internal proxyVotingRegistry;
+    mapping (address => bool) internal principalsBlacklist;
+
+    address[] internal fullRepresented;
+    mapping (address => uint256) internal fullRepresentedIndexes;
+
+    mapping (address => address[]) internal instanceRepresented;
+    mapping (address => mapping (address => uint256)) internal instanceRepresentedIndexes;
+
+    mapping (address => mapping (uint256 => address[])) internal voteRepresented;
+    mapping (address => mapping (uint256 => mapping (address => uint256))) internal voteRepresentedIndexes;
+
+    event ChangePrincipalsBlacklist(address principal, bool blacklisted);
+
+    modifier onlyRepresentative {
+        require(msg.sender == representative, ERROR_SENDER_NOT_REPRESENTATIVE);
+        _;
+    }
+
+    modifier onlyProxyVoting {
+        require(_isProxyVoting(msg.sender), ERROR_SENDER_NOT_PROXY_VOTING);
+        _;
+    }
+
+    modifier whitelisted {
+        require(_isWhitelisted(msg.sender), ERROR_BLACKLISTED_SENDER);
+        _;
+    }
+
+    constructor(address _representative, ProxyVotingRegistry _proxyVotingRegistry) public {
+        representative = _representative;
+        proxyVotingRegistry = _proxyVotingRegistry;
+    }
+
+    function onSetFullRepresentative(bool _allowed) external onlyProxyVoting whitelisted {
+        if (_allowed) {
+            uint256 index = fullRepresented.length;
+            fullRepresented.push(msg.sender);
+            fullRepresentedIndexes[msg.sender] = index;
+        } else {
+            uint256 representativeIndex = fullRepresentedIndexes[msg.sender];
+            uint256 lastIndex = fullRepresented.length.sub(1);
+            address lastRepresentative = fullRepresented[lastIndex];
+            fullRepresented[representativeIndex] = lastRepresentative;
+            fullRepresented.length--;
+            fullRepresentedIndexes[msg.sender] = 0;
+            fullRepresentedIndexes[lastRepresentative] = representativeIndex;
+        }
+    }
+
+    function onSetInstanceRepresentative(address _voting, bool _allowed) external onlyProxyVoting whitelisted {
+        if (_allowed) {
+            uint256 index = instanceRepresented[_voting].length;
+            instanceRepresented[_voting].push(msg.sender);
+            instanceRepresentedIndexes[_voting][msg.sender] = index;
+        } else {
+            uint256 representativeIndex = instanceRepresentedIndexes[_voting][msg.sender];
+            uint256 lastIndex = instanceRepresented[_voting].length.sub(1);
+            address lastRepresentative = instanceRepresented[_voting][lastIndex];
+            instanceRepresented[_voting][representativeIndex] = lastRepresentative;
+            instanceRepresented[_voting].length--;
+            instanceRepresentedIndexes[_voting][msg.sender] = 0;
+            instanceRepresentedIndexes[_voting][lastRepresentative] = representativeIndex;
+        }
+    }
+
+    function onSetVoteRepresentative(address _voting, uint256 _voteId, bool _allowed) external onlyProxyVoting whitelisted {
+        require(Voting(_voting).canVote(_voteId, msg.sender), ERROR_PRINCIPAL_CANNOT_VOTE);
+
+        if (_allowed) {
+            uint256 index = voteRepresented[_voting][_voteId].length;
+            voteRepresented[_voting][_voteId].push(msg.sender);
+            voteRepresentedIndexes[_voting][_voteId][msg.sender] = index;
+        } else {
+            uint256 representativeIndex = voteRepresentedIndexes[_voting][_voteId][msg.sender];
+            uint256 lastIndex = voteRepresented[_voting][_voteId].length.sub(1);
+            address lastRepresentative = voteRepresented[_voting][_voteId][lastIndex];
+            voteRepresented[_voting][_voteId][representativeIndex] = lastRepresentative;
+            voteRepresented[_voting][_voteId].length--;
+            voteRepresentedIndexes[_voting][_voteId][msg.sender] = 0;
+            voteRepresentedIndexes[_voting][_voteId][lastRepresentative] = representativeIndex;
+        }
+    }
+
+    function blacklistPrincipal(address _principal, bool _blacklisted) external onlyRepresentative {
+        principalsBlacklist[_principal] = _blacklisted;
+        emit ChangePrincipalsBlacklist(_principal, _blacklisted);
+    }
+
+    function proxyVotes(Voting[] _votings, uint256[] _voteIds, bool[] _supports) external onlyRepresentative {
+        for (uint256 i = 0; i < _votings.length; i++) {
+            proxyVote(_votings[i], _voteIds[i], _supports[i]);
+        }
+    }
+
+    function proxyVote(Voting _voting, uint256 _voteId, bool _supports) public onlyRepresentative {
+        _proxyFullRepresentedPrincipals(_voting, _voteId, _supports);
+        _proxyInstanceRepresentedPrincipals(_voting, _voteId, _supports);
+        _proxyVoteRepresentedPrincipals(_voting, _voteId, _supports);
+    }
+
+    function _proxyFullRepresentedPrincipals(Voting _voting, uint256 _voteId, bool _supports) internal {
+        for (uint256 i = 0; i < fullRepresented.length; i++) {
+            address voter = fullRepresented[i];
+            if (_canVote(_voting, _voteId, voter)) {
+                HybridProxyVoting(voter).proxyVote(_voting, _voteId, _supports);
+            }
+        }
+    }
+
+    function _proxyInstanceRepresentedPrincipals(Voting _voting, uint256 _voteId, bool _supports) internal {
+        address[] instanceRepresentedPrincipals = instanceRepresented[_voting];
+        for (uint256 i = 0; i < instanceRepresentedPrincipals.length; i++) {
+            address voter = instanceRepresentedPrincipals[i];
+            if (_canVote(_voting, _voteId, voter)) {
+                HybridProxyVoting(voter).proxyVote(_voting, _voteId, _supports);
+            }
+        }
+    }
+
+    function _proxyVoteRepresentedPrincipals(Voting _voting, uint256 _voteId, bool _supports) internal {
+        address[] voteRepresentedPrincipals = voteRepresented[_voting][_voteId];
+        for (uint256 i = 0; i < voteRepresentedPrincipals.length; i++) {
+            address voter = voteRepresentedPrincipals[i];
+            if (_canVote(_voting, _voteId, voter)) {
+                HybridProxyVoting(voter).proxyVote(_voting, _voteId, _supports);
+            }
+        }
+    }
+
+    function _canVote(Voting _voting, uint256 _voteId, address _voter) internal view returns (bool) {
+        return _isWhitelisted(_voter) && _voting.canVote(_voteId, _voter);
+    }
+
+    function _isProxyVoting(address _principal) internal view returns (bool) {
+        return proxyVotingRegistry.isValidProxyVoting(_principal);
+    }
+
+    function _isWhitelisted(address _principal) internal view returns (bool) {
+        return !principalsBlacklist[_principal];
+    }
+}
+
+
+contract ProxyVotingRegistry {
+    mapping (address => bool) internal proxyVotings;
+    mapping (address => bool) internal representativeProxies;
+
+    event NewProxyVoting(address proxyVoting);
+    event NewRepresentativeProxy(address representativeProxy);
+
+    function newProxyVoting(uint64 _overruleWindow) external returns (HybridProxyVoting) {
+        HybridProxyVoting proxyVoting = new HybridProxyVoting(msg.sender, _overruleWindow);
+        address proxyVotingAddress = address(proxyVoting);
+        proxyVotings[proxyVotingAddress] = true;
+        emit NewProxyVoting(proxyVotingAddress);
+        return proxyVoting;
+    }
+
+    function newRepresentativeProxy() external returns (HybridRepresentativeProxy) {
+        HybridRepresentativeProxy representativeProxy = new HybridRepresentativeProxy(msg.sender, ProxyVotingRegistry(this));
+        address representativeProxyAddress = address(representativeProxy);
+        representativeProxies[representativeProxyAddress] = true;
+        emit NewRepresentativeProxy(representativeProxyAddress);
+        return representativeProxy;
+    }
+
+    function isValidProxyVoting(address _proxyVoting) public view returns (bool) {
+        return proxyVotings[_proxyVoting];
+    }
+
+    function isValidRepresentativeProxy(address _representativeProxy) public view returns (bool) {
+        return representativeProxies[_representativeProxy];
+    }
+
+    // TODO: we could handle here specific logic to allow representatives signaling their involvement in specific domains
+}

--- a/apps/voting/contracts/ProxyVoting.sol
+++ b/apps/voting/contracts/ProxyVoting.sol
@@ -1,0 +1,113 @@
+pragma solidity ^0.4.24;
+
+import "./Voting.sol";
+import "./VotingHelpers.sol";
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+import "@aragon/os/contracts/common/TimeHelpers.sol";
+import "@aragon/os/contracts/lib/math/SafeMath64.sol";
+
+
+contract ProxyVoting is TimeHelpers {
+    using SafeMath64 for uint64;
+    using VotingHelpers for Voting;
+
+    string constant private ERROR_WITHDRAW_FAILED = "PV_WITHDRAW_FAILED";
+    string constant private ERROR_VOTE_ALREADY_CASTED = "PV_VOTE_ALREADY_CASTED";
+    string constant private ERROR_WITHIN_OVERRULE_WINDOW = "PV_WITHIN_OVERRULE_WINDOW";
+    string constant private ERROR_SENDER_NOT_PRINCIPAL = "PV_SENDER_NOT_PRINCIPAL";
+    string constant private ERROR_REPRESENTATIVE_NOT_ALLOWED = "PV_REPRESENTATIVE_NOT_ALLOWED";
+
+    uint64 internal overruleWindow;
+    address internal principal;
+    mapping (address => bool) internal fullRepresentatives;
+    mapping (address => mapping (address => bool)) internal instanceRepresentatives;
+    mapping (address => mapping (uint256 => mapping (address => bool))) internal voteRepresentatives;
+
+    event Withdraw(address token, uint256 amount);
+    event ChangeFullRepresentative(address indexed representative, bool allowed);
+    event ChangeInstanceRepresentative(address indexed representative, address indexed voting, bool allowed);
+    event ChangeVoteRepresentative(address indexed representative, address indexed voting, uint256 indexed voteId, bool allowed);
+
+    modifier onlyPrincipal {
+        require(msg.sender == principal, ERROR_SENDER_NOT_PRINCIPAL);
+        _;
+    }
+
+    modifier onlyRepresentative(Voting _voting, uint256 _voteId) {
+        require(_isRepresentativeAllowed(msg.sender, address(_voting), _voteId), ERROR_REPRESENTATIVE_NOT_ALLOWED);
+        _;
+    }
+
+    constructor(address _principal, uint64 _overruleWindow) public {
+        principal = _principal;
+        overruleWindow = _overruleWindow;
+    }
+
+    function setFullRepresentative(address _representative, bool _allowed) external onlyPrincipal {
+        fullRepresentatives[_representative] = _allowed;
+        emit ChangeFullRepresentative(_representative, _allowed);
+    }
+
+    function setInstanceRepresentative(address _representative, address _voting, bool _allowed) external onlyPrincipal {
+        instanceRepresentatives[_voting][_representative] = _allowed;
+        emit ChangeInstanceRepresentative(_representative, _voting, _allowed);
+    }
+
+    function setVoteRepresentative(address _representative, address _voting, uint256 _voteId, bool _allowed) external onlyPrincipal {
+        voteRepresentatives[_voting][_voteId][_representative] = _allowed;
+        emit ChangeVoteRepresentative(_representative, _voting, _voteId, _allowed);
+    }
+
+    function withdraw(ERC20 _token, uint256 _amount) external onlyPrincipal {
+        emit Withdraw(address(_token), _amount);
+        require(_token.transfer(principal, _amount), ERROR_WITHDRAW_FAILED);
+    }
+
+    function newVote(Voting _voting, bytes _executionScript, string _metadata) external onlyPrincipal returns (uint256 voteId) {
+        // do not cas principals vote to allow representatives vote
+        return _voting.newVote(_executionScript, _metadata, false, false);
+    }
+
+    function proxyVote(Voting _voting, uint256 _voteId, bool _supports) external onlyRepresentative(_voting, _voteId) {
+        // TODO: do we want to allow representatives to change their votes?
+        require(hasNotVoteYet(_voting, _voteId), ERROR_VOTE_ALREADY_CASTED);
+        require(!withinOverruleWindow(_voting, _voteId), ERROR_WITHIN_OVERRULE_WINDOW);
+
+        // do not execute if decided to allow principals overruling
+        _voting.vote(_voteId, _supports, false);
+    }
+
+    function vote(Voting _voting, uint256 _voteId, bool _supports, bool _executesIfDecided) external onlyPrincipal {
+        _voting.vote(_voteId, _supports, _executesIfDecided);
+    }
+
+    function hasNotVoteYet(Voting _voting, uint256 _voteId) public view returns (bool) {
+        return _voting.isVoteAbsent(_voteId, address(this));
+    }
+
+    function withinOverruleWindow(Voting _voting, uint256 _voteId) public view returns (bool) {
+        bool open = _voting.isVoteOpen(_voteId);
+        uint64 endDate = _voting.getVoteEndDate(_voteId);
+
+        // Note that if current timestamp is greater than the end date, open will be false
+        return open && getTimestamp64() >= endDate.sub(overruleWindow);
+    }
+
+    function isRepresentativeFullyAllowed(address _representative) public view returns (bool) {
+        return fullRepresentatives[_representative];
+    }
+
+    function isRepresentativeAllowedForInstance(address _representative, address _voting) public view returns (bool) {
+        return instanceRepresentatives[_voting][_representative];
+    }
+
+    function isRepresentativeAllowedForVote(address _representative, address _voting, uint256 _voteId) public view returns (bool) {
+        return voteRepresentatives[_voting][_voteId][_representative];
+    }
+
+    function _isRepresentativeAllowed(address _representative, address _voting, uint256 _voteId) internal view returns (bool) {
+        return isRepresentativeFullyAllowed(_representative) ||
+               isRepresentativeAllowedForInstance(_representative, _voting) ||
+               isRepresentativeAllowedForVote(_representative, _voting, _voteId);
+    }
+}

--- a/apps/voting/contracts/ProxyVoting.sol
+++ b/apps/voting/contracts/ProxyVoting.sol
@@ -43,21 +43,6 @@ contract ProxyVoting is TimeHelpers {
         overruleWindow = _overruleWindow;
     }
 
-    function setFullRepresentative(address _representative, bool _allowed) external onlyPrincipal {
-        fullRepresentatives[_representative] = _allowed;
-        emit ChangeFullRepresentative(_representative, _allowed);
-    }
-
-    function setInstanceRepresentative(address _representative, address _voting, bool _allowed) external onlyPrincipal {
-        instanceRepresentatives[_voting][_representative] = _allowed;
-        emit ChangeInstanceRepresentative(_representative, _voting, _allowed);
-    }
-
-    function setVoteRepresentative(address _representative, address _voting, uint256 _voteId, bool _allowed) external onlyPrincipal {
-        voteRepresentatives[_voting][_voteId][_representative] = _allowed;
-        emit ChangeVoteRepresentative(_representative, _voting, _voteId, _allowed);
-    }
-
     function withdraw(ERC20 _token, uint256 _amount) external onlyPrincipal {
         emit Withdraw(address(_token), _amount);
         require(_token.transfer(principal, _amount), ERROR_WITHDRAW_FAILED);
@@ -79,6 +64,21 @@ contract ProxyVoting is TimeHelpers {
 
     function vote(Voting _voting, uint256 _voteId, bool _supports, bool _executesIfDecided) external onlyPrincipal {
         _voting.vote(_voteId, _supports, _executesIfDecided);
+    }
+
+    function setFullRepresentative(address _representative, bool _allowed) public onlyPrincipal {
+        fullRepresentatives[_representative] = _allowed;
+        emit ChangeFullRepresentative(_representative, _allowed);
+    }
+
+    function setInstanceRepresentative(address _representative, address _voting, bool _allowed) public onlyPrincipal {
+        instanceRepresentatives[_voting][_representative] = _allowed;
+        emit ChangeInstanceRepresentative(_representative, _voting, _allowed);
+    }
+
+    function setVoteRepresentative(address _representative, address _voting, uint256 _voteId, bool _allowed) public onlyPrincipal {
+        voteRepresentatives[_voting][_voteId][_representative] = _allowed;
+        emit ChangeVoteRepresentative(_representative, _voting, _voteId, _allowed);
     }
 
     function hasNotVoteYet(Voting _voting, uint256 _voteId) public view returns (bool) {

--- a/apps/voting/contracts/RepresentativeProxy.sol
+++ b/apps/voting/contracts/RepresentativeProxy.sol
@@ -1,0 +1,88 @@
+pragma solidity ^0.4.24;
+
+import "./Voting.sol";
+import "./VotingHelpers.sol";
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
+import "@aragon/os/contracts/lib/math/SafeMath64.sol";
+import "@aragon/os/contracts/common/TimeHelpers.sol";
+
+
+contract RepresentativeProxy is TimeHelpers {
+    using SafeMath for uint256;
+    using SafeMath64 for uint64;
+    using VotingHelpers for Voting;
+
+    string constant private ERROR_WITHIN_OVERRULE_WINDOW = "RP_WITHIN_OVERRULE_WINDOW";
+    string constant private ERROR_SENDER_NOT_REPRESENTATIVE = "RP_SENDER_NOT_REPRESENTATIVE";
+    string constant private ERROR_DISALLOW_AMOUNT_UNAVAILABLE = "RP_DISALLOW_AMOUNT_UNAVAILABLE";
+    string constant private ERROR_TRANSFER_FROM_TOKEN_FAILED = "RP_TRANSFER_FROM_TOKEN_FAILED";
+    string constant private ERROR_TRANSFER_TO_PRINCIPAL_FAILED = "RP_TRANSFER_TO_PRINCIPAL_FAILED";
+
+    uint64 internal overruleWindow;
+    address internal representative;
+    mapping (address => mapping (address => uint256)) internal principalAmounts;
+
+    event Delegate(address principal, address token, uint256 amount, uint256 totalAmount);
+    event Withdraw(address principal, address token, uint256 amount, uint256 totalAmount);
+
+    modifier onlyRepresentative {
+        require(msg.sender == representative, ERROR_SENDER_NOT_REPRESENTATIVE);
+        _;
+    }
+
+    constructor(address _representative, uint64 _overruleWindow) public {
+        representative = _representative;
+        overruleWindow = _overruleWindow;
+    }
+
+    function delegate(ERC20 _token, uint256 _amount) external {
+        address tokenAddress = address(_token);
+        uint256 updatedAmount = principalAmounts[msg.sender][tokenAddress].add(_amount);
+        principalAmounts[msg.sender][tokenAddress] = updatedAmount;
+        emit Delegate(msg.sender, tokenAddress, _amount, updatedAmount);
+
+        require(_token.transferFrom(msg.sender, address(this), _amount), ERROR_TRANSFER_FROM_TOKEN_FAILED);
+    }
+
+    function withdraw(ERC20 _token, uint256 _amount) external {
+        address tokenAddress = address(_token);
+        uint256 currentAmount = principalAmounts[msg.sender][tokenAddress];
+        require(currentAmount >= _amount, ERROR_DISALLOW_AMOUNT_UNAVAILABLE);
+
+        uint256 updatedAmount = currentAmount.sub(_amount);
+        principalAmounts[msg.sender][tokenAddress] = updatedAmount;
+        emit Withdraw(msg.sender, tokenAddress, _amount, updatedAmount);
+
+        require(_token.transfer(msg.sender, _amount), ERROR_TRANSFER_TO_PRINCIPAL_FAILED);
+    }
+
+    function newVote(Voting _voting, bytes _executionScript, string _metadata) external onlyRepresentative returns (uint256 voteId) {
+        // do not cas principals vote to allow representatives vote
+        return _voting.newVote(_executionScript, _metadata, false, false);
+    }
+
+    function proxyVotes(Voting[] _votings, uint256[] _voteIds, bool[] _supports) external onlyRepresentative {
+        for (uint256 i = 0; i < _votings.length; i++) {
+            proxyVote(_votings[i], _voteIds[i], _supports[i]);
+        }
+    }
+
+    function proxyVote(Voting _voting, uint256 _voteId, bool _supports) public onlyRepresentative {
+        require(!withinOverruleWindow(_voting, _voteId), ERROR_WITHIN_OVERRULE_WINDOW);
+        // do not execute if decided to allow principals overruling
+        _voting.vote(_voteId, _supports, false);
+    }
+
+    function isAllowedBy(address _principal, address _token) public view returns (bool) {
+        return principalAmounts[_principal][_token] > 0;
+    }
+
+    function withinOverruleWindow(Voting _voting, uint256 _voteId) public view returns (bool) {
+        bool open = _voting.isVoteOpen(_voteId);
+        uint64 endDate = _voting.getVoteEndDate(_voteId);
+
+        // Note that if current timestamp is greater than the end date, open will be false
+        return open && getTimestamp64() >= endDate.sub(overruleWindow);
+    }
+}

--- a/apps/voting/contracts/VotingHelpers.sol
+++ b/apps/voting/contracts/VotingHelpers.sol
@@ -1,0 +1,25 @@
+pragma solidity 0.4.24;
+
+import "./Voting.sol";
+import "@aragon/os/contracts/lib/math/SafeMath64.sol";
+
+
+library VotingHelpers {
+    using SafeMath64 for uint64;
+
+    function isVoteAbsent(Voting self, uint256 voteId, address voter) internal view returns (bool) {
+        Voting.VoterState state = self.getVoterState(voteId, voter);
+        return state == Voting.VoterState.Absent;
+    }
+
+    function isVoteOpen(Voting self, uint256 voteId) internal view returns (bool open) {
+        (open, , , , , , , , , ) = self.getVote(voteId);
+    }
+
+    function getVoteEndDate(Voting self, uint256 voteId) internal view returns (uint64) {
+        uint64 startDate;
+        (, , startDate, , , , , , , ) = self.getVote(voteId);
+
+        return startDate.add(self.voteTime());
+    }
+}

--- a/apps/voting/contracts/test/mocks/HybridProxyVotingMock.sol
+++ b/apps/voting/contracts/test/mocks/HybridProxyVotingMock.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.4.24;
+
+import "../../HybridProxyVoting.sol";
+import "@aragon/test-helpers/contracts/TimeHelpersMock.sol";
+
+
+contract HybridProxyVotingMock is HybridProxyVoting, TimeHelpersMock {
+    constructor(address _principal, uint64 _overruleWindow) HybridProxyVoting(_principal, _overruleWindow) public {
+        // solium-disable-previous-line no-empty-blocks
+    }
+}
+
+
+contract ProxyVotingRegistryMock is ProxyVotingRegistry {
+    function newProxyVoting(uint64 _overruleWindow) external returns (HybridProxyVoting) {
+        HybridProxyVotingMock proxyVoting = new HybridProxyVotingMock(msg.sender, _overruleWindow);
+        address proxyVotingAddress = address(proxyVoting);
+        proxyVotings[proxyVotingAddress] = true;
+        emit NewProxyVoting(proxyVotingAddress);
+        return HybridProxyVoting(proxyVoting);
+    }
+}

--- a/apps/voting/contracts/test/mocks/ProxyVotingMock.sol
+++ b/apps/voting/contracts/test/mocks/ProxyVotingMock.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.24;
+
+import "../../ProxyVoting.sol";
+import "@aragon/test-helpers/contracts/TimeHelpersMock.sol";
+
+
+contract ProxyVotingMock is ProxyVoting, TimeHelpersMock {
+    constructor(address _principal, uint64 _overruleWindow) ProxyVoting(_principal, _overruleWindow) public {
+        // solium-disable-previous-line no-empty-blocks
+    }
+}

--- a/apps/voting/contracts/test/mocks/RepresentativeProxyMock.sol
+++ b/apps/voting/contracts/test/mocks/RepresentativeProxyMock.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.24;
+
+import "../../RepresentativeProxy.sol";
+import "@aragon/test-helpers/contracts/TimeHelpersMock.sol";
+
+
+contract RepresentativeProxyMock is RepresentativeProxy, TimeHelpersMock {
+    constructor(address _representative, uint64 _overruleWindow) RepresentativeProxy(_representative, _overruleWindow) public {
+        // solium-disable-previous-line no-empty-blocks
+    }
+}

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -49,7 +49,8 @@
     "solidity-sha3": "^0.4.1",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
-    "truffle-extract": "^1.2.1"
+    "truffle-extract": "^1.2.1",
+    "web3-eth-abi": "1.0.0-beta.33"
   },
   "dependencies": {
     "@aragon/apps-shared-minime": "1.0.0",

--- a/apps/voting/test/contracts/hybrid_proxy_voting.js
+++ b/apps/voting/test/contracts/hybrid_proxy_voting.js
@@ -1,0 +1,856 @@
+const VOTER_STATE = require('../helpers/state')
+const { bigExp, pct } = require('../helpers/numbers')(web3)
+const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { decodeEventsOfType } = require('@aragon/os/test/helpers/decodeEvent')
+const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
+const { assertEvent, assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
+
+const Voting = artifacts.require('VotingMock')
+const ProxyVoting = artifacts.require('HybridProxyVotingMock')
+const RepresentativeProxy = artifacts.require('HybridRepresentativeProxy')
+const ProxyVotingRegistry = artifacts.require('ProxyVotingRegistryMock')
+const ExecutionTarget = artifacts.require('ExecutionTarget')
+
+const ACL = artifacts.require('@aragon/os/contracts/acl/ACL')
+const Kernel = artifacts.require('@aragon/os/contracts/kernel/Kernel')
+const DAOFactory = artifacts.require('@aragon/os/contracts/factory/DAOFactory')
+const EVMScriptRegistryFactory = artifacts.require('@aragon/os/contracts/factory/EVMScriptRegistryFactory')
+const MiniMeToken = artifacts.require('@aragon/apps-shared-minime/contracts/MiniMeToken')
+
+const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+contract('HybridProxyVoting', ([_, root, holder20, holder29, holder51, representative, anyone, anotherVoting]) => {
+  let votingBase, kernelBase, aclBase, daoFactory
+  let dao, acl, voting, token, executionTarget, script, voteId, holder51Proxy, representativeProxy
+  let APP_MANAGER_ROLE, CREATE_VOTES_ROLE, MODIFY_SUPPORT_ROLE, MODIFY_QUORUM_ROLE
+
+  const NOW = 1553703809  // random fixed timestamp in seconds
+  const ONE_DAY = 60 * 60 * 24
+  const OVERRULE_WINDOW = ONE_DAY
+  const VOTING_DURATION = ONE_DAY * 5
+
+  const MIN_QUORUM = pct(20)
+  const MIN_SUPPORT = pct(70)
+
+  before('deploy base implementations', async () => {
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+    const regFact = await EVMScriptRegistryFactory.new()
+    daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, regFact.address)
+    votingBase = await Voting.new()
+  })
+
+  before('load roles', async () => {
+    APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
+    CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE()
+    MODIFY_SUPPORT_ROLE = await votingBase.MODIFY_SUPPORT_ROLE()
+    MODIFY_QUORUM_ROLE = await votingBase.MODIFY_QUORUM_ROLE()
+  })
+
+  before('create dao', async () => {
+    const receipt = await daoFactory.newDAO(root)
+    dao = Kernel.at(getEventArgument(receipt, 'DeployDAO', 'dao'))
+    acl = ACL.at(await dao.acl())
+    await acl.createPermission(root, dao.address, APP_MANAGER_ROLE, root, { from: root })
+  })
+
+  beforeEach('mint tokens', async () => {
+    token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 18, 'n', true, { from: root }) // empty parameters minime
+    await token.generateTokens(holder20, bigExp(20, 18), { from: root })
+    await token.generateTokens(holder29, bigExp(29, 18), { from: root })
+    await token.generateTokens(holder51, bigExp(51, 18), { from: root })
+  })
+
+  beforeEach('create proxy voting and representative proxy', async () => {
+    const registry = await ProxyVotingRegistry.new()
+
+    const representativeReceipt = await registry.newRepresentativeProxy({ from: representative })
+    const representativeProxyAddress = getEventArgument(representativeReceipt, 'NewRepresentativeProxy', 'representativeProxy')
+    assert(await registry.isValidRepresentativeProxy(representativeProxyAddress), 'representative proxy is not valid')
+    representativeProxy = RepresentativeProxy.at(representativeProxyAddress)
+
+    const principalReceipt = await registry.newProxyVoting(OVERRULE_WINDOW, { from: holder51 })
+    const proxyVotingAddress = getEventArgument(principalReceipt, 'NewProxyVoting', 'proxyVoting')
+    assert(await registry.isValidProxyVoting(proxyVotingAddress), 'proxy voting is not valid')
+    holder51Proxy = ProxyVoting.at(proxyVotingAddress)
+    await token.transfer(holder51Proxy.address, bigExp(51, 18), { from: holder51 })
+  })
+
+  beforeEach('create voting app', async () => {
+    const receipt = await dao.newAppInstance('0x1234', votingBase.address, '0x', false, { from: root })
+    voting = Voting.at(getNewProxyAddress(receipt))
+
+    await holder51Proxy.mockSetTimestamp(NOW)
+    await voting.mockSetTimestamp(NOW)
+    await voting.initialize(token.address, MIN_SUPPORT, MIN_QUORUM, VOTING_DURATION, { from: root })
+
+    await acl.createPermission(ANY_ADDR, voting.address, CREATE_VOTES_ROLE, root, { from: root })
+    await acl.createPermission(ANY_ADDR, voting.address, MODIFY_SUPPORT_ROLE, root, { from: root })
+    await acl.createPermission(ANY_ADDR, voting.address, MODIFY_QUORUM_ROLE, root, { from: root })
+  })
+
+  const createVote = async (from = holder51) => {
+    executionTarget = await ExecutionTarget.new()
+    const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
+    script = encodeCallScript([action])
+
+    const { tx } = await holder51Proxy.newVote(voting.address, script, 'metadata', { from })
+    const receipt = await web3.eth.getTransactionReceipt(tx)
+    const events = decodeEventsOfType(receipt, Voting.abi, 'StartVote')
+    assert.equal(events.length, 1, 'number of StartVote emitted events does not match')
+    const startVoteEvent = events[0].args
+    voteId = startVoteEvent.voteId
+    return startVoteEvent
+  }
+
+  const getVoteState = async () => {
+    const [open, executed, startDate, snapshotBlock, support, quorum, yeas, nays, votingPower, execScript] = await voting.getVote(voteId)
+    return { open, executed, startDate, snapshotBlock, support, quorum, yeas, nays, votingPower, execScript }
+  }
+
+  const getVoterState = async (voter) => voting.getVoterState(voteId, voter)
+
+  const increaseTime = async (seconds) => {
+    await voting.mockIncreaseTime(seconds)
+    await holder51Proxy.mockIncreaseTime(seconds)
+  }
+
+  describe('setFullRepresentative', () => {
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      context('when the proxy voting is valid', () => {
+        it('is not allowed by default', async () => {
+          assert.isFalse(await holder51Proxy.isRepresentativeFullyAllowed(representativeProxy.address))
+        })
+
+        context('when the representative was not set yet', () => {
+          context('when the representative is not blacklisted', () => {
+            it('sets the given representative', async () => {
+              const receipt = await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from })
+
+              assertAmountOfEvents(receipt, 'ChangeFullRepresentative')
+              assertEvent(receipt, 'ChangeFullRepresentative', { representative: representativeProxy.address, allowed: true })
+
+              assert.isTrue(await holder51Proxy.isRepresentativeFullyAllowed(representativeProxy.address))
+            })
+          })
+
+          context('when the representative is blacklisted', () => {
+            beforeEach('blacklist representative', async () => {
+              await representativeProxy.blacklistPrincipal(holder51Proxy.address, true, { from: representative })
+            })
+
+            it('reverts', async () => {
+              await assertRevert(holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from }), 'RP_BLACKLISTED_SENDER')
+            })
+          })
+        })
+
+        context('when the representative was already set', () => {
+          beforeEach('add representative', async () => {
+            await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from })
+          })
+
+          it('updates the given representative', async () => {
+            const receipt = await holder51Proxy.setFullRepresentative(representativeProxy.address, false, { from })
+
+            assertAmountOfEvents(receipt, 'ChangeFullRepresentative')
+            assertEvent(receipt, 'ChangeFullRepresentative', { representative: representativeProxy.address, allowed: false })
+
+            assert.isFalse(await holder51Proxy.isRepresentativeFullyAllowed(representativeProxy.address))
+          })
+        })
+      })
+
+      context('when the proxy voting is valid', () => {
+        it('reverts', async () => {
+          const invalidProxyVoting = await ProxyVoting.new(holder51, OVERRULE_WINDOW)
+          await assertRevert(invalidProxyVoting.setFullRepresentative(representativeProxy.address, true, { from }), 'RP_SENDER_NOT_PROXY_VOTING')
+        })
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('setInstanceRepresentative', () => {
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      context('when the proxy voting is valid', () => {
+        it('is not allowed by default', async () => {
+          assert.isFalse(await holder51Proxy.isRepresentativeAllowedForInstance(representativeProxy.address, voting.address))
+        })
+
+        context('when the representative was not set yet', () => {
+          context('when the representative is not blacklisted', () => {
+            it('sets the given representative', async () => {
+              const receipt = await holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, true, {from})
+
+              assertAmountOfEvents(receipt, 'ChangeInstanceRepresentative')
+              assertEvent(receipt, 'ChangeInstanceRepresentative', {
+                representative: representativeProxy.address,
+                voting: voting.address,
+                allowed: true
+              })
+
+              assert.isTrue(await holder51Proxy.isRepresentativeAllowedForInstance(representativeProxy.address, voting.address))
+            })
+          })
+
+          context('when the representative is blacklisted', () => {
+            beforeEach('blacklist representative', async () => {
+              await representativeProxy.blacklistPrincipal(holder51Proxy.address, true, {from: representative})
+            })
+
+            it('reverts', async () => {
+              await assertRevert(holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, true, {from}), 'RP_BLACKLISTED_SENDER')
+            })
+          })
+        })
+
+        context('when the representative was already set', () => {
+          beforeEach('add representative', async () => {
+            await holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, true, {from})
+          })
+
+          it('updates the given representative', async () => {
+            const receipt = await holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, false, { from })
+
+            assertAmountOfEvents(receipt, 'ChangeInstanceRepresentative')
+            assertEvent(receipt, 'ChangeInstanceRepresentative', {
+              representative: representativeProxy.address,
+              voting: voting.address,
+              allowed: false
+            })
+
+            assert.isFalse(await holder51Proxy.isRepresentativeAllowedForInstance(representativeProxy.address, voting.address))
+          })
+        })
+      })
+
+      context('when the proxy voting is valid', () => {
+        it('reverts', async () => {
+          const invalidProxyVoting = await ProxyVoting.new(holder51, OVERRULE_WINDOW)
+          await assertRevert(invalidProxyVoting.setInstanceRepresentative(representativeProxy.address, voting.address, false, { from }), 'RP_SENDER_NOT_PROXY_VOTING')
+        })
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, true, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('setVoteRepresentative', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      context('when the proxy voting is valid', () => {
+        it('is not allowed by default', async () => {
+          assert.isFalse(await holder51Proxy.isRepresentativeAllowedForVote(representativeProxy.address, voting.address, voteId))
+        })
+
+        context('when the representative was not set yet', () => {
+          context('when the representative is not blacklisted', () => {
+            it('sets the given representative', async () => {
+              const receipt = await holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, {from})
+
+              assertAmountOfEvents(receipt, 'ChangeVoteRepresentative')
+              assertEvent(receipt, 'ChangeVoteRepresentative', {
+                representative: representativeProxy.address,
+                voting: voting.address,
+                voteId,
+                allowed: true
+              })
+
+              assert.isTrue(await holder51Proxy.isRepresentativeAllowedForVote(representativeProxy.address, voting.address, voteId))
+            })
+          })
+
+          context('when the representative is blacklisted', () => {
+            beforeEach('blacklist representative', async () => {
+              await representativeProxy.blacklistPrincipal(holder51Proxy.address, true, {from: representative})
+            })
+
+            it('reverts', async () => {
+              await assertRevert(holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, {from}), 'RP_BLACKLISTED_SENDER')
+            })
+          })
+        })
+
+        context('when the representative was already set', () => {
+          beforeEach('add representative', async () => {
+            await holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, {from})
+          })
+
+          it('updates the given representative', async () => {
+            const receipt = await holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, false, { from })
+
+            assertAmountOfEvents(receipt, 'ChangeVoteRepresentative')
+            assertEvent(receipt, 'ChangeVoteRepresentative', {
+              representative: representativeProxy.address,
+              voting: voting.address,
+              voteId,
+              allowed: false
+            })
+
+            assert.isFalse(await holder51Proxy.isRepresentativeAllowedForVote(representativeProxy.address, voting.address, voteId))
+          })
+        })
+      })
+
+      context('when the proxy voting is valid', () => {
+        it('reverts', async () => {
+          const invalidProxyVoting = await ProxyVoting.new(holder51, OVERRULE_WINDOW)
+          await assertRevert(invalidProxyVoting.setVoteRepresentative(representativeProxy.address, voting.address, voteId, false, { from }), 'RP_SENDER_NOT_PROXY_VOTING')
+        })
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('newVote', () => {
+    context('when the sender is the principal', () => {
+      let startVoteEvent
+      const from = holder51
+
+      beforeEach('create a vote', async () => {
+        startVoteEvent = await createVote(from)
+      })
+
+      it('creates a vote', async () => {
+        assert.equal(voteId, 0, 'vote id should be correct')
+        assert.equal(startVoteEvent.metadata, 'metadata', 'should have returned correct metadata')
+        assert.equal(startVoteEvent.creator, web3.toChecksumAddress(holder51Proxy.address), 'creator should be correct')
+      })
+
+      it('does not cast the principal votes and has the correct state', async () => {
+        const { open, executed, yeas, nays } = await getVoteState()
+
+        assert.isTrue(open, 'vote should be open')
+        assert.isFalse(executed, 'vote should not be executed')
+        assert.equal(yeas.toString(), 0, 'yeas should be 0')
+        assert.equal(nays.toString(), 0, 'nays should be 0')
+        assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal should not have voted yet')
+        assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.ABSENT, 'principal proxy should not have voted yet')
+      })
+
+      it('sets it up correctly', async () => {
+        const { startDate, snapshotBlock, support, quorum, votingPower, execScript } = await getVoteState()
+
+        assert.equal(startDate.toString(), NOW, 'start date should be correct')
+        assert.equal(snapshotBlock.toString(), await getBlockNumber() - 1, 'snapshot block should be correct')
+        assert.equal(support.toString(), MIN_SUPPORT.toString(), 'required support should be app required support')
+        assert.equal(quorum.toString(), MIN_QUORUM.toString(), 'min quorum should be app min quorum')
+        assert.equal(votingPower.toString(), bigExp(100, 18).toString(), 'voting power should be 100')
+        assert.equal(execScript, script, 'script should be correct')
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.newVote(voting.address, script, 'metadata', { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('proxyVote', () => {
+    context('when the vote exists', () => {
+      beforeEach('create a vote', createVote)
+
+      context('when the representative is an EOA', () => {
+        context('when the representative is not allowed', () => {
+          const from = representative
+
+          const itReverts = () => {
+            it('reverts', async () => {
+              await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from }), 'PV_REPRESENTATIVE_NOT_ALLOWED')
+            })
+          }
+
+          context('when the representative is not allowed at all', () => {
+            itReverts()
+          })
+
+          context('when the representative is allowed for a another vote instance', () => {
+            beforeEach('allow representative for another instance', async () => {
+              await holder51Proxy.setInstanceRepresentative(representative, anotherVoting, true, { from: holder51 })
+            })
+
+            itReverts()
+          })
+
+          context('when the representative is allowed for a another vote', () => {
+            beforeEach('allow representative for another vote', async () => {
+              await holder51Proxy.setVoteRepresentative(representative, voting.address, voteId + 1, true, { from: holder51 })
+            })
+
+            itReverts()
+          })
+        })
+
+        context('when the representative is allowed', () => {
+          const from = representative
+
+          context('when not within the overrule window', () => {
+            const itCastsTheProxiedVote = () => {
+              beforeEach('proxy representative\'s vote', async () => {
+                await holder51Proxy.proxyVote(voting.address, voteId, false, { from: representative })
+              })
+
+              it('casts the proxied vote', async () => {
+                const { yeas, nays } = await getVoteState()
+
+                assert.equal(yeas.toString(), 0, 'yeas should be 0')
+                assert.equal(nays.toString(), bigExp(51, 18).toString(), 'nays should be 51%')
+                assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
+                assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.NAY, 'principal proxy should have voted')
+              })
+
+              it('cannot be changed by the same representative', async () => {
+                await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from }), 'PV_VOTE_ALREADY_CASTED')
+              })
+
+              it('cannot be overruled by another representative', async () => {
+                await holder51Proxy.setFullRepresentative(holder29, true, { from: holder51 })
+                await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from: holder29 }), 'PV_VOTE_ALREADY_CASTED')
+              })
+            }
+
+            context('when the representative is allowed for any vote instance', () => {
+              beforeEach('allow representative for any instance', async () => {
+                await holder51Proxy.setFullRepresentative(representative, true, { from: holder51 })
+              })
+
+              itCastsTheProxiedVote()
+            })
+
+            context('when the representative is allowed for that particular vote instance', () => {
+              beforeEach('allow representative for instance', async () => {
+                await holder51Proxy.setInstanceRepresentative(representative, voting.address, true, { from: holder51 })
+              })
+
+              itCastsTheProxiedVote()
+            })
+
+            context('when the representative is allowed for that particular vote', () => {
+              beforeEach('allow representative for vote', async () => {
+                await holder51Proxy.setVoteRepresentative(representative, voting.address, voteId, true, { from: holder51 })
+              })
+
+              itCastsTheProxiedVote()
+            })
+          })
+
+          context('when within the overrule window', () => {
+            beforeEach('move within overrule window', async () => {
+              await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+            })
+
+            const itReverts = () => {
+              it('reverts', async () => {
+                await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from }), 'PV_WITHIN_OVERRULE_WINDOW')
+              })
+            }
+
+            context('when the representative is allowed for any vote instance', () => {
+              beforeEach('allow representative for any instance', async () => {
+                await holder51Proxy.setFullRepresentative(representative, true, { from: holder51 })
+              })
+
+              itReverts()
+            })
+
+            context('when the representative is allowed for that particular vote instance', () => {
+              beforeEach('allow representative for instance', async () => {
+                await holder51Proxy.setInstanceRepresentative(representative, voting.address, true, { from: holder51 })
+              })
+
+              itReverts()
+            })
+
+            context('when the representative is allowed for that particular vote', () => {
+              beforeEach('allow representative for vote', async () => {
+                await holder51Proxy.setVoteRepresentative(representative, voting.address, voteId, true, { from: holder51 })
+              })
+
+              itReverts()
+            })
+          })
+        })
+      })
+
+      context('when the representative is a proxy', () => {
+        context('when the representative is not allowed', () => {
+          const from = representative
+
+          const itDoesNotProxyTheVote = () => {
+            it('does not cast the vote', async () => {
+              await representativeProxy.proxyVotes([voting.address], [voteId], [true], { from })
+
+              const { yeas, nays } = await getVoteState()
+
+              assert.equal(yeas.toString(), 0, 'yeas should be 0')
+              assert.equal(nays.toString(), 0, 'nays should be 0')
+              assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal should not have voted')
+              assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.ABSENT, 'principal proxy should not have voted yet')
+            })
+          }
+
+          context('when the representative is not allowed at all', () => {
+            itDoesNotProxyTheVote()
+          })
+
+          context('when the representative is allowed for a another vote instance', () => {
+            beforeEach('allow representative for another instance', async () => {
+              await holder51Proxy.setInstanceRepresentative(representativeProxy.address, anotherVoting, true, { from: holder51 })
+            })
+
+            itDoesNotProxyTheVote()
+          })
+
+          context('when the representative is allowed for a another vote', () => {
+            beforeEach('allow representative for another vote', async () => {
+              await holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, { from: holder51 })
+              await createVote()
+            })
+
+            itDoesNotProxyTheVote()
+          })
+        })
+
+        context('when the representative is allowed', () => {
+          const from = representative
+
+          context('when not within the overrule window', () => {
+            const itCastsTheProxiedVote = () => {
+              context('when the sender is the representative', () => {
+                beforeEach('proxy representative\'s vote', async () => {
+                  await representativeProxy.proxyVotes([voting.address], [voteId], [false], { from: representative })
+                })
+
+                it('casts the proxied vote', async () => {
+                  const { yeas, nays } = await getVoteState()
+
+                  assert.equal(yeas.toString(), 0, 'yeas should be 0')
+                  assert.equal(nays.toString(), bigExp(51, 18).toString(), 'nays should be 51%')
+                  assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
+                  assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.NAY, 'principal proxy should have voted')
+                })
+
+                it('cannot be changed by the same representative', async () => {
+                  await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [true], { from }), 'PV_VOTE_ALREADY_CASTED')
+                })
+
+                it('cannot be overruled by another representative', async () => {
+                  await holder51Proxy.setFullRepresentative(holder29, true, { from: holder51 })
+                  await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from: holder29 }), 'PV_VOTE_ALREADY_CASTED')
+                })
+              })
+
+              context('when the sender is not the representative', () => {
+                it('reverts', async () => {
+                  await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [false], { from: anyone }), 'RP_SENDER_NOT_REPRESENTATIVE')
+                })
+              })
+            }
+
+            context('when the representative is allowed for any vote instance', () => {
+              beforeEach('allow representative for any instance', async () => {
+                await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from: holder51 })
+              })
+
+              itCastsTheProxiedVote()
+            })
+
+            context('when the representative is allowed for that particular vote instance', () => {
+              beforeEach('allow representative for instance', async () => {
+                await holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, true, { from: holder51 })
+              })
+
+              itCastsTheProxiedVote()
+            })
+
+            context('when the representative is allowed for that particular vote', () => {
+              beforeEach('allow representative for vote', async () => {
+                await holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, { from: holder51 })
+              })
+
+              itCastsTheProxiedVote()
+            })
+          })
+
+          context('when within the overrule window', () => {
+            beforeEach('move within overrule window', async () => {
+              await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+            })
+
+            const itReverts = () => {
+              it('reverts', async () => {
+                await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [true], { from }), 'PV_WITHIN_OVERRULE_WINDOW')
+              })
+            }
+
+            context('when the representative is allowed for any vote instance', () => {
+              beforeEach('allow representative for any instance', async () => {
+                await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from: holder51 })
+              })
+
+              itReverts()
+            })
+
+            context('when the representative is allowed for that particular vote instance', () => {
+              beforeEach('allow representative for instance', async () => {
+                await holder51Proxy.setInstanceRepresentative(representativeProxy.address, voting.address, true, { from: holder51 })
+              })
+
+              itReverts()
+            })
+
+            context('when the representative is allowed for that particular vote', () => {
+              beforeEach('allow representative for vote', async () => {
+                await holder51Proxy.setVoteRepresentative(representativeProxy.address, voting.address, voteId, true, { from: holder51 })
+              })
+
+              itReverts()
+            })
+          })
+        })
+      })
+    })
+
+    context('when the vote does not exist', () => {
+      it('reverts', async () => {
+        await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from: holder51 })
+        await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [true], { from: representative }), 'VOTING_NO_VOTE')
+      })
+    })
+  })
+
+  describe('vote', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      const itCastsTheProxiedVote = () => {
+        it('casts the proxied vote', async () => {
+          await holder51Proxy.vote(voting.address, voteId, true, false, { from })
+
+          const { yeas, nays } = await getVoteState()
+
+          assert.equal(yeas.toString(), bigExp(51, 18).toString(), 'yeas should be 51%')
+          assert.equal(nays.toString(), 0, 'nays should be 0')
+          assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
+          assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.YEA, 'principal proxy should have voted')
+        })
+      }
+
+      context('when no one proxied a vote yet', () => {
+        itCastsTheProxiedVote()
+      })
+
+      context('when a representative already proxied a vote', () => {
+        beforeEach('proxy representative\'s vote', async () => {
+          await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from: holder51 })
+          await representativeProxy.proxyVote(voting.address, voteId, false, { from: representative })
+        })
+
+        itCastsTheProxiedVote()
+      })
+
+      context('when the principal already proxied a vote', () => {
+        beforeEach('proxy principal\'s vote', async () => {
+          await holder51Proxy.vote(voting.address, voteId, false, false, { from: holder51 })
+        })
+
+        itCastsTheProxiedVote()
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.vote(voting.address, voteId, true, false, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('hasNotVoteYet', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when no one has vote yet', () => {
+      it('returns true', async () => {
+        assert.isTrue(await holder51Proxy.hasNotVoteYet(voting.address, voteId))
+      })
+    })
+
+    context('when a representative has proxied a vote', () => {
+      beforeEach('proxy representative\'s vote', async () => {
+        await holder51Proxy.setFullRepresentative(representativeProxy.address, true, { from: holder51 })
+        await representativeProxy.proxyVote(voting.address, voteId, true, { from: representative })
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.hasNotVoteYet(voting.address, voteId))
+      })
+    })
+
+    context('when the principal has proxied a vote', () => {
+      beforeEach('proxy principal\'s vote', async () => {
+        await holder51Proxy.vote(voting.address, voteId, true, false, { from: holder51 })
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.hasNotVoteYet(voting.address, voteId))
+      })
+    })
+  })
+
+  describe('withinOverruleWindow', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when previous to the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(ONE_DAY)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when right at the beginning of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+      })
+
+      it('returns true', async () => {
+        assert.isTrue(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when in the middle of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION - OVERRULE_WINDOW/2 )
+      })
+
+      it('returns true', async () => {
+        assert.isTrue(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when right at the end of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when after the end of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION + 1)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+  })
+
+  describe('withdraw', () => {
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      context('when the transfer succeeds', () => {
+        const amount = bigExp(1, 18)
+
+        it('transfers the requested amount of tokens to the principal', async () => {
+          const previousProxyBalance = await token.balanceOf(holder51Proxy.address)
+          const previousPrincipalBalance = await token.balanceOf(holder51)
+
+          await holder51Proxy.withdraw(token.address, amount, { from })
+
+          const currentProxyBalance = await token.balanceOf(holder51Proxy.address)
+          assert.equal(currentProxyBalance.toString(), previousProxyBalance.minus(amount).toString())
+
+          const currentPrincipalBalance = await token.balanceOf(holder51)
+          assert.equal(currentPrincipalBalance.toString(), previousPrincipalBalance.plus(amount).toString())
+        })
+
+        it('emits an event', async () => {
+          const receipt = await holder51Proxy.withdraw(token.address, amount, { from })
+
+          assertAmountOfEvents(receipt, 'Withdraw')
+          assertEvent(receipt, 'Withdraw', { token: token.address, amount })
+        })
+      })
+
+      context('when the transfer does not succeed', () => {
+        const amount = bigExp(100, 18)
+
+        it('reverts', async () => {
+          await assertRevert(holder51Proxy.withdraw(token.address, amount, { from }), 'PV_WITHDRAW_FAILED')
+        })
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.withdraw(token.address, 1, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('registry', () => {
+    const ProxyVotingRegistry = artifacts.require('ProxyVotingRegistry')
+
+    it('creates proxy votings', async () => {
+      const registry = await ProxyVotingRegistry.new()
+      const receipt = await registry.newRepresentativeProxy({ from: representative })
+      const representativeProxyAddress = getEventArgument(receipt, 'NewRepresentativeProxy', 'representativeProxy')
+
+      assert(await registry.isValidRepresentativeProxy(representativeProxyAddress), 'representative proxy is not valid')
+    })
+
+    it('creates representatives proxies', async () => {
+      const registry = await ProxyVotingRegistry.new()
+      const receipt = await registry.newProxyVoting(OVERRULE_WINDOW, { from: holder51 })
+      const proxyVotingAddress = getEventArgument(receipt, 'NewProxyVoting', 'proxyVoting')
+
+      assert(await registry.isValidProxyVoting(proxyVotingAddress), 'proxy voting is not valid')
+    })
+  })
+})

--- a/apps/voting/test/contracts/proxy_voting.js
+++ b/apps/voting/test/contracts/proxy_voting.js
@@ -62,7 +62,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
     await token.generateTokens(holder51, bigExp(51, 18), { from: root })
   })
 
-  before('deploy proxy voting', async () => {
+  before('create proxy voting', async () => {
     holder51Proxy = await ProxyVoting.new(holder51, OVERRULE_WINDOW)
     await token.transfer(holder51Proxy.address, bigExp(51, 18), { from: holder51 })
   })
@@ -107,7 +107,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
   }
 
   describe('setFullRepresentative', () => {
-    context('when the sender is the principal', async () => {
+    context('when the sender is the principal', () => {
       const from = holder51
 
       it('is not allowed by default', async () => {
@@ -141,7 +141,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
       })
     })
 
-    context('when the sender is not the principal', async () => {
+    context('when the sender is not the principal', () => {
       const from = anyone
 
       it('reverts', async () => {
@@ -151,7 +151,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
   })
 
   describe('setInstanceRepresentative', () => {
-    context('when the sender is the principal', async () => {
+    context('when the sender is the principal', () => {
       const from = holder51
 
       it('is not allowed by default', async () => {
@@ -185,7 +185,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
       })
     })
 
-    context('when the sender is not the principal', async () => {
+    context('when the sender is not the principal', () => {
       const from = anyone
 
       it('reverts', async () => {
@@ -197,7 +197,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
   describe('setVoteRepresentative', () => {
     beforeEach('create a vote', createVote)
 
-    context('when the sender is the principal', async () => {
+    context('when the sender is the principal', () => {
       const from = holder51
 
       it('is not allowed by default', async () => {
@@ -231,7 +231,7 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
       })
     })
 
-    context('when the sender is not the principal', async () => {
+    context('when the sender is not the principal', () => {
       const from = anyone
 
       it('reverts', async () => {
@@ -260,8 +260,8 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
 
         assert.isTrue(open, 'vote should be open')
         assert.isFalse(executed, 'vote should not be executed')
-        assert.equal(yeas.toString(), 0, 'initial yea should be 0')
-        assert.equal(nays.toString(), 0, 'initial nay should be 0')
+        assert.equal(yeas.toString(), 0, 'yeas should be 0')
+        assert.equal(nays.toString(), 0, 'nays should be 0')
         assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal should not have voted yet')
         assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.ABSENT, 'principal proxy should not have voted yet')
       })
@@ -333,8 +333,8 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
             it('casts the proxied vote', async () => {
               const { yeas, nays } = await getVoteState()
 
-              assert.equal(yeas.toString(), 0, 'initial yea should be 0')
-              assert.equal(nays.toString(), bigExp(51, 18).toString(), 'initial nay should be 51%')
+              assert.equal(yeas.toString(), 0, 'yeas should be 0')
+              assert.equal(nays.toString(), bigExp(51, 18).toString(), 'nays should be 51%')
               assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
               assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.NAY, 'principal proxy should have voted')
             })
@@ -432,8 +432,8 @@ contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, another
 
           const { yeas, nays } = await getVoteState()
 
-          assert.equal(yeas.toString(), bigExp(51, 18).toString(), 'initial yea should be 51%')
-          assert.equal(nays.toString(), 0, 'initial nay should be 0')
+          assert.equal(yeas.toString(), bigExp(51, 18).toString(), 'yeas should be 51%')
+          assert.equal(nays.toString(), 0, 'nays should be 0')
           assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
           assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.YEA, 'principal proxy should have voted')
         })

--- a/apps/voting/test/contracts/proxy_voting.js
+++ b/apps/voting/test/contracts/proxy_voting.js
@@ -1,0 +1,603 @@
+const VOTER_STATE = require('../helpers/state')
+const { bigExp, pct } = require('../helpers/numbers')(web3)
+const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { decodeEventsOfType } = require('@aragon/os/test/helpers/decodeEvent')
+const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
+const { assertEvent, assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
+
+const Voting = artifacts.require('VotingMock')
+const ProxyVoting = artifacts.require('ProxyVotingMock')
+const ExecutionTarget = artifacts.require('ExecutionTarget')
+
+const ACL = artifacts.require('@aragon/os/contracts/acl/ACL')
+const Kernel = artifacts.require('@aragon/os/contracts/kernel/Kernel')
+const DAOFactory = artifacts.require('@aragon/os/contracts/factory/DAOFactory')
+const EVMScriptRegistryFactory = artifacts.require('@aragon/os/contracts/factory/EVMScriptRegistryFactory')
+const MiniMeToken = artifacts.require('@aragon/apps-shared-minime/contracts/MiniMeToken')
+
+const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+contract('ProxyVoting', ([_, root, holder20, holder29, holder51, anyone, anotherVoting]) => {
+  let votingBase, kernelBase, aclBase, daoFactory
+  let dao, acl, voting, token, executionTarget, script, voteId, holder51Proxy
+  let APP_MANAGER_ROLE, CREATE_VOTES_ROLE, MODIFY_SUPPORT_ROLE, MODIFY_QUORUM_ROLE
+
+  const NOW = 1553703809  // random fixed timestamp in seconds
+  const ONE_DAY = 60 * 60 * 24
+  const OVERRULE_WINDOW = ONE_DAY
+  const VOTING_DURATION = ONE_DAY * 5
+
+  const MIN_QUORUM = pct(20)
+  const MIN_SUPPORT = pct(70)
+
+  before('deploy base implementations', async () => {
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+    const regFact = await EVMScriptRegistryFactory.new()
+    daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, regFact.address)
+    votingBase = await Voting.new()
+  })
+
+  before('load roles', async () => {
+    APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
+    CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE()
+    MODIFY_SUPPORT_ROLE = await votingBase.MODIFY_SUPPORT_ROLE()
+    MODIFY_QUORUM_ROLE = await votingBase.MODIFY_QUORUM_ROLE()
+  })
+
+  before('create dao', async () => {
+    const receipt = await daoFactory.newDAO(root)
+    dao = Kernel.at(getEventArgument(receipt, 'DeployDAO', 'dao'))
+    acl = ACL.at(await dao.acl())
+    await acl.createPermission(root, dao.address, APP_MANAGER_ROLE, root, { from: root })
+  })
+
+  before('mint tokens', async () => {
+    token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 18, 'n', true, { from: root }) // empty parameters minime
+    await token.generateTokens(holder20, bigExp(20, 18), { from: root })
+    await token.generateTokens(holder29, bigExp(29, 18), { from: root })
+    await token.generateTokens(holder51, bigExp(51, 18), { from: root })
+  })
+
+  before('deploy proxy voting', async () => {
+    holder51Proxy = await ProxyVoting.new(holder51, OVERRULE_WINDOW)
+    await token.transfer(holder51Proxy.address, bigExp(51, 18), { from: holder51 })
+  })
+
+  beforeEach('create voting app', async () => {
+    const receipt = await dao.newAppInstance('0x1234', votingBase.address, '0x', false, { from: root })
+    voting = Voting.at(getNewProxyAddress(receipt))
+
+    await holder51Proxy.mockSetTimestamp(NOW)
+    await voting.mockSetTimestamp(NOW)
+    await voting.initialize(token.address, MIN_SUPPORT, MIN_QUORUM, VOTING_DURATION, { from: root })
+
+    await acl.createPermission(ANY_ADDR, voting.address, CREATE_VOTES_ROLE, root, { from: root })
+    await acl.createPermission(ANY_ADDR, voting.address, MODIFY_SUPPORT_ROLE, root, { from: root })
+    await acl.createPermission(ANY_ADDR, voting.address, MODIFY_QUORUM_ROLE, root, { from: root })
+  })
+
+  const createVote = async (from = holder51) => {
+    executionTarget = await ExecutionTarget.new()
+    const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
+    script = encodeCallScript([action])
+
+    const { tx } = await holder51Proxy.newVote(voting.address, script, 'metadata', { from })
+    const receipt = await web3.eth.getTransactionReceipt(tx)
+    const events = decodeEventsOfType(receipt, Voting.abi, 'StartVote')
+    assert.equal(events.length, 1, 'number of StartVote emitted events does not match')
+    const startVoteEvent = events[0].args
+    voteId = startVoteEvent.voteId
+    return startVoteEvent
+  }
+
+  const getVoteState = async () => {
+    const [open, executed, startDate, snapshotBlock, support, quorum, yeas, nays, votingPower, execScript] = await voting.getVote(voteId)
+    return { open, executed, startDate, snapshotBlock, support, quorum, yeas, nays, votingPower, execScript }
+  }
+
+  const getVoterState = async (voter) => voting.getVoterState(voteId, voter)
+
+  const increaseTime = async (seconds) => {
+    await voting.mockIncreaseTime(seconds)
+    await holder51Proxy.mockIncreaseTime(seconds)
+  }
+
+  describe('setFullRepresentative', () => {
+    context('when the sender is the principal', async () => {
+      const from = holder51
+
+      it('is not allowed by default', async () => {
+        assert.isFalse(await holder51Proxy.isRepresentativeFullyAllowed(holder20))
+      })
+
+      context('when the representative was not set yet', () => {
+        it('sets the given representative', async () => {
+          const receipt = await holder51Proxy.setFullRepresentative(holder20, true, { from })
+
+          assertAmountOfEvents(receipt, 'ChangeFullRepresentative')
+          assertEvent(receipt, 'ChangeFullRepresentative', { representative: holder20, allowed: true })
+
+          assert.isTrue(await holder51Proxy.isRepresentativeFullyAllowed(holder20))
+        })
+      })
+
+      context('when the representative was already set', () => {
+        beforeEach('add representative', async () => {
+          await holder51Proxy.setFullRepresentative(holder20, true, { from })
+        })
+
+        it('updates the given representative', async () => {
+          const receipt = await holder51Proxy.setFullRepresentative(holder20, false, { from })
+
+          assertAmountOfEvents(receipt, 'ChangeFullRepresentative')
+          assertEvent(receipt, 'ChangeFullRepresentative', { representative: holder20, allowed: false })
+
+          assert.isFalse(await holder51Proxy.isRepresentativeFullyAllowed(holder20))
+        })
+      })
+    })
+
+    context('when the sender is not the principal', async () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.setFullRepresentative(holder20, true, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('setInstanceRepresentative', () => {
+    context('when the sender is the principal', async () => {
+      const from = holder51
+
+      it('is not allowed by default', async () => {
+        assert.isFalse(await holder51Proxy.isRepresentativeAllowedForInstance(holder20, voting.address))
+      })
+
+      context('when the representative was not set yet', () => {
+        it('sets the given representative', async () => {
+          const receipt = await holder51Proxy.setInstanceRepresentative(holder20, voting.address, true, { from })
+
+          assertAmountOfEvents(receipt, 'ChangeInstanceRepresentative')
+          assertEvent(receipt, 'ChangeInstanceRepresentative', { representative: holder20, voting: voting.address, allowed: true })
+
+          assert.isTrue(await holder51Proxy.isRepresentativeAllowedForInstance(holder20, voting.address))
+        })
+      })
+
+      context('when the representative was already set', () => {
+        beforeEach('add representative', async () => {
+          await holder51Proxy.setInstanceRepresentative(holder20, voting.address, true, { from })
+        })
+
+        it('updates the given representative', async () => {
+          const receipt = await holder51Proxy.setInstanceRepresentative(holder20, voting.address, false, { from })
+
+          assertAmountOfEvents(receipt, 'ChangeInstanceRepresentative')
+          assertEvent(receipt, 'ChangeInstanceRepresentative', { representative: holder20, voting: voting.address, allowed: false })
+
+          assert.isFalse(await holder51Proxy.isRepresentativeAllowedForInstance(holder20, voting.address))
+        })
+      })
+    })
+
+    context('when the sender is not the principal', async () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.setInstanceRepresentative(holder20, voting.address, true, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('setVoteRepresentative', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when the sender is the principal', async () => {
+      const from = holder51
+
+      it('is not allowed by default', async () => {
+        assert.isFalse(await holder51Proxy.isRepresentativeAllowedForVote(holder20, voting.address, voteId))
+      })
+
+      context('when the representative was not set yet', () => {
+        it('sets the given representative', async () => {
+          const receipt = await holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId, true, { from })
+
+          assertAmountOfEvents(receipt, 'ChangeVoteRepresentative')
+          assertEvent(receipt, 'ChangeVoteRepresentative', { representative: holder20, voting: voting.address, voteId, allowed: true })
+
+          assert.isTrue(await holder51Proxy.isRepresentativeAllowedForVote(holder20, voting.address, voteId))
+        })
+      })
+
+      context('when the representative was already set', () => {
+        beforeEach('add representative', async () => {
+          await holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId, true, { from })
+        })
+
+        it('updates the given representative', async () => {
+          const receipt = await holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId, false, { from })
+
+          assertAmountOfEvents(receipt, 'ChangeVoteRepresentative')
+          assertEvent(receipt, 'ChangeVoteRepresentative', { representative: holder20, voting: voting.address, voteId, allowed: false })
+
+          assert.isFalse(await holder51Proxy.isRepresentativeAllowedForVote(holder20, voting.address, voteId))
+        })
+      })
+    })
+
+    context('when the sender is not the principal', async () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId, true, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('newVote', () => {
+    context('when the sender is the principal', () => {
+      let startVoteEvent
+      const from = holder51
+
+      beforeEach('create a vote', async () => {
+        startVoteEvent = await createVote(from)
+      })
+
+      it('creates a vote', async () => {
+        assert.equal(voteId, 0, 'vote id should be correct')
+        assert.equal(startVoteEvent.metadata, 'metadata', 'should have returned correct metadata')
+        assert.equal(startVoteEvent.creator, web3.toChecksumAddress(holder51Proxy.address), 'creator should be correct')
+      })
+
+      it('does not cast the principal votes and has the correct state', async () => {
+        const { open, executed, yeas, nays } = await getVoteState()
+
+        assert.isTrue(open, 'vote should be open')
+        assert.isFalse(executed, 'vote should not be executed')
+        assert.equal(yeas.toString(), 0, 'initial yea should be 0')
+        assert.equal(nays.toString(), 0, 'initial nay should be 0')
+        assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal should not have voted yet')
+        assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.ABSENT, 'principal proxy should not have voted yet')
+      })
+
+      it('sets it up correctly', async () => {
+        const { startDate, snapshotBlock, support, quorum, votingPower, execScript } = await getVoteState()
+
+        assert.equal(startDate.toString(), NOW, 'start date should be correct')
+        assert.equal(snapshotBlock.toString(), await getBlockNumber() - 1, 'snapshot block should be correct')
+        assert.equal(support.toString(), MIN_SUPPORT.toString(), 'required support should be app required support')
+        assert.equal(quorum.toString(), MIN_QUORUM.toString(), 'min quorum should be app min quorum')
+        assert.equal(votingPower.toString(), bigExp(100, 18).toString(), 'voting power should be 100')
+        assert.equal(execScript, script, 'script should be correct')
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.newVote(voting.address, script, 'metadata', { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('proxyVote', () => {
+    context('when the vote exists', () => {
+      beforeEach('create a vote', createVote)
+
+      context('when the representative is not allowed', () => {
+        const from = holder20
+
+        const itReverts = () => {
+          it('reverts', async () => {
+            await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from }), 'PV_REPRESENTATIVE_NOT_ALLOWED')
+          })
+        }
+
+        context('when the representative is not allowed at all', () => {
+          itReverts()
+        })
+
+        context('when the representative is allowed for a another vote instance', () => {
+          beforeEach('allow representative for another instance', async () => {
+            await holder51Proxy.setInstanceRepresentative(holder20, anotherVoting, true, { from: holder51 })
+          })
+
+          itReverts()
+        })
+
+        context('when the representative is allowed for a another vote', () => {
+          beforeEach('allow representative for another vote', async () => {
+            await holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId + 1, true, { from: holder51 })
+          })
+
+          itReverts()
+        })
+      })
+
+      context('when the representative is allowed', () => {
+        const from = holder20
+
+        context('when not within the overrule window', () => {
+          const itCastsTheProxiedVote = () => {
+            beforeEach('proxy representative\'s vote', async () => {
+              await holder51Proxy.proxyVote(voting.address, voteId, false, { from: holder20 })
+            })
+
+            it('casts the proxied vote', async () => {
+              const { yeas, nays } = await getVoteState()
+
+              assert.equal(yeas.toString(), 0, 'initial yea should be 0')
+              assert.equal(nays.toString(), bigExp(51, 18).toString(), 'initial nay should be 51%')
+              assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
+              assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.NAY, 'principal proxy should have voted')
+            })
+
+            it('cannot be changed by the same representative', async () => {
+              await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from }), 'PV_VOTE_ALREADY_CASTED')
+            })
+
+            it('cannot be overruled by another representative', async () => {
+              await holder51Proxy.setFullRepresentative(holder29, true, { from: holder51 })
+              await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from: holder29 }), 'PV_VOTE_ALREADY_CASTED')
+            })
+          }
+
+          context('when the representative is allowed for any vote instance', () => {
+            beforeEach('allow representative for any instance', async () => {
+              await holder51Proxy.setFullRepresentative(holder20, true, { from: holder51 })
+            })
+
+            itCastsTheProxiedVote()
+          })
+
+          context('when the representative is allowed for that particular vote instance', () => {
+            beforeEach('allow representative for instance', async () => {
+              await holder51Proxy.setInstanceRepresentative(holder20, voting.address, true, { from: holder51 })
+            })
+
+            itCastsTheProxiedVote()
+          })
+
+          context('when the representative is allowed for that particular vote', () => {
+            beforeEach('allow representative for vote', async () => {
+              await holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId, true, { from: holder51 })
+            })
+
+            itCastsTheProxiedVote()
+          })
+        })
+
+        context('when within the overrule window', () => {
+          beforeEach('move within overrule window', async () => {
+            await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+          })
+
+          const itReverts = () => {
+            it('reverts', async () => {
+              await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from }), 'PV_WITHIN_OVERRULE_WINDOW')
+            })
+          }
+
+          context('when the representative is allowed for any vote instance', () => {
+            beforeEach('allow representative for any instance', async () => {
+              await holder51Proxy.setFullRepresentative(holder20, true, { from: holder51 })
+            })
+
+            itReverts()
+          })
+
+          context('when the representative is allowed for that particular vote instance', () => {
+            beforeEach('allow representative for instance', async () => {
+              await holder51Proxy.setInstanceRepresentative(holder20, voting.address, true, { from: holder51 })
+            })
+
+            itReverts()
+          })
+
+          context('when the representative is allowed for that particular vote', () => {
+            beforeEach('allow representative for vote', async () => {
+              await holder51Proxy.setVoteRepresentative(holder20, voting.address, voteId, true, { from: holder51 })
+            })
+
+            itReverts()
+          })
+        })
+      })
+    })
+
+    context('when the vote does not exist', () => {
+      it('reverts', async () => {
+        await holder51Proxy.setFullRepresentative(holder20, true, { from: holder51 })
+        await assertRevert(holder51Proxy.proxyVote(voting.address, voteId, true, { from: holder20 }), 'VOTING_NO_VOTE')
+      })
+    })
+  })
+
+  describe('vote', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      const itCastsTheProxiedVote = () => {
+        it('casts the proxied vote', async () => {
+          await holder51Proxy.vote(voting.address, voteId, true, false, { from })
+
+          const { yeas, nays } = await getVoteState()
+
+          assert.equal(yeas.toString(), bigExp(51, 18).toString(), 'initial yea should be 51%')
+          assert.equal(nays.toString(), 0, 'initial nay should be 0')
+          assert.equal(await getVoterState(holder51), VOTER_STATE.ABSENT, 'principal proxy should have voted')
+          assert.equal(await getVoterState(holder51Proxy.address), VOTER_STATE.YEA, 'principal proxy should have voted')
+        })
+      }
+
+      context('when no one proxied a vote yet', () => {
+        itCastsTheProxiedVote()
+      })
+
+      context('when a representative already proxied a vote', () => {
+        beforeEach('proxy representative\'s vote', async () => {
+          await holder51Proxy.setFullRepresentative(holder20, true, { from: holder51 })
+          await holder51Proxy.proxyVote(voting.address, voteId, false, { from: holder20 })
+        })
+
+        itCastsTheProxiedVote()
+      })
+
+      context('when the principal already proxied a vote', () => {
+        beforeEach('proxy principal\'s vote', async () => {
+          await holder51Proxy.vote(voting.address, voteId, false, false, { from: holder51 })
+        })
+
+        itCastsTheProxiedVote()
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.vote(voting.address, voteId, true, false, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+
+  describe('hasNotVoteYet', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when no one has vote yet', () => {
+      it('returns true', async () => {
+        assert.isTrue(await holder51Proxy.hasNotVoteYet(voting.address, voteId))
+      })
+    })
+
+    context('when a representative has proxied a vote', () => {
+      beforeEach('proxy representative\'s vote', async () => {
+        await holder51Proxy.setFullRepresentative(holder20, true, { from: holder51 })
+        await holder51Proxy.proxyVote(voting.address, voteId, true, { from: holder20 })
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.hasNotVoteYet(voting.address, voteId))
+      })
+    })
+
+    context('when the principal has proxied a vote', () => {
+      beforeEach('proxy principal\'s vote', async () => {
+        await holder51Proxy.vote(voting.address, voteId, true, false, { from: holder51 })
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.hasNotVoteYet(voting.address, voteId))
+      })
+    })
+  })
+
+  describe('withinOverruleWindow', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when previous to the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(ONE_DAY)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when right at the beginning of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+      })
+
+      it('returns true', async () => {
+        assert.isTrue(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when in the middle of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION - OVERRULE_WINDOW/2 )
+      })
+
+      it('returns true', async () => {
+        assert.isTrue(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when right at the end of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when after the end of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION + 1)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await holder51Proxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+  })
+
+  describe('withdraw', () => {
+    context('when the sender is the principal', () => {
+      const from = holder51
+
+      context('when the transfer succeeds', () => {
+        const amount = bigExp(1, 18)
+
+        it('transfers the requested amount of tokens to the principal', async () => {
+          const previousProxyBalance = await token.balanceOf(holder51Proxy.address)
+          const previousPrincipalBalance = await token.balanceOf(holder51)
+
+          await holder51Proxy.withdraw(token.address, amount, { from })
+
+          const currentProxyBalance = await token.balanceOf(holder51Proxy.address)
+          assert.equal(currentProxyBalance.toString(), previousProxyBalance.minus(amount).toString())
+
+          const currentPrincipalBalance = await token.balanceOf(holder51)
+          assert.equal(currentPrincipalBalance.toString(), previousPrincipalBalance.plus(amount).toString())
+        })
+
+        it('emits an event', async () => {
+          const receipt = await holder51Proxy.withdraw(token.address, amount, { from })
+
+          assertAmountOfEvents(receipt, 'Withdraw')
+          assertEvent(receipt, 'Withdraw', { token: token.address, amount })
+        })
+      })
+
+      context('when the transfer does not succeed', () => {
+        const amount = bigExp(100, 18)
+
+        it('reverts', async () => {
+          await assertRevert(holder51Proxy.withdraw(token.address, amount, { from }), 'PV_WITHDRAW_FAILED')
+        })
+      })
+    })
+
+    context('when the sender is not the principal', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(holder51Proxy.withdraw(token.address, 1, { from }), 'PV_SENDER_NOT_PRINCIPAL')
+      })
+    })
+  })
+})

--- a/apps/voting/test/contracts/representative_proxy.js
+++ b/apps/voting/test/contracts/representative_proxy.js
@@ -1,0 +1,369 @@
+const VOTER_STATE = require('../helpers/state')
+const { bigExp, pct } = require('../helpers/numbers')(web3)
+const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
+const { assertRevert } = require('@aragon/test-helpers/assertThrow')
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { decodeEventsOfType } = require('@aragon/os/test/helpers/decodeEvent')
+const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
+const { assertEvent, assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
+
+const Voting = artifacts.require('VotingMock')
+const RepresentativeProxy = artifacts.require('RepresentativeProxyMock')
+const ExecutionTarget = artifacts.require('ExecutionTarget')
+
+const ACL = artifacts.require('@aragon/os/contracts/acl/ACL')
+const Kernel = artifacts.require('@aragon/os/contracts/kernel/Kernel')
+const DAOFactory = artifacts.require('@aragon/os/contracts/factory/DAOFactory')
+const EVMScriptRegistryFactory = artifacts.require('@aragon/os/contracts/factory/EVMScriptRegistryFactory')
+const MiniMeToken = artifacts.require('@aragon/apps-shared-minime/contracts/MiniMeToken')
+
+const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+contract('RepresentativeProxy', ([_, root, holder20, holder29, holder51, representative, anyone]) => {
+  let votingBase, kernelBase, aclBase, daoFactory
+  let dao, acl, voting, token, executionTarget, script, voteId, representativeProxy
+  let APP_MANAGER_ROLE, CREATE_VOTES_ROLE, MODIFY_SUPPORT_ROLE, MODIFY_QUORUM_ROLE
+
+  const NOW = 1553703809  // random fixed timestamp in seconds
+  const ONE_DAY = 60 * 60 * 24
+  const OVERRULE_WINDOW = ONE_DAY
+  const VOTING_DURATION = ONE_DAY * 5
+
+  const MIN_QUORUM = pct(20)
+  const MIN_SUPPORT = pct(70)
+
+  before('deploy base implementations', async () => {
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+    const regFact = await EVMScriptRegistryFactory.new()
+    daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, regFact.address)
+    votingBase = await Voting.new()
+  })
+
+  before('load roles', async () => {
+    APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
+    CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE()
+    MODIFY_SUPPORT_ROLE = await votingBase.MODIFY_SUPPORT_ROLE()
+    MODIFY_QUORUM_ROLE = await votingBase.MODIFY_QUORUM_ROLE()
+  })
+
+  before('create dao', async () => {
+    const receipt = await daoFactory.newDAO(root)
+    dao = Kernel.at(getEventArgument(receipt, 'DeployDAO', 'dao'))
+    acl = ACL.at(await dao.acl())
+    await acl.createPermission(root, dao.address, APP_MANAGER_ROLE, root, { from: root })
+  })
+
+  beforeEach('mint tokens', async () => {
+    token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 18, 'n', true, { from: root }) // empty parameters minime
+    await token.generateTokens(holder20, bigExp(20, 18), { from: root })
+    await token.generateTokens(holder29, bigExp(29, 18), { from: root })
+    await token.generateTokens(holder51, bigExp(51, 18), { from: root })
+  })
+
+  beforeEach('create representative proxy', async () => {
+    representativeProxy = await RepresentativeProxy.new(representative, OVERRULE_WINDOW)
+    await token.approve(representativeProxy.address, bigExp(51, 18), { from: holder51 })
+    await token.approve(representativeProxy.address, bigExp(20, 18), { from: holder20 })
+  })
+
+  beforeEach('create voting app', async () => {
+    const receipt = await dao.newAppInstance('0x1234', votingBase.address, '0x', false, { from: root })
+    voting = Voting.at(getNewProxyAddress(receipt))
+
+    await representativeProxy.mockSetTimestamp(NOW)
+    await voting.mockSetTimestamp(NOW)
+    await voting.initialize(token.address, MIN_SUPPORT, MIN_QUORUM, VOTING_DURATION, { from: root })
+
+    await acl.createPermission(ANY_ADDR, voting.address, CREATE_VOTES_ROLE, root, { from: root })
+    await acl.createPermission(ANY_ADDR, voting.address, MODIFY_SUPPORT_ROLE, root, { from: root })
+    await acl.createPermission(ANY_ADDR, voting.address, MODIFY_QUORUM_ROLE, root, { from: root })
+  })
+
+  const createVote = async (from = representative) => {
+    executionTarget = await ExecutionTarget.new()
+    const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
+    script = encodeCallScript([action])
+
+    const { tx } = await representativeProxy.newVote(voting.address, script, 'metadata', { from })
+    const receipt = await web3.eth.getTransactionReceipt(tx)
+    const events = decodeEventsOfType(receipt, Voting.abi, 'StartVote')
+    assert.equal(events.length, 1, 'number of StartVote emitted events does not match')
+    const startVoteEvent = events[0].args
+    voteId = startVoteEvent.voteId
+    return startVoteEvent
+  }
+
+  const getVoteState = async () => {
+    const [open, executed, startDate, snapshotBlock, support, quorum, yeas, nays, votingPower, execScript] = await voting.getVote(voteId)
+    return { open, executed, startDate, snapshotBlock, support, quorum, yeas, nays, votingPower, execScript }
+  }
+
+  const getVoterState = async (voter) => voting.getVoterState(voteId, voter)
+
+  const increaseTime = async (seconds) => {
+    await voting.mockIncreaseTime(seconds)
+    await representativeProxy.mockIncreaseTime(seconds)
+  }
+
+  describe('delegate', () => {
+    const from = holder51
+
+    it('is not allowed by default', async () => {
+      assert.isFalse(await representativeProxy.isAllowedBy(holder51, token.address))
+    })
+
+    context('when the token transfer does not fail', () => {
+      const amount = bigExp(2, 18)
+
+      it('transfers given amount of tokens to the representative proxy', async () => {
+        const previousProxyBalance = await token.balanceOf(representativeProxy.address)
+        const previousPrincipalBalance = await token.balanceOf(holder51)
+
+        await representativeProxy.delegate(token.address, amount, { from })
+
+        assert.isTrue(await representativeProxy.isAllowedBy(holder51, token.address))
+
+        const currentProxyBalance = await token.balanceOf(representativeProxy.address)
+        assert.equal(currentProxyBalance.toString(), previousProxyBalance.plus(amount).toString())
+
+        const currentPrincipalBalance = await token.balanceOf(holder51)
+        assert.equal(currentPrincipalBalance.toString(), previousPrincipalBalance.minus(amount).toString())
+      })
+
+      it('emits an event', async () => {
+        const receipt = await representativeProxy.delegate(token.address, amount, { from })
+
+        assertAmountOfEvents(receipt, 'Delegate')
+        assertEvent(receipt, 'Delegate', { principal: holder51, token: token.address, amount, totalAmount: amount })
+      })
+    })
+
+    context('when the token transfer fails', () => {
+      const amount = bigExp(100, 18)
+
+      it('reverts', async () => {
+        await assertRevert(representativeProxy.delegate(token.address, amount, { from }), 'RP_TRANSFER_FROM_TOKEN_FAILED')
+      })
+    })
+  })
+
+  describe('withdraw', () => {
+    const from = holder51
+
+    context('when the token transfer does not fail', () => {
+      const amount = bigExp(2, 18)
+
+      beforeEach('delegate amount', async () => {
+        await representativeProxy.delegate(token.address, amount, { from })
+      })
+
+      it('withdraw given amount of tokens from the representative proxy', async () => {
+        const previousProxyBalance = await token.balanceOf(representativeProxy.address)
+        const previousPrincipalBalance = await token.balanceOf(holder51)
+
+        await representativeProxy.withdraw(token.address, amount, { from })
+
+        assert.isFalse(await representativeProxy.isAllowedBy(holder51, token.address))
+
+        const currentProxyBalance = await token.balanceOf(representativeProxy.address)
+        assert.equal(currentProxyBalance.toString(), previousProxyBalance.minus(amount).toString())
+
+        const currentPrincipalBalance = await token.balanceOf(holder51)
+        assert.equal(currentPrincipalBalance.toString(), previousPrincipalBalance.plus(amount).toString())
+      })
+
+      it('emits an event', async () => {
+        const receipt = await representativeProxy.withdraw(token.address, amount, { from })
+
+        assertAmountOfEvents(receipt, 'Withdraw')
+        assertEvent(receipt, 'Withdraw', { principal: holder51, token: token.address, amount, totalAmount: 0 })
+      })
+    })
+
+    context('when the token transfer fails', () => {
+      const amount = bigExp(100, 18)
+
+      it('reverts', async () => {
+        await assertRevert(representativeProxy.withdraw(token.address, amount, { from }), 'RP_DISALLOW_AMOUNT_UNAVAILABLE')
+      })
+    })
+  })
+
+  describe('newVote', () => {
+    context('when the sender is the representative', () => {
+      let startVoteEvent
+      const from = representative
+
+      beforeEach('create a vote', async () => {
+        startVoteEvent = await createVote(from)
+      })
+
+      it('creates a vote', async () => {
+        assert.equal(voteId, 0, 'vote id should be correct')
+        assert.equal(startVoteEvent.metadata, 'metadata', 'should have returned correct metadata')
+        assert.equal(startVoteEvent.creator, web3.toChecksumAddress(representativeProxy.address), 'creator should be correct')
+      })
+
+      it('does not cast the representatives votes and has the correct state', async () => {
+        const { open, executed, yeas, nays } = await getVoteState()
+
+        assert.isTrue(open, 'vote should be open')
+        assert.isFalse(executed, 'vote should not be executed')
+        assert.equal(yeas.toString(), 0, 'yeas should be 0')
+        assert.equal(nays.toString(), 0, 'nays should be 0')
+        assert.equal(await getVoterState(representativeProxy.address), VOTER_STATE.ABSENT, 'representative proxy should not have voted yet')
+      })
+
+      it('sets it up correctly', async () => {
+        const { startDate, snapshotBlock, support, quorum, votingPower, execScript } = await getVoteState()
+
+        assert.equal(startDate.toString(), NOW, 'start date should be correct')
+        assert.equal(snapshotBlock.toString(), await getBlockNumber() - 1, 'snapshot block should be correct')
+        assert.equal(support.toString(), MIN_SUPPORT.toString(), 'required support should be app required support')
+        assert.equal(quorum.toString(), MIN_QUORUM.toString(), 'min quorum should be app min quorum')
+        assert.equal(votingPower.toString(), bigExp(100, 18).toString(), 'voting power should be 100')
+        assert.equal(execScript, script, 'script should be correct')
+      })
+    })
+
+    context('when the sender is not the representative', () => {
+      const from = anyone
+
+      it('reverts', async () => {
+        await assertRevert(representativeProxy.newVote(voting.address, script, 'metadata', { from }), 'RP_SENDER_NOT_REPRESENTATIVE')
+      })
+    })
+  })
+
+  describe('proxyVotes', () => {
+    context('when the vote exists', () => {
+
+      context('when the sender is the representative', () => {
+        const from = representative
+
+        context('when the representative is allowed', () => {
+          beforeEach('allow representative', async () => {
+            await representativeProxy.delegate(token.address, bigExp(51, 18), { from: holder51 })
+            await representativeProxy.delegate(token.address, bigExp(20, 18), { from: holder20 })
+          })
+
+          beforeEach('create a vote', createVote)
+
+          context('when not within the overrule window', () => {
+            beforeEach('proxy vote', async () => {
+              await representativeProxy.proxyVotes([voting.address], [voteId], [false], { from })
+            })
+
+            it('casts the proxied vote', async () => {
+              const { yeas, nays } = await getVoteState()
+
+              assert.equal(yeas.toString(), 0, 'yeas should be 0')
+              assert.equal(nays.toString(), bigExp(71, 18).toString(), 'nays should be 71%')
+              assert.equal(await getVoterState(representativeProxy.address), VOTER_STATE.NAY, 'representative proxy should have voted')
+            })
+
+            it('can be changed by the same representative', async () => {
+              await representativeProxy.proxyVotes([voting.address], [voteId], [true], { from })
+
+              const { yeas, nays } = await getVoteState()
+
+              assert.equal(nays.toString(), 0, 'nays should be 0')
+              assert.equal(yeas.toString(), bigExp(71, 18).toString(), 'yeas should be 71%')
+              assert.equal(await getVoterState(representativeProxy.address), VOTER_STATE.YEA, 'representative proxy should have voted')
+            })
+          })
+
+          context('when within the overrule window', () => {
+            beforeEach('move within overrule window', async () => {
+              await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+            })
+
+            it('reverts', async () => {
+              await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [false], { from }), 'RP_WITHIN_OVERRULE_WINDOW')
+            })
+          })
+        })
+
+        context('when the representative is not allowed', () => {
+          beforeEach('create a vote', createVote)
+
+          it('reverts', async () => {
+            await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [false], { from }), 'VOTING_CAN_NOT_VOTE')
+          })
+        })
+      })
+
+      context('when the sender is not the representative', () => {
+        const from = anyone
+
+        beforeEach('create a vote', createVote)
+
+        it('reverts', async () => {
+          await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [true], { from }), 'RP_SENDER_NOT_REPRESENTATIVE')
+        })
+      })
+    })
+
+    context('when the vote does not exist', () => {
+      it('reverts', async () => {
+        await assertRevert(representativeProxy.proxyVotes([voting.address], [voteId], [false], { from: representative }), 'VOTING_NO_VOTE')
+      })
+    })
+  })
+
+  describe('withinOverruleWindow', () => {
+    beforeEach('create a vote', createVote)
+
+    context('when previous to the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(ONE_DAY)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await representativeProxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when right at the beginning of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION - OVERRULE_WINDOW)
+      })
+
+      it('returns true', async () => {
+        assert.isTrue(await representativeProxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when in the middle of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION - OVERRULE_WINDOW/2 )
+      })
+
+      it('returns true', async () => {
+        assert.isTrue(await representativeProxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when right at the end of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await representativeProxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+
+    context('when after the end of the overrule window', () => {
+      beforeEach('increase time', async () => {
+        await increaseTime(VOTING_DURATION + 1)
+      })
+
+      it('returns false', async () => {
+        assert.isFalse(await representativeProxy.withinOverruleWindow(voting.address, voteId))
+      })
+    })
+  })
+})

--- a/apps/voting/test/contracts/voting.js
+++ b/apps/voting/test/contracts/voting.js
@@ -1,11 +1,13 @@
+const VOTER_STATE = require('../helpers/state')
+const { bigExp, pct } = require('../helpers/numbers')(web3)
+const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
 const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const { assertAmountOfEvents } = require('@aragon/test-helpers/assertEvent')(web3)
-const { getEventAt, getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
-const getBlockNumber = require('@aragon/test-helpers/blockNumber')(web3)
 const { encodeCallScript, EMPTY_SCRIPT } = require('@aragon/test-helpers/evmScript')
-const ExecutionTarget = artifacts.require('ExecutionTarget')
+const { getEventArgument, getNewProxyAddress } = require('@aragon/test-helpers/events')
 
 const Voting = artifacts.require('VotingMock')
+const ExecutionTarget = artifacts.require('ExecutionTarget')
 
 const ACL = artifacts.require('@aragon/os/contracts/acl/ACL')
 const Kernel = artifacts.require('@aragon/os/contracts/kernel/Kernel')
@@ -14,18 +16,10 @@ const EVMScriptRegistryFactory = artifacts.require('@aragon/os/contracts/factory
 const MiniMeToken = artifacts.require('@aragon/apps-shared-minime/contracts/MiniMeToken')
 
 const getContract = name => artifacts.require(name)
-const bigExp = (x, y) => new web3.BigNumber(x).times(new web3.BigNumber(10).toPower(y))
-const pct16 = x => bigExp(x, 16)
 const createdVoteId = receipt => getEventArgument(receipt, 'StartVote', 'voteId')
 
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-
-const VOTER_STATE = ['ABSENT', 'YEA', 'NAY'].reduce((state, key, index) => {
-    state[key] = index;
-    return state;
-}, {})
-
 
 contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, nonHolder]) => {
     let votingBase, daoFact, voting, token, executionTarget
@@ -67,8 +61,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
     })
 
     context('normal token supply, common tests', () => {
-        const neededSupport = pct16(50)
-        const minimumAcceptanceQuorum = pct16(20)
+        const neededSupport = pct(50)
+        const minimumAcceptanceQuorum = pct(20)
 
         beforeEach(async () => {
             token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true) // empty parameters minime
@@ -104,8 +98,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         })
 
         it('fails changing required support to 100% or more', async () => {
-            await assertRevert(voting.changeSupportRequiredPct(pct16(101)))
-            await assertRevert(voting.changeSupportRequiredPct(pct16(100)))
+            await assertRevert(voting.changeSupportRequiredPct(pct(101)))
+            await assertRevert(voting.changeSupportRequiredPct(pct(100)))
         })
 
         it('can change minimum acceptance quorum', async () => {
@@ -123,8 +117,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
     for (const decimals of [0, 2, 18, 26]) {
         context(`normal token supply, ${decimals} decimals`, () => {
-            const neededSupport = pct16(50)
-            const minimumAcceptanceQuorum = pct16(20)
+            const neededSupport = pct(50)
+            const minimumAcceptanceQuorum = pct(20)
 
             beforeEach(async () => {
                 token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', decimals, 'n', true) // empty parameters minime
@@ -212,7 +206,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                 })
 
                 it('changing required support does not affect vote required support', async () => {
-                    await voting.changeSupportRequiredPct(pct16(70))
+                    await voting.changeSupportRequiredPct(pct(70))
 
                     // With previous required support at 50%, vote should be approved
                     // with new quorum at 70% it shouldn't have, but since min quorum is snapshotted
@@ -229,7 +223,7 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
                 })
 
                 it('changing min quorum doesnt affect vote min quorum', async () => {
-                    await voting.changeMinAcceptQuorumPct(pct16(50))
+                    await voting.changeMinAcceptQuorumPct(pct(50))
 
                     // With previous min acceptance quorum at 20%, vote should be approved
                     // with new quorum at 50% it shouldn't have, but since min quorum is snapshotted
@@ -332,21 +326,21 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
         })
 
         it('fails if min acceptance quorum is greater than min support', async () => {
-            const neededSupport = pct16(20)
-            const minimumAcceptanceQuorum = pct16(50)
+            const neededSupport = pct(20)
+            const minimumAcceptanceQuorum = pct(50)
             await assertRevert(voting.initialize(token.address, neededSupport, minimumAcceptanceQuorum, votingDuration))
         })
 
         it('fails if min support is 100% or more', async () => {
-            const minimumAcceptanceQuorum = pct16(20)
-            await assertRevert(voting.initialize(token.address, pct16(101), minimumAcceptanceQuorum, votingDuration))
-            await assertRevert(voting.initialize(token.address, pct16(100), minimumAcceptanceQuorum, votingDuration))
+            const minimumAcceptanceQuorum = pct(20)
+            await assertRevert(voting.initialize(token.address, pct(101), minimumAcceptanceQuorum, votingDuration))
+            await assertRevert(voting.initialize(token.address, pct(100), minimumAcceptanceQuorum, votingDuration))
         })
     })
 
     context('empty token', () => {
-        const neededSupport = pct16(50)
-        const minimumAcceptanceQuorum = pct16(20)
+        const neededSupport = pct(50)
+        const minimumAcceptanceQuorum = pct(20)
 
         beforeEach(async() => {
             token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true) // empty parameters minime
@@ -360,8 +354,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
     })
 
     context('token supply = 1', () => {
-        const neededSupport = pct16(50)
-        const minimumAcceptanceQuorum = pct16(20)
+        const neededSupport = pct(50)
+        const minimumAcceptanceQuorum = pct(20)
 
         beforeEach(async () => {
             token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true) // empty parameters minime
@@ -406,8 +400,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
     })
 
     context('token supply = 3', () => {
-        const neededSupport = pct16(34)
-        const minimumAcceptanceQuorum = pct16(20)
+        const neededSupport = pct(34)
+        const minimumAcceptanceQuorum = pct(20)
 
         beforeEach(async () => {
             token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true) // empty parameters minime
@@ -442,8 +436,8 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
     })
 
     context('changing token supply', () => {
-        const neededSupport = pct16(50)
-        const minimumAcceptanceQuorum = pct16(20)
+        const neededSupport = pct(50)
+        const minimumAcceptanceQuorum = pct(20)
 
         beforeEach(async () => {
             token = await MiniMeToken.new(ZERO_ADDRESS, ZERO_ADDRESS, 0, 'n', 0, 'n', true) // empty parameters minime
@@ -489,32 +483,32 @@ contract('Voting App', ([root, holder1, holder2, holder20, holder29, holder51, n
 
     context('isValuePct unit test', async () => {
         it('tests total = 0', async () => {
-            const result1 = await voting.isValuePct(0, 0, pct16(50))
+            const result1 = await voting.isValuePct(0, 0, pct(50))
             assert.equal(result1, false, "total 0 should always return false")
-            const result2 = await voting.isValuePct(1, 0, pct16(50))
+            const result2 = await voting.isValuePct(1, 0, pct(50))
             assert.equal(result2, false, "total 0 should always return false")
         })
 
         it('tests value = 0', async () => {
-            const result1 = await voting.isValuePct(0, 10, pct16(50))
+            const result1 = await voting.isValuePct(0, 10, pct(50))
             assert.equal(result1, false, "value 0 should false if pct is non-zero")
             const result2 = await voting.isValuePct(0, 10, 0)
             assert.equal(result2, false, "value 0 should return false if pct is zero")
         })
 
         it('tests pct ~= 100', async () => {
-            const result1 = await voting.isValuePct(10, 10, pct16(100).minus(1))
+            const result1 = await voting.isValuePct(10, 10, pct(100).minus(1))
             assert.equal(result1, true, "value 10 over 10 should pass")
         })
 
         it('tests strict inequality', async () => {
-            const result1 = await voting.isValuePct(10, 20, pct16(50))
+            const result1 = await voting.isValuePct(10, 20, pct(50))
             assert.equal(result1, false, "value 10 over 20 should not pass for 50%")
 
-            const result2 = await voting.isValuePct(pct16(50).minus(1), pct16(100), pct16(50))
+            const result2 = await voting.isValuePct(pct(50).minus(1), pct(100), pct(50))
             assert.equal(result2, false, "off-by-one down should not pass")
 
-            const result3 = await voting.isValuePct(pct16(50).plus(1), pct16(100), pct16(50))
+            const result3 = await voting.isValuePct(pct(50).plus(1), pct(100), pct(50))
             assert.equal(result3, true, "off-by-one up should pass")
         })
     })

--- a/apps/voting/test/helpers/numbers.js
+++ b/apps/voting/test/helpers/numbers.js
@@ -1,0 +1,11 @@
+module.exports = web3 => {
+  const bn = x => new web3.BigNumber(x)
+  const bigExp = (x, y) => bn(x).mul(bn(10).pow(bn(y)))
+  const pct = x => bigExp(x, 16)
+
+  return {
+    bn,
+    bigExp,
+    pct
+  }
+}

--- a/apps/voting/test/helpers/state.js
+++ b/apps/voting/test/helpers/state.js
@@ -1,0 +1,5 @@
+module.exports = {
+  ABSENT: 0,
+  YEA: 1,
+  NAY: 2,
+}


### PR DESCRIPTION
*This PR aims to show some simple alternatives to tackle single delegation voting based on the requirements described in [the forum post](https://forum.aragon.org/t/voting-v1-single-delegation/440).*

There are two main problems we are trying to solve here:
- Having a way to vote with a pair of hot and cold wallets
- Having a way to delegate my vote to a representative that will vote on my behalf

That said, I've been exploring some simple alternatives that don't require changing the voting app at all <sup>(1)</sup>, as opposed in https://github.com/aragon/aragon-apps/pull/881.

## Terminology

*The following terminology is not set in stone, it was based on this [article](https://en.wikipedia.org/wiki/Proxy_voting) and followed to keep some consistency between the implementations showed.* 

**Principal:** The person assigning someone to vote on his/her behalf.

**Representative:** The person assigned to vote on behalf of someone.

## Approaches

### Principal's proxy
[[Implementation]](https://github.com/aragon/aragon-apps/pull/869/commits/120fc726cdb57da80b241bc72f451d95437faddf)

One option could be to have a particular smart contract that token holders (principals) can deploy, while transferring their tokens to this contract, that will basically allow them to control their representatives to vote on their behalf.

**PROS:**
- Principals have full control of their tokens
- Principals don't need to rely on someone else’s code
- Easy to have representatives for different domains
- Same vote gas costs for the principal or the representative

**CONS:**
- Representatives voting on behalf of many principals need to perform one transaction for each of them

### Representative's proxy
[[Implementation]](https://github.com/aragon/aragon-apps/pull/869/commits/661469ade01e00fa88541caba2974aa61db79be2)

Another option could be to have a particular smart contract that representatives can deploy, that will basically allow them to receive tokens from the principals being represented to vote on their behalf.

**PROS:**
- Representatives can vote on behalf of multiple principals with a single transaction

**CONS:**
- Principals need to rely on someone else’s code
- Principals may not have full control of their tokens and in which domains they are used for
- Cannot have multiple representatives per principal 
- Cannot overrule vote for a single principal, all or none

### Hybrid
[[Implementation]](https://github.com/aragon/aragon-apps/pull/869/commits/c2febdae772f6eb08483f3cedb84aabdb960b311)

A third alternative could be to try an implementation that allows having both ways, full control for principals while optimized gas costs for representatives.

----- 
<sup>(1)</sup> One of the requirements mentioned in the forum post for vote delegation is to allow the principal to overrule their representative's decision. With the current voting app this is actually not possible. Note that votes can be executed as soon as they reached the support and quorum expected. 