### PR TITLE
Finance: update mainnet warning copy

### DIFF
--- a/apps/finance/app/src/components/NewTransfer/Deposit.js
+++ b/apps/finance/app/src/components/NewTransfer/Deposit.js
@@ -309,7 +309,7 @@ class Deposit extends React.Component {
         <Info>
           {isMainnet && (
             <p>
-              Remember, Mainnet organizations use <strong>real tokens</strong>.
+              Remember, Mainnet organizations use <strong>real funds</strong>.
             </p>
           )}
           <p>


### PR DESCRIPTION
From https://github.com/aragon/aragon-apps/pull/929#discussion_r314504863

We will align on using "funds" rather than "tokens" when referring to both ETH and ERC20 tokens.