### PR TITLE
Payroll: Use PPF rate precision

### DIFF
--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -601,7 +601,7 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
                 // Convert amount (in denomination tokens) to payout token and apply allocation
                 uint256 tokenAmount = _totalAmount.mul(exchangeRate).mul(tokenAllocation);
                 // Divide by 100 for the allocation percentage and by the exchange rate precision
-                tokenAmount = tokenAmount.div(feed.ratePrecision().mul(100));
+                tokenAmount = tokenAmount.div(100).div(feed.ratePrecision());
 
                 // Finance reverts if the payment wasn't possible
                 finance.newImmediatePayment(token, employeeAddress, tokenAmount, paymentReference);

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -39,7 +39,6 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
     bytes32 constant public MODIFY_PRICE_FEED_ROLE = 0x74350efbcba8b85341c5bbf70cc34e2a585fc1463524773a12fa0a71d4eb9302;
     bytes32 constant public MODIFY_RATE_EXPIRY_ROLE = 0x79fe989a8899060dfbdabb174ebb96616fa9f1d9dadd739f8d814cbab452404e;
 
-    uint128 internal constant ONE = 10 ** 18; // 10^18 is considered 1 in the price feed to allow for decimal calculations
     uint256 internal constant MAX_ALLOWED_TOKENS = 20; // prevent OOG issues with `payday()`
     uint64 internal constant MIN_RATE_EXPIRY = uint64(1 minutes); // 1 min == ~4 block window to mine both a price feed update and a payout
 
@@ -601,8 +600,8 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
 
                 // Convert amount (in denomination tokens) to payout token and apply allocation
                 uint256 tokenAmount = _totalAmount.mul(exchangeRate).mul(tokenAllocation);
-                // Divide by 100 for the allocation percentage and by ONE for the exchange rate precision
-                tokenAmount = tokenAmount / (100 * ONE);
+                // Divide by 100 for the allocation percentage and by the exchange rate precision
+                tokenAmount = tokenAmount.div(feed.ratePrecision().mul(100));
 
                 // Finance reverts if the payment wasn't possible
                 finance.newImmediatePayment(token, employeeAddress, tokenAmount, paymentReference);
