### PR TITLE
Voting: don't query vote status when there's no connected account

### DIFF
--- a/apps/voting/app/src/script.js
+++ b/apps/voting/app/src/script.js
@@ -1,6 +1,7 @@
 import Aragon, { events } from '@aragon/api'
 import { addressesEqual } from './web3-utils'
 import voteSettings from './vote-settings'
+import { VOTE_ABSENT } from './vote-types'
 import { voteTypeFromContractEnum } from './vote-utils'
 import { EMPTY_CALLSCRIPT } from './evmscript-utils'
 import tokenDecimalsAbi from './abi/token-decimals.json'
@@ -227,6 +228,13 @@ async function getAccountVotes({ connectedAccount, votes = [] }) {
 }
 
 async function getVoterState({ connectedAccount, voteId }) {
+  if (!connectedAccount) {
+    return {
+      voteId,
+      voteType: VOTE_ABSENT,
+    }
+  }
+
   // Wrap with retry in case the vote is somehow not present
   return retryEvery(() =>
     app


### PR DESCRIPTION
Fixes some errors in the script if the user's account wasn't connected.