### PR TITLE
Finance: increase gas estimate for deposits

### DIFF
--- a/apps/finance/app/src/App.js
+++ b/apps/finance/app/src/App.js
@@ -66,7 +66,7 @@ class App extends React.Component {
         // transition but we do the estimation with some breathing room in case it is being
         // forwarded (unlikely in deposit).
         gas:
-          400000 +
+          450000 +
           20000 * Math.ceil(reference.length / 32) +
           80000 * periodTransitions,
       }


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/834

The transaction linked in the issue would have worked with 431,885 gas (if all accounting periods were already transitioned, which I assume that was the case given that the gas estimate was 420k). In any case, the real amount of gas that is actually used is lower, but because of DelegateProxy's `FWD_GAS_LIMIT` the transaction needs extra gas that is not used. I created an issue on aragonOS to rethink this: https://github.com/aragon/aragonOS/issues/556

There's another factor that we are not taking into account in this estimate and that is if the transaction is the first one in the accounting period, 15k more gas are needed as there is [an extra slot that is changed from zero to non-zero](https://github.com/aragon/aragon-apps/blob/master/apps/finance/contracts/Finance.sol#L733)