### PR TITLE
Voting: fix a crash that was happening in certain cases

### DIFF
--- a/apps/voting/app/src/components/VoteCard/VoteCard.js
+++ b/apps/voting/app/src/components/VoteCard/VoteCard.js
@@ -68,13 +68,15 @@ const VoteCard = ({ vote, onOpen }) => {
           margin-bottom: ${1 * GU}px;
         `}
       >
-        <LocalLabelAppBadge
-          badgeOnly
-          appAddress={executionTargetData.address}
-          iconSrc={executionTargetData.iconSrc}
-          identifier={executionTargetData.identifier}
-          label={executionTargetData.name}
-        />
+        {executionTargetData && (
+          <LocalLabelAppBadge
+            badgeOnly
+            appAddress={executionTargetData.address}
+            iconSrc={executionTargetData.iconSrc}
+            identifier={executionTargetData.identifier}
+            label={executionTargetData.name}
+          />
+        )}
         {youVoted && (
           <div
             css={`

--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -5,12 +5,6 @@ import { VOTE_ABSENT } from '../vote-types'
 import { EMPTY_ADDRESS } from '../web3-utils'
 import useNow from './useNow'
 
-// Temporary fix to make sure executionTargets always returns an array, until
-// we find out the reason why it can sometimes be missing in the cached data.
-function getVoteExecutionTargets(vote) {
-  return vote.data.executionTargets || []
-}
-
 // Decorate the votes array with more information relevant to the frontend
 function useDecoratedVotes() {
   const { votes, connectedAccountVotes } = useAppState()
@@ -22,10 +16,14 @@ function useDecoratedVotes() {
       return [[], []]
     }
     const decoratedVotes = votes.map((vote, i) => {
-      const executionTargets = getVoteExecutionTargets(vote)
+      const executionTargets = vote.data.executionTargets
 
       let targetApp
-      if (!executionTargets.length) {
+      if (!executionTargets) {
+        console.warn(
+          `Voting: vote #${vote.voteId} does not list any execution targets. The app's cache is likely corrupted and needs to be reset.`
+        )
+      } else if (!executionTargets.length) {
         // If there's no execution target, consider it targetting this Voting app
         targetApp = {
           ...currentApp,
@@ -82,7 +80,7 @@ function useDecoratedVotes() {
     const executionTargets = installedApps
       .filter(app =>
         votes.some(vote =>
-          getVoteExecutionTargets(vote).includes(app.appAddress)
+          (vote.data.executionTargets || []).includes(app.appAddress)
         )
       )
       .map(({ appAddress, identifier, name }) => ({

--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -34,7 +34,6 @@ function useDecoratedVotes() {
         // If there's multiple targets, make a "multiple" version
         targetApp = {
           appAddress: EMPTY_ADDRESS,
-          icon: () => null,
           name: 'Multiple',
         }
       } else {
@@ -45,7 +44,6 @@ function useDecoratedVotes() {
         if (!targetApp) {
           targetApp = {
             appAddress: targetAddress,
-            icon: () => null,
             name: 'External',
           }
         }
@@ -57,14 +55,8 @@ function useDecoratedVotes() {
         executionTargetData = {
           address: appAddress,
           name,
-
-          // This check ensures icon() only gets called if it actually exists,
-          // as users were reporting a crash happening in some cases. The
-          // problem seems to come from the multiple targets condition that
-          // was not including icon(), but this ensures it won’t crash anymore,
-          // until we can 100% reproduce the issue.
+          // Only try to get the icon if it's available
           iconSrc: typeof icon === 'function' ? icon(24) : null,
-
           identifier,
         }
       }

--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -36,6 +36,7 @@ function useDecoratedVotes() {
         // If there's multiple targets, make a "multiple" version
         targetApp = {
           appAddress: EMPTY_ADDRESS,
+          icon: () => null,
           name: 'Multiple',
         }
       } else {
@@ -58,7 +59,14 @@ function useDecoratedVotes() {
         executionTargetData = {
           address: appAddress,
           name,
-          iconSrc: icon(24),
+
+          // This check ensures icon() only gets called if it actually exists,
+          // as users were reporting a crash happening in some cases. The
+          // problem seems to come from the multiple targets condition that
+          // was not including icon(), but this ensures it won’t crash anymore,
+          // until we can 100% reproduce the issue.
+          iconSrc: typeof icon === 'function' ? icon(24) : null,
+
           identifier,
         }
       }

--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -49,7 +49,7 @@ function useDecoratedVotes() {
         }
       }
 
-      let executionTargetData = {}
+      let executionTargetData = null
       if (targetApp) {
         const { appAddress, icon, identifier, name } = targetApp
         executionTargetData = {

--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -85,12 +85,14 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
                 justify-content: space-between;
               `}
             >
-              <LocalLabelAppBadge
-                appAddress={executionTargetData.address}
-                iconSrc={executionTargetData.iconSrc}
-                identifier={executionTargetData.identifier}
-                label={executionTargetData.name}
-              />
+              {executionTargetData && (
+                <LocalLabelAppBadge
+                  appAddress={executionTargetData.address}
+                  iconSrc={executionTargetData.iconSrc}
+                  identifier={executionTargetData.identifier}
+                  label={executionTargetData.name}
+                />
+              )}
               {youVoted && (
                 <Tag icon={<IconCheck size="small" />} label="Voted" />
               )}


### PR DESCRIPTION
This change ensures `icon()` only gets called when it exists.

/cc @john-light 