### PR TITLE
Voting: Make early execution configurable

### DIFF
--- a/apps/voting/arapp.json
+++ b/apps/voting/arapp.json
@@ -54,6 +54,14 @@
       ]
     },
     {
+      "name": "Modify early execution setting",
+      "id": "MODIFY_EARLY_EXECUTION_ROLE",
+      "params": [
+        "New early execution setting",
+        "Current early execution setting"
+      ]
+    },
+    {
       "name": "Modify overrule window",
       "id": "MODIFY_OVERRULE_WINDOW_ROLE",
       "params": [

--- a/apps/voting/scripts/vote-stats.js
+++ b/apps/voting/scripts/vote-stats.js
@@ -48,13 +48,13 @@ module.exports = async (cb) => {
   const voting = Voting.at(appAddress)
 
   const [
-    isOpen,
     isExecuted,
     startDate,
     snapshotBlock,
     supportRequired,
     minQuorum,
     overruleWindow,
+    earlyExecution,
     y,
     n,
     votingPower,

--- a/apps/voting/test/contracts/voting_delegation.js
+++ b/apps/voting/test/contracts/voting_delegation.js
@@ -24,7 +24,7 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 contract('Voting delegation', ([_, root, voter, anotherVoter, thirdVoter, representative, anotherRepresentative, anyone]) => {
   let votingBase, kernelBase, aclBase, daoFactory
   let dao, acl, token, executionTarget, script, voteId, voting
-  let APP_MANAGER_ROLE, CREATE_VOTES_ROLE, MODIFY_SUPPORT_ROLE, MODIFY_QUORUM_ROLE, MODIFY_OVERRULE_WINDOW_ROLE
+  let APP_MANAGER_ROLE, CREATE_VOTES_ROLE, MODIFY_OVERRULE_WINDOW_ROLE
 
   const NOW = 1553703809  // random fixed timestamp in seconds
   const ONE_DAY = 60 * 60 * 24
@@ -59,8 +59,6 @@ contract('Voting delegation', ([_, root, voter, anotherVoter, thirdVoter, repres
   before('load roles', async () => {
     APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
     CREATE_VOTES_ROLE = await votingBase.CREATE_VOTES_ROLE()
-    MODIFY_SUPPORT_ROLE = await votingBase.MODIFY_SUPPORT_ROLE()
-    MODIFY_QUORUM_ROLE = await votingBase.MODIFY_QUORUM_ROLE()
     MODIFY_OVERRULE_WINDOW_ROLE = await votingBase.MODIFY_OVERRULE_WINDOW_ROLE()
   })
 
@@ -505,7 +503,7 @@ contract('Voting delegation', ([_, root, voter, anotherVoter, thirdVoter, repres
       const newWindow = VOTING_DURATION
 
       it('reverts', async () => {
-        await assertRevert(voting.changeOverruleWindow(newWindow, { from }), 'APP_AUTH_FAILED')
+        await assertRevert(voting.changeOverruleWindow(newWindow, { from }), ERRORS.APP_AUTH_FAILED)
       })
     })
   })

--- a/apps/voting/test/helpers/voting.js
+++ b/apps/voting/test/helpers/voting.js
@@ -1,6 +1,8 @@
 const getVoteState = async (voting, id) => {
-  const [isOpen, isExecuted, startDate, snapshotBlock, support, quorum, overruleWindow, yeas, nays, votingPower, script] = await voting.getVote(id)
-  return { isOpen, isExecuted, startDate, snapshotBlock, support, quorum, overruleWindow, yeas, nays, votingPower, script }
+  const isOpen = await voting.isVoteOpen(id)
+  const [isExecuted, startDate, snapshotBlock, support, quorum, overruleWindow, earlyExecution, yeas, nays, votingPower, script] = await voting.getVote(id)
+
+  return { isOpen, isExecuted, startDate, snapshotBlock, support, quorum, overruleWindow, earlyExecution, yeas, nays, votingPower, script }
 }
 
 module.exports = {


### PR DESCRIPTION
Related to https://github.com/aragon/aragon/issues/590

This PR aims to turn the fact that votes can be early executed once they have already been decided, into a configurable option. 