### PR TITLE
Improve invalid script handling

### DIFF
--- a/apps/voting/app/src/components/VotePanel.js
+++ b/apps/voting/app/src/components/VotePanel.js
@@ -111,6 +111,16 @@ const VotePanelContent = React.memo(
           </div>
         </SidePanelSplit>
         <Part>
+          {description && (
+            <React.Fragment>
+              <h2>
+                <Label>Description</Label>
+              </h2>
+              <p>
+                <VoteText text={description} />
+              </p>
+            </React.Fragment>
+          )}
           {metadata && (
             <React.Fragment>
               <h2>
@@ -125,16 +135,6 @@ const VotePanelContent = React.memo(
                 `}
               >
                 <VoteText text={metadata} />
-              </p>
-            </React.Fragment>
-          )}
-          {description && (
-            <React.Fragment>
-              <h2>
-                <Label>Description</Label>
-              </h2>
-              <p>
-                <VoteText text={description} />
               </p>
             </React.Fragment>
           )}

--- a/apps/voting/app/src/components/VotingCard/VotingCard.js
+++ b/apps/voting/app/src/components/VotingCard/VotingCard.js
@@ -76,7 +76,7 @@ const VotingCard = React.memo(
             <Label>
               <Text color={theme.textTertiary}>#{voteId} </Text>
               <span>
-                <VoteText text={metadata || description} />
+                <VoteText text={description || metadata} />
               </span>
             </Label>
             <VotingOptions options={options} votingPower={votingPower} />

--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -239,8 +239,6 @@ async function loadVoteDescription(vote) {
   } catch (error) {
     console.error('Error describing vote script', error)
     vote.description = 'Invalid script. The result cannot be executed.'
-    // Clear metadata so ensure it's rendered with a description rather than question
-    vote.metadata = null
   }
 
   return vote


### PR DESCRIPTION
## What
- `description` takes precedence over `metadata`
- Render description first
- Do not nullify metadata for invalid scripts

## Example
For `/#/futhorcecosystem/0xd9ed670476974e371607c9a6f8bffd44462510af` with an invalid vote:
<img width="857" alt="Screen Shot 2019-06-06 at 7 38 24 pm" src="https://user-images.githubusercontent.com/1992255/59054306-addca780-8893-11e9-9bfb-08ad546a6e64.png">