### PR TITLE
voting: catch invalid script error

### DIFF
--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -239,6 +239,7 @@ async function loadVoteDescription(vote) {
   } catch (error) {
     console.error('Error describing vote script', error)
     vote.description = 'Invalid script. The result cannot be executed.'
+    // Clear metadata so ensure it's rendered with a description rather than question
     vote.metadata = ''
   }
 

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -237,7 +237,7 @@ async function loadVoteDescription(vote) {
           .join('\n')
       : ''
   } catch (error) {
-    console.log('Error describing vote script', error)
+    console.error('Error describing vote script', error)
     vote.description = 'Invalid script. The result cannot be executed.'
     vote.metadata = ''
   }

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -240,7 +240,7 @@ async function loadVoteDescription(vote) {
     console.error('Error describing vote script', error)
     vote.description = 'Invalid script. The result cannot be executed.'
     // Clear metadata so ensure it's rendered with a description rather than question
-    vote.metadata = ''
+    vote.metadata = null
   }
 
   return vote

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -223,17 +223,24 @@ async function loadVoteDescription(vote) {
     return vote
   }
 
-  const path = await app.describeScript(vote.script).toPromise()
-  vote.description = path
-    ? path
-        .map(step => {
-          const identifier = step.identifier ? ` (${step.identifier})` : ''
-          const app = step.name ? `${step.name}${identifier}` : `${step.to}`
+  try {
+    const path = await app.describeScript(vote.script).toPromise()
 
-          return `${app}: ${step.description || 'No description'}`
-        })
-        .join('\n')
-    : ''
+    vote.description = path
+      ? path
+          .map(step => {
+            const identifier = step.identifier ? ` (${step.identifier})` : ''
+            const app = step.name ? `${step.name}${identifier}` : `${step.to}`
+
+            return `${app}: ${step.description || 'No description'}`
+          })
+          .join('\n')
+      : ''
+  } catch (error) {
+    console.log('Error describing vote script', error)
+    vote.description = 'Invalid script. The result cannot be executed.'
+    vote.metadata = ''
+  }
 
   return vote
 }


### PR DESCRIPTION
## What
- Fix an an caught error which would crash the background script 
- The error was detected with the following `newVote` [tx](https://etherscan.io/tx/0x5dc24de292dcc6e4728b973629a4d3f1a9eb1a2954a851d054f4507e273c2c01)
- Render votes with invalid scripts with an error message

## Bug Example 
- https://mainnet.aragon.org/#/futhorcecosystem/0xd9ed670476974e371607c9a6f8bffd44462510af