### PR TITLE
Token Manager: deploy preview to now

### DIFF
--- a/apps/token-manager/app/now.json
+++ b/apps/token-manager/app/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "public": true,
+  "scope": "aragon",
+  "name": "token-manager",
+  "alias": "nightly-token-manager.aragon.org",
+  "builds": [
+    { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "build" } }
+  ]
+}

--- a/apps/token-manager/app/package.json
+++ b/apps/token-manager/app/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aragon/api": "^2.0.0-beta.4",
     "@aragon/api-react": "^2.0.0-beta.4",
-    "@aragon/ui": "^0.40.1",
+    "@aragon/ui": "^1.0.0-alpha.7",
     "bn.js": "^4.11.6",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
@@ -45,9 +45,10 @@
     "lint": "eslint ./src",
     "start": "npm run sync-assets && npm run watch:script & parcel serve index.html -p 3003 --out-dir build/",
     "build": "npm run sync-assets && npm run build:script && parcel build index.html --out-dir build/ --public-url \".\"",
-    "watch:script": "parcel watch src/script.js --out-dir build/ --no-hmr",
     "build:script": "parcel build src/script.js --out-dir build/",
-    "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && rsync -rtu ./public/ ./build"
+    "watch:script": "parcel watch src/script.js --out-dir build/ --no-hmr",
+    "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && rsync -rtu ./public/ ./build",
+    "now-build": "npm run build"
   },
   "browserslist": [
     ">2%",


### PR DESCRIPTION
Sets up a `now.json` file that allows someone to use

```
now --target production
```

to deploy a preview to `nightly-token-manager.aragon.org`.