### PR TITLE
Apps: use consistent style across WebWorker scripts

### DIFF
--- a/apps/token-manager/app/src/script.js
+++ b/apps/token-manager/app/src/script.js
@@ -47,17 +47,18 @@ retryEvery(retry => {
 async function initialize(tokenAddress) {
   const token = app.external(tokenAddress, tokenAbi)
 
-  async function reducer(state, { address, event, returnValues }) {
-    let nextState = {
+  function reducer(state, { address, event, returnValues }) {
+    const nextState = {
       ...state,
     }
 
     if (event === events.SYNC_STATUS_SYNCING) {
-      nextState.isSyncing = true
+      return { ...nextState, isSyncing: true }
     } else if (event === events.SYNC_STATUS_SYNCED) {
-      nextState.isSyncing = false
+      return { ...nextState, isSyncing: false }
     }
 
+    // Token event
     if (addressesEqual(address, tokenAddress)) {
       switch (event) {
         case 'ClaimedTokens':
@@ -70,10 +71,10 @@ async function initialize(tokenAddress) {
         default:
           return nextState
       }
-    } else {
-      // Token Manager event
-      // TODO: add handlers for the vesting events from token Manager
     }
+
+    // Token Manager event
+    // TODO: add handlers for the vesting events from token Manager
 
     return nextState
   }

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -57,8 +57,8 @@ retryEvery(retry => {
 
 async function initialize(tokenAddr) {
   return app.store(
-    async (state, { event, returnValues }) => {
-      let nextState = {
+    (state, { event, returnValues }) => {
+      const nextState = {
         ...state,
       }
 


### PR DESCRIPTION
Tries to apply a consistent style across the WebWorker scripts.

I liked leaving the `return nextState` at the end previously, because it was easy to add debugging logs, but this is still fairly easy to do by piping a `tap()` operator.