### PR TITLE
Payroll: Remove unused import

### DIFF
--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -7,7 +7,6 @@ import "@aragon/os/contracts/common/IForwarder.sol";
 
 import "@aragon/os/contracts/lib/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/math/SafeMath64.sol";
-import "@aragon/os/contracts/lib/math/SafeMath8.sol";
 
 import "@aragon/ppf-contracts/contracts/IFeed.sol";
 import "@aragon/apps-finance/contracts/Finance.sol";


### PR DESCRIPTION
*Fixing finding 6.8 of audit report*

### 6.8 Payroll - Unused Import `SafeMath8`

| Severity     | Status    | Remediation Comment |
|:------------:|:---------:| ------------------- |
| Minor | Open | This issue is currently under review. |

#### Description

`Payroll` imports `SafeMath8` but it is never used.

**code/payroll/future-apps/payroll/contracts/Payroll.sol:L10**
```solidity
import "@aragon/os/contracts/lib/math/SafeMath8.sol";
```

#### Remediation

Remove the unused import statement.