### PR TITLE
test-helpers: publish new major

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.1.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ethereumjs-util": "^6.1.0",

--- a/apps/finance/package.json
+++ b/apps/finance/package.json
@@ -40,7 +40,7 @@
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/apps-shared-scripts": "^1.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.1.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ganache-cli": "^6.4.3",

--- a/apps/survey/package.json
+++ b/apps/survey/package.json
@@ -34,7 +34,7 @@
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/apps-shared-scripts": "^1.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.1.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ganache-cli": "^6.4.3",

--- a/apps/token-manager/package.json
+++ b/apps/token-manager/package.json
@@ -40,7 +40,7 @@
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/apps-shared-scripts": "^1.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.1.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ganache-cli": "^6.4.3",

--- a/apps/vault/package.json
+++ b/apps/vault/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.1.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",

--- a/apps/voting/package.json
+++ b/apps/voting/package.json
@@ -41,7 +41,7 @@
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/apps-shared-scripts": "^1.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.1.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ganache-cli": "^6.4.3",

--- a/future-apps/payroll/package.json
+++ b/future-apps/payroll/package.json
@@ -54,7 +54,7 @@
     "@aragon/apps-token-manager": "2.0.0",
     "@aragon/apps-vault": "4.0.0",
     "@aragon/cli": "~5.6.0",
-    "@aragon/test-helpers": "^1.2.0",
+    "@aragon/test-helpers": "^2.0.0",
     "eth-gas-reporter": "^0.2.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ganache-cli": "^6.4.3",

--- a/shared/minime/package.json
+++ b/shared/minime/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@aragon/apps-shared-migrations": "1.0.0",
-    "@aragon/test-helpers": "^1.0.1",
+    "@aragon/test-helpers": "^2.0.0",
     "ethereumjs-testrpc-sc": "^6.1.6",
     "ganache-cli": "^6.4.3",
     "solidity-coverage": "^0.5.11",

--- a/shared/test-helpers/package.json
+++ b/shared/test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/test-helpers",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "author": "Aragon Assocation <legal@aragon.org>",
   "license": "AGPL-3.0-or-later",
   "files": [


### PR DESCRIPTION
With the changes in #864 (see [`assertEvent()`](https://github.com/aragon/aragon-apps/commit/102b85e6d986d2106ada9b0d81c6cd0ba051571b#diff-f72e32bf8d0e8ebb509795f5d9457118)), `test-helpers`'s external API has a breaking change from the last published version.