### PR TITLE
Apps: update for @aragon/rpc-messenger's new deferred behaviour

### DIFF
--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -34,12 +34,9 @@ class App extends React.Component {
   }
   handleWithdraw = (tokenAddress, recipient, amount, reference) => {
     // Immediate, one-time payment
-    this.props.api.newImmediatePayment(
-      tokenAddress,
-      recipient,
-      amount,
-      reference
-    )
+    this.props.api
+      .newImmediatePayment(tokenAddress, recipient, amount, reference)
+      .toPromise() // Don't care about response
     this.handleNewTransferClose()
   }
   handleDeposit = async (tokenAddress, amount, reference) => {
@@ -72,7 +69,8 @@ class App extends React.Component {
       }
     }
 
-    api.deposit(tokenAddress, amount, reference, intentParams)
+    // Don't care about response
+    api.deposit(tokenAddress, amount, reference, intentParams).toPromise()
     this.handleNewTransferClose()
   }
 

--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -40,11 +40,12 @@ class App extends React.PureComponent {
   handleUpdateTokens = ({ amount, holder, mode }) => {
     const { api } = this.props
 
+    // Don't care about responses
     if (mode === 'assign') {
-      api.mint(holder, amount)
+      api.mint(holder, amount).toPromise()
     }
     if (mode === 'remove') {
-      api.burn(holder, amount)
+      api.burn(holder, amount).toPromise()
     }
 
     this.handleSidepanelClose()

--- a/apps/voting/app/src/app-logic.js
+++ b/apps/voting/app/src/app-logic.js
@@ -37,7 +37,8 @@ export function useCreateVoteAction(onDone) {
   return useCallback(
     question => {
       if (api) {
-        api.newVote(EMPTY_CALLSCRIPT, question)
+        // Don't care about response
+        api.newVote(EMPTY_CALLSCRIPT, question).toPromise()
         onDone()
       }
     },
@@ -50,7 +51,8 @@ export function useVoteAction(onDone) {
   const api = useApi()
   return useCallback(
     (voteId, voteType, executesIfDecided = true) => {
-      api.vote(voteId, voteType === VOTE_YEA, executesIfDecided)
+      // Don't care about response
+      api.vote(voteId, voteType === VOTE_YEA, executesIfDecided).toPromise()
       onDone()
     },
     [api, onDone]
@@ -62,7 +64,8 @@ export function useExecuteAction(onDone) {
   const api = useApi()
   return useCallback(
     voteId => {
-      api.executeVote(voteId)
+      // Don't care about response
+      api.executeVote(voteId).toPromise()
       onDone()
     },
     [api, onDone]


### PR DESCRIPTION
Breaking change from https://github.com/aragon/aragon.js/pull/305 (to be released as `@aragon/rpc-messenger@2`).

I believe intents were the only RPC requests we were sending without caring for their response. All other requests were either made for their response, or we wanted to have feedback if the user cancelled (e.g. identity modifications)