### PR TITLE
Transfers: wrap amount to avoid csv parsing errors

### DIFF
--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -85,7 +85,7 @@ const getDownloadData = async (transfers, tokenDetails, resolveAddress) => {
         const { name = '' } = (await resolveAddress(entity)) || {}
         return `${formatDate(
           date
-        )},${name},${entity},${reference},${`${formattedAmount} ${symbol}`}`
+        )},${name},${entity},${reference},${`"${formattedAmount} ${symbol}"`}`
       }
     )
   )


### PR DESCRIPTION
The commas from the formatted amount were breaking the csv, by wrapping with `"` this does not happen anymore.

Ref: https://github.com/aragon/aragon-apps/issues/893