### PR TITLE
Voting: support external apps as target

### DIFF
--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -40,6 +40,7 @@ function useDecoratedVotes() {
         if (!targetApp) {
           targetApp = {
             appAddress: targetAddress,
+            icon: () => null,
             name: 'External',
           }
         }
@@ -47,11 +48,11 @@ function useDecoratedVotes() {
 
       let executionTargetData = {}
       if (targetApp) {
-        const { appAddress, name, identifier } = targetApp
+        const { appAddress, icon, identifier, name } = targetApp
         executionTargetData = {
           address: appAddress,
           name,
-          iconSrc: targetApp.icon(24),
+          iconSrc: icon(24),
           identifier,
         }
       }


### PR DESCRIPTION
Partially fixes https://github.com/aragon/aragon-apps/issues/994 (`app.icon()` error).

The issue was caused by the dummy app object used for external targets, that was not including `icon()`.