@@ -708,17 +707,11 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
     /**
      * @dev Get exchange rate for a token based on the denomination token.
      *      As an example, if the denomination token was USD and ETH's price was 100USD,
-     *      this would return 0.01 * ONE for ETH.
+     *      this would return 0.01 * precision rate for ETH.
      * @param _token Token to get price of in denomination tokens
-     * @return Exchange rate (multiplied by ONE for precision).
-               Exactly ONE if _token is denominationToken or 0 if the exchange rate isn't recent enough.
+     * @return Exchange rate (multiplied by the PPF rate precision)
      */
     function _getExchangeRateInDenominationToken(address _token) internal view returns (uint256) {
-        // Denomination token has always exchange rate of 1
-        if (_token == denominationToken) {
-            return ONE;
-        }
-
         // xrt is the number of `_token` that can be exchanged for one `denominationToken`
         (uint128 xrt, uint64 when) = feed.get(
             denominationToken,  // Base (e.g. USD)

--- a/future-apps/payroll/contracts/examples/PayrollKit.sol
+++ b/future-apps/payroll/contracts/examples/PayrollKit.sol
@@ -18,7 +18,11 @@ import "../Payroll.sol";
 
 
 contract PPFMock is IFeed {
-  function get(address, address) external view returns (uint128 xrt, uint64 when) {
+    function ratePrecision() external pure returns (uint256) {
+        return 10 ** 18;
+    }
+
+    function get(address, address) external view returns (uint128 xrt, uint64 when) {
       xrt = 7500000000000000; // 1 ETH = ~133USD
       when = uint64(now);
   }

--- a/future-apps/payroll/contracts/test/mocks/PriceFeedMock.sol
+++ b/future-apps/payroll/contracts/test/mocks/PriceFeedMock.sol
@@ -19,17 +19,17 @@ contract PriceFeedMock is PPF, TimeHelpersMock {
 
     // Overwrite function using TimeHelpers and allowing to set past rates
     function update(address base, address quote, uint128 xrt, uint64 when, bytes sig) public {
-        bytes32 pair = super.pairId(base, quote);
+        bytes32 pair = _pairId(base, quote);
 
         // Remove check that ensures a given rate is more recent than the current value
         // require(when > feed[pair].when && when <= getTimestamp());
         require(xrt > 0); // Make sure xrt is not 0, as the math would break (Dividing by 0 sucks big time)
         require(base != quote); // Assumption that currency units are fungible and xrt should always be 1
 
-        bytes32 h = super.setHash(base, quote, xrt, when);
+        bytes32 h = _setHash(base, quote, xrt, when);
         require(h.personalRecover(sig) == operator); // Make sure the update was signed by the operator
 
-        feed[pair] = Price(super.pairXRT(base, quote, xrt), when);
+        feed[pair] = Price(_pairXRT(base, quote, xrt), when);
 
         emit SetRate(base, quote, xrt, when);
     }

--- a/future-apps/payroll/package.json
+++ b/future-apps/payroll/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@aragon/apps-finance": "3.0.0",
     "@aragon/os": "4.2.0",
-    "@aragon/ppf-contracts": "1.1.0"
+    "@aragon/ppf-contracts": "1.2.0"
   },
   "devDependencies": {
     "@aragon/apps-shared-migrations": "1.0.0",

--- a/future-apps/payroll/test/contracts/Payroll_gas_costs.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_gas_costs.test.js
@@ -35,12 +35,12 @@ contract('Payroll gas costs', ([owner, employee, anotherEmployee]) => {
     })
 
     context('when there is only one allowed token', function () {
-      it('expends ~335k gas for a single allowed token', async () => {
+      it('expends ~339k gas for a single allowed token', async () => {
         await payroll.determineAllocation([DAI.address], [100], { from: employee })
 
         const { receipt: { cumulativeGasUsed } } = await payroll.payday(PAYMENT_TYPES.PAYROLL, 0, { from: employee })
 
-        assert.isAtMost(cumulativeGasUsed, 336000, 'payout gas cost for a single allowed token should be ~336k')
+        assert.isAtMost(cumulativeGasUsed, 339000, 'payout gas cost for a single allowed token should be ~339k')
       })
     })
 


### PR DESCRIPTION
*Fixing finding 6.6 of the audit report*

### 6.6 Decimal calculations `ONE`, can differ between Price feed and Payroll

| Severity     | Status    | Remediation Comment |
|:------------:|:---------:| ------------------- |
| Minor | Open | This issue is currently under review. |

#### Description
The decimal calculation is using a hardcoded `ONE = 10 ** 18`; in both PPF (**uint256**) and Payroll (**uint128**) contracts. 

- In `PPF.sol`:

**code/ppf-contracts/packages/ppf-contracts/contracts/PPF.sol:L11**
```solidity
uint256 constant public ONE = 10 ** 18; // 10^18 is considered 1 in the price feed to allow for decimal calculations
```

- In `Payroll.sol`:

**code/payroll/future-apps/payroll/contracts/Payroll.sol:L32**
```solidity
uint128 internal constant ONE = 10 ** 18; // 10^18 is considered 1 in the price feed to allow for decimal calculations
```

This can result in an issue in some calculations as the types are different (uint128 v.s. uint 256) but mainly for future/thirdparty IFEED interfaces that specify different decimal points for `ONE`. 

#### Examples

- In `PPF.sol`:


**code/ppf-contracts/packages/ppf-contracts/contracts/PPF.sol:L113-L116**
```solidity
function get(address base, address quote) public view returns (uint128, uint64) {
    if (base == quote) {
        return (uint128(ONE), getTimestamp64());
    }
```

- In `Payroll.sol`:


**code/payroll/future-apps/payroll/contracts/Payroll.sol:L627-L630**
```solidity
// Convert amount (in denomination tokens) to payout token and apply allocation
uint256 tokenAmount = _totalAmount.mul(exchangeRate).mul(tokenAllocation);
// Divide by 100 for the allocation percentage and by ONE for the exchange rate precision
tokenAmount = tokenAmount / (100 * ONE);
```

#### Remediation

In `Payroll.sol` where `ONE` is used, read the value from PPF contract, or simply `require` them to be the same. 
