### PR TITLE
Payroll: Add payroll remainders as accrued salary

### DIFF
--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -662,8 +662,8 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
         // into their accrued salary
         uint256 extraSalary = currentSalaryPaid % salary;
         if (extraSalary > 0) {
-            timeDiff.add(1);
-            employee.accruedSalary = extraSalary;
+            timeDiff = timeDiff.add(1);
+            employee.accruedSalary = salary - currentSalaryPaid;
         } else if (accruedSalary > 0) {
             employee.accruedSalary = 0;
         }

--- a/future-apps/payroll/contracts/Payroll.sol
+++ b/future-apps/payroll/contracts/Payroll.sol
@@ -651,42 +651,27 @@ contract Payroll is EtherTokenConstant, IForwarder, IsContract, AragonApp {
         if (accruedSalary > 0) {
             // Employee is cashing out a mixed amount between previous and current owed salaries;
             // first use up their accrued salary
-            employee.accruedSalary = uint256(0);
             // No need to use SafeMath here as we already know _paymentAmount > accruedSalary
             currentSalaryPaid = _paymentAmount - accruedSalary;
         }
-        _updateEmployeeLastPayrollDate(_employeeId, currentSalaryPaid);
-    }
+        uint256 salary = employee.denominationTokenSalary;
+        uint256 timeDiff = currentSalaryPaid.div(salary);
 
-    /**
-     * @dev Update the last payroll date for an employee based on the requested payment amount. If the requested amount
-     *      cannot be represented by a multiple of the employee's salary per second, it will be added as accrued salary.
-     * @param _employeeId Employee's identifier
-     * @param _paidAmount Requested amount to be paid to the employee
-     */
-    function _updateEmployeeLastPayrollDate(uint256 _employeeId, uint256 _paidAmount) internal {
-        Employee storage employee = employees[_employeeId];
-
-        uint256 timeDiff = _paidAmount.div(employee.denominationTokenSalary);
-
-        // We check if the division was perfect, and if not, take its ceiling to avoid giving away tiny amounts of
-        // salary and add the remainder to the accrued salary.
-        if (timeDiff.mul(employee.denominationTokenSalary) != _paidAmount) {
-            timeDiff = timeDiff.add(1);
-            // No need to use SafeMath here, we already now that _paidAmount is lower than its ceil
-            uint256 remainder = timeDiff.mul(employee.denominationTokenSalary) - _paidAmount;
-
-            uint256 currentAccruedSalary = employee.accruedSalary;
-            uint256 newAccruedSalary = currentAccruedSalary + remainder;
-            if (newAccruedSalary < currentAccruedSalary) {
-                newAccruedSalary = MAX_UINT256;
-            }
-            employee.accruedSalary = newAccruedSalary;
+        // If they're being paid an amount that doesn't match perfectly with the adjusted time
+        // (up to a seconds' worth of salary), add the second and put the extra remaining salary
+        // into their accrued salary
+        uint256 extraSalary = currentSalaryPaid % salary;
+        if (extraSalary > 0) {
+            timeDiff.add(1);
+            employee.accruedSalary = extraSalary;
+        } else if (accruedSalary > 0) {
+            employee.accruedSalary = 0;
         }
 
         uint256 lastPayrollDate = uint256(employee.lastPayroll).add(timeDiff);
-        // Even though this function should never receive a _paidAmount value that would result in
-        // the lastPayrollDate being higher than the current time, let's double check to be safe
+        // Even though this function should never receive a currentSalaryPaid value that would
+        // result in the lastPayrollDate being higher than the current time,
+        // let's double check to be safe
         require(lastPayrollDate <= uint256(getTimestamp64()), ERROR_LAST_PAYROLL_DATE_TOO_BIG);
         // Already know lastPayrollDate must fit in uint64 from above
         employee.lastPayroll = uint64(lastPayrollDate);

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -597,7 +597,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
             })
           })
 
-          context('when the employee has a huge salary', () => {
+          context.only('when the employee has a huge salary', () => {
             const salary = MAX_UINT256
 
             beforeEach('add employee', async () => {


### PR DESCRIPTION
*Fixing finding 6.3 of the audit report*

### 6.3 Employee may lose up to a second of the salary

| Severity     | Status    | Remediation Comment |
|:------------:|:---------:| ------------------- |
| Medium | Open | This issue is currently under review. |

#### Description

An employee can lose up to a second of their salary on calling `payday` function. It happens if the employee requests a specific amount of money that cannot be formed by multiplying salary-per-second base-unit `denominationTokenSalary` and any amount of seconds. On that case, rounding is done in favour of an employer. 


**code/payroll/future-apps/payroll/contracts/Payroll.sol:L751-L759**
```solidity
uint256 timeDiff = _paidAmount.div(employee.denominationTokenSalary);

// We check if the division was perfect, and if not, take its ceiling to avoid giving away
// tiny amounts of salary.
// Employees may lose up to a second's worth of payroll if they use the "request partial
// amount" feature or reach salary amounts that get capped by uint max.
if (timeDiff.mul(employee.denominationTokenSalary) != _paidAmount) {
    timeDiff = timeDiff.add(1);
}
```

This issue has also been [discussed](https://github.com/aragon/aragon-apps/tree/payroll-readme/future-apps/payroll#losing-one-second-of-pay-when-using-partial-payments) by the project team.

#### Remediation

While losing up to a second might not sound like a big issue, it can be easily fixed by adding this rounding error to the accrued salary of the employee instead of just keeping it to the employer. Adding this to the accrued salary, might have side-effects e.g. that a terminated employee cannot immediately be removed from storage after cashing out, because `payday` accounted the lost fraction of a second to accrued salary. 
