### PR TITLE
Travis: move Payroll's payday() tests into its own integration test stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       name: "Agent"
     - script: npm run test:finance
       name: "Finance"
-    - script: npm run test:payroll:only:payday
+    - script: npm run test:payroll:except:payday
       name: "Payroll except payday"
     - script: npm run test:survey
       name: "Survey"
@@ -68,7 +68,7 @@ jobs:
       name: "Voting"
 
     - stage: integration
-      script: npm run test:payroll:except:payday
+      script: npm run test:payroll:only:payday
       name: "Payroll payday"
 after_success:
   - ./node_modules/.bin/lcov-result-merger 'apps/*/coverage/lcov.info' | ./node_modules/.bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ jobs:
     - script: npm run test:finance
       name: "Finance"
     - script: npm run test:payroll:only:payday
-      name: "Payroll payday"
-    - script: npm run test:payroll:except:payday
       name: "Payroll except payday"
     - script: npm run test:survey
       name: "Survey"
@@ -68,5 +66,9 @@ jobs:
       name: "Vault"
     - script: npm run coverage:voting
       name: "Voting"
+
+    - stage: integration
+      script: npm run test:payroll:except:payday
+      name: "Payroll payday"
 after_success:
   - ./node_modules/.bin/lcov-result-merger 'apps/*/coverage/lcov.info' | ./node_modules/.bin/coveralls


### PR DESCRIPTION
Moves this long-running (1h+) test into its own stage, so that it doesn't block the rest of the coverage tests from running.