### PR TITLE
Payroll: cover cases for moving extra pay from payday into accrued salary

### DIFF
--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -307,7 +307,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, currentOwedSalary)
                 })
 
-                context.only('when the requested amount is lower than the total owed salary', () => {
+                context('when the requested amount is lower than the total owed salary', () => {
                   context('when the requested amount represents less than a second of the earnings', () => {
                     const requestedAmount = salary.div(2).floor()
 
@@ -386,13 +386,13 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)
                 })
 
-                context.only('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
+                context('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
                   const requestedAmount = previousOwedSalary.plus(salary).minus(1)
 
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)
                 })
 
-                context.only('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
+                context('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
                   const requestedAmount = previousOwedSalary.plus(salary).plus(1)
 
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -257,7 +257,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                       await payroll.terminateEmployee(employeeId, await payroll.getTimestampPublic(), { from: owner })
                     })
 
-                    if (requestedAmount.eq(0) || requestedAmount === totalOwedAmount) {
+                    if (requestedAmount.eq(0) || requestedAmount.eq(totalOwedAmount)) {
                       context('when exchange rates are not expired', () => {
                         assertTransferredAmounts(requestedAmount, expectedRequestedAmount)
 
@@ -301,13 +301,13 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
 
                 context.only('when the requested amount is lower than the total owed salary', () => {
                   context('when the requested amount represents less than a second of the earnings', () => {
-                    const requestedAmount = salary.div(2)
+                    const requestedAmount = salary.div(2).floor()
 
                     itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, currentOwedSalary)
                   })
 
                   context('when the requested amount represents more than a second of the earnings', () => {
-                    const requestedAmount = currentOwedSalary.div(2)
+                    const requestedAmount = currentOwedSalary.div(2).ceil()
 
                     itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, currentOwedSalary)
                   })
@@ -413,7 +413,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                 })
 
                 context('when the requested amount is lower than the previous owed salary', () => {
-                  const requestedAmount = previousOwedSalary.div(2)
+                  const requestedAmount = previousOwedSalary.div(2).floor()
 
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, previousOwedSalary)
                 })
@@ -444,7 +444,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
               })
 
               context('when the requested amount is lower than the total owed salary', () => {
-                const requestedAmount = owedSalary.div(2)
+                const requestedAmount = owedSalary.div(2).floor()
 
                 it('reverts', async () => {
                   await assertRevert(payroll.payday(PAYMENT_TYPES.PAYROLL, requestedAmount, { from }), 'PAYROLL_DISTRIBUTION_NOT_FULL')

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -299,18 +299,11 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, currentOwedSalary)
                 })
 
-                context('when the requested amount is lower than the total owed salary', () => {
+                context.only('when the requested amount is lower than the total owed salary', () => {
                   context('when the requested amount represents less than a second of the earnings', () => {
                     const requestedAmount = salary.div(2)
 
-                    it('updates the last payroll date by one second', async () => {
-                      const previousLastPayrollDate = (await payroll.getEmployee(employeeId))[5]
-
-                      await payroll.payday(PAYMENT_TYPES.PAYROLL, requestedAmount, { from })
-
-                      const currentLastPayrollDate = (await payroll.getEmployee(employeeId))[5]
-                      assert.equal(currentLastPayrollDate.toString(), previousLastPayrollDate.plus(1).toString(), 'last payroll date does not match')
-                    })
+                    itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, currentOwedSalary)
                   })
 
                   context('when the requested amount represents more than a second of the earnings', () => {
@@ -385,8 +378,14 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)
                 })
 
-                context('when the requested amount is greater than the previous owed salary but lower than the total owed', () => {
-                  const requestedAmount = totalOwedSalary.div(2)
+                context.only('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
+                  const requestedAmount = previousOwedSalary.plus(salary).minus(1)
+
+                  itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)
+                })
+
+                context.only('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
+                  const requestedAmount = previousOwedSalary.plus(salary).plus(1)
 
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)
                 })
@@ -694,7 +693,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                     }
 
                     const assertEmployeeIsUpdated = requestedAmount => {
-                      it('updates the last payroll date', async () => {
+                      it('updates the employee accounting', async () => {
                         const timeDiff = 1 // should be bn(requestedAmount).div(salary).ceil() but BN cannot represent such a small number, hardcoding it to 1
                         const [previousAccruedSalary, , , previousPayrollDate] = (await payroll.getEmployee(employeeId)).slice(2, 6)
 

--- a/future-apps/payroll/test/contracts/Payroll_payday.test.js
+++ b/future-apps/payroll/test/contracts/Payroll_payday.test.js
@@ -386,7 +386,7 @@ contract('Payroll payday', ([owner, employee, anyone]) => {
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)
                 })
 
-                context('when the requested amount is greater than the previous owed salary but greater than one second of additional salary', () => {
+                context('when the requested amount is greater than the previous owed salary but less than one second of additional salary', () => {
                   const requestedAmount = previousOwedSalary.plus(salary).minus(1)
 
                   itHandlesPayrollProperlyNeverthelessExtrasOwedAmounts(requestedAmount, totalOwedSalary)


### PR DESCRIPTION
Modified a few of the tests to try and cover the case we had with `payday()`'s extra remainder salary being moved into the employee's accrued salary.