### PR TITLE
Payroll: Move payroll example kit into `contracts/examples/` dir

### DIFF
--- a/future-apps/payroll/.solcover.js
+++ b/future-apps/payroll/.solcover.js
@@ -2,6 +2,7 @@ module.exports = {
     norpc: true,
     copyPackages: ['@aragon/os', '@aragon/apps-finance', '@aragon/apps-vault', '@aragon/test-helpers'],
     skipFiles: [
+        'examples',
         'test',
         '@aragon/os',
         '@aragon/apps-vault/contracts/Finance.sol',

--- a/future-apps/payroll/.solcover.js
+++ b/future-apps/payroll/.solcover.js
@@ -2,7 +2,6 @@ module.exports = {
     norpc: true,
     copyPackages: ['@aragon/os', '@aragon/apps-finance', '@aragon/apps-vault', '@aragon/test-helpers'],
     skipFiles: [
-        'PayrollKit.sol',
         'test',
         '@aragon/os',
         '@aragon/apps-vault/contracts/Finance.sol',

--- a/future-apps/payroll/contracts/examples/PayrollKit.sol
+++ b/future-apps/payroll/contracts/examples/PayrollKit.sol
@@ -14,7 +14,7 @@ import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
 import "@aragon/ppf-contracts/contracts/IFeed.sol";
 import "@aragon/apps-token-manager/contracts/TokenManager.sol";
 
-import "./Payroll.sol";
+import "../Payroll.sol";
 
 
 contract PPFMock is IFeed {


### PR DESCRIPTION
Simply to avoid confusing with a real kit, it is only used for testing purposes