### PR TITLE
Voting: deploy preview to now

### DIFF
--- a/apps/voting/app/now.json
+++ b/apps/voting/app/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "public": true,
+  "scope": "aragon",
+  "name": "voting",
+  "alias": "nightly-voting.aragon.org",
+  "builds": [
+    { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "build" } }
+  ]
+}

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -45,11 +45,12 @@
   "scripts": {
     "lint": "eslint ./src",
     "test": "jest",
-    "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && rsync -rtu ./public/ ./build",
     "start": "npm run sync-assets && npm run watch:script & parcel serve index.html -p 3001 --out-dir build/",
     "build": "npm run sync-assets && npm run build:script && parcel build index.html --out-dir build/ --public-url \".\"",
+    "build:script": "parcel build src/script.js --out-dir build/",
     "watch:script": "parcel watch src/script.js --out-dir build/ --no-hmr",
-    "build:script": "parcel build src/script.js --out-dir build/"
+    "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && rsync -rtu ./public/ ./build",
+    "now-build": "npm run build"
   },
   "browserslist": [
     ">2%",

--- a/apps/voting/app/package.json
+++ b/apps/voting/app/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aragon/api": "^2.0.0-beta.3",
     "@aragon/api-react": "^2.0.0-beta.1",
-    "@aragon/ui": "^0.40.1",
+    "@aragon/ui": "^1.0.0-alpha.7",
     "bn.js": "^4.11.8",
     "date-fns": "2.0.0-alpha.22",
     "onecolor": "^3.1.0",


### PR DESCRIPTION
Similar to #937, allows someone to deploy to `nightly-voting.aragon.org` with

```
now --target production
```