### PR TITLE
Replace Identifier misspelling in license headers

### DIFF
--- a/apps/agent/contracts/Agent.sol
+++ b/apps/agent/contracts/Agent.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    GPL-3.0-or-later
+ * SPDX-License-Identifier:    GPL-3.0-or-later
  */
 
 pragma solidity 0.4.24;

--- a/apps/finance/contracts/Finance.sol
+++ b/apps/finance/contracts/Finance.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    GPL-3.0-or-later
+ * SPDX-License-Identifier:    GPL-3.0-or-later
  */
 
 pragma solidity 0.4.24;

--- a/apps/survey/contracts/Survey.sol
+++ b/apps/survey/contracts/Survey.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    GPL-3.0-or-later
+ * SPDX-License-Identifier:    GPL-3.0-or-later
  */
 
 pragma solidity 0.4.24;

--- a/apps/token-manager/contracts/TokenManager.sol
+++ b/apps/token-manager/contracts/TokenManager.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    GPL-3.0-or-later
+ * SPDX-License-Identifier:    GPL-3.0-or-later
  */
 
 /* solium-disable function-order */

--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    GPL-3.0-or-later
+ * SPDX-License-Identifier:    GPL-3.0-or-later
  */
 
 pragma solidity 0.4.24;


### PR DESCRIPTION
Even though it was fun to spot projects reusing or forking aragon contracts: https://github.com/search?q=SPDX-License-Identitifer&type=Code

But I thought it might be interesting to fix the misspelling, in case any automated script might eventually parse that header to show the license.

Related: https://github.com/aragon/aragonOS/pull/558