### PR TITLE
chore: fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,9 @@ node_modules
 lerna-debug.log
 
 # truffle build artifacts
-*/**/abi
-*/**/build
-*/**/.DS_Store
+# Ignore only for first level to select just the contract build directories
+*/*/abi
+*/*/build
 
 # yarn
 yarn-error.log
@@ -26,3 +26,7 @@ yarn-error.log
 # Ignore lock files
 package-lock.json
 yarn.lock
+
+# Misc
+.DS_Store
+.cache

--- a/apps/voting/app/src/abi/token-balanceOf.json
+++ b/apps/voting/app/src/abi/token-balanceOf.json
@@ -1,0 +1,21 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
Avoid selecting /build and /abi folders too deep into the repo, so that app frontends can control this themselves.