### PR TITLE
Finance, Tokens, Voting: guard accesses to network.type

### DIFF
--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -122,7 +122,6 @@ const getDownloadFilename = (appAddress, { start, end }) => {
 const Transfers = React.memo(({ tokens, transactions }) => {
   const connectedAccount = useConnectedAccount()
   const currentApp = useCurrentApp()
-  const network = useNetwork()
   const toast = useToast()
   const theme = useTheme()
   const { layoutName } = useLayout()
@@ -325,10 +324,7 @@ const Transfers = React.memo(({ tokens, transactions }) => {
       }}
       renderEntryActions={({ entity, transactionHash }) => (
         <ContextMenu zIndex={1}>
-          <ContextMenuViewTransaction
-            transactionHash={transactionHash}
-            network={network}
-          />
+          <ContextMenuViewTransaction transactionHash={transactionHash} />
           <ContextMenuItemCustomLabel entity={entity} />
         </ContextMenu>
       )}
@@ -364,10 +360,11 @@ const ContextMenuItemCustomLabel = ({ entity }) => {
   )
 }
 
-const ContextMenuViewTransaction = ({ transactionHash, network }) => {
+const ContextMenuViewTransaction = ({ transactionHash }) => {
   const theme = useTheme()
-  const handleViewTransaction = useCallback(
-    () => {
+  const network = useNetwork()
+  const handleViewTransaction = useCallback(() => {
+    if (network && network.type) {
       window.open(
         blockExplorerUrl('transaction', transactionHash, {
           networkType: network.type,
@@ -375,9 +372,8 @@ const ContextMenuViewTransaction = ({ transactionHash, network }) => {
         '_blank',
         'noopener'
       )
-    },
-    [transactionHash, network]
-  )
+    }
+  }, [transactionHash, network])
 
   return (
     <ContextMenuItem onClick={handleViewTransaction}>

--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -151,15 +151,12 @@ const Transfers = React.memo(({ tokens, transactions }) => {
     },
     [setPage, setSelectedTransferType]
   )
-  const handleClearFilters = useCallback(
-    () => {
-      setPage(0)
-      setSelectedTransferType(UNSELECTED_TRANSFER_TYPE_FILTER)
-      setSelectedToken(UNSELECTED_TOKEN_FILTER)
-      setSelectedDateRange(INITIAL_DATE_RANGE)
-    },
-    [setPage, setSelectedTransferType, setSelectedToken, setSelectedDateRange]
-  )
+  const handleClearFilters = useCallback(() => {
+    setPage(0)
+    setSelectedTransferType(UNSELECTED_TRANSFER_TYPE_FILTER)
+    setSelectedToken(UNSELECTED_TOKEN_FILTER)
+    setSelectedDateRange(INITIAL_DATE_RANGE)
+  }, [setPage, setSelectedTransferType, setSelectedToken, setSelectedDateRange])
   const filteredTransfers = getFilteredTransfers({
     transactions,
     selectedToken: selectedToken > 0 ? tokens[selectedToken - 1] : null,
@@ -169,26 +166,23 @@ const Transfers = React.memo(({ tokens, transactions }) => {
   const symbols = tokens.map(({ symbol }) => symbol)
   const tokenDetails = tokens.reduce(getTokenDetails, {})
   const { resolve: resolveAddress } = React.useContext(IdentityContext)
-  const handleDownload = useCallback(
-    async () => {
-      if (!currentApp || !currentApp.appAddress) {
-        return
-      }
+  const handleDownload = useCallback(async () => {
+    if (!currentApp || !currentApp.appAddress) {
+      return
+    }
 
-      const data = await getDownloadData(
-        filteredTransfers,
-        tokenDetails,
-        resolveAddress
-      )
-      const filename = getDownloadFilename(
-        currentApp.appAddress,
-        selectedDateRange
-      )
-      saveAs(new Blob([data], { type: 'text/csv;charset=utf-8' }), filename)
-      toast('Transfers data exported')
-    },
-    [currentApp, filteredTransfers, tokenDetails, resolveAddress]
-  )
+    const data = await getDownloadData(
+      filteredTransfers,
+      tokenDetails,
+      resolveAddress
+    )
+    const filename = getDownloadFilename(
+      currentApp.appAddress,
+      selectedDateRange
+    )
+    saveAs(new Blob([data], { type: 'text/csv;charset=utf-8' }), filename)
+    toast('Transfers data exported')
+  }, [currentApp, filteredTransfers, tokenDetails, resolveAddress])
   const emptyResultsViaFilters =
     !filteredTransfers.length &&
     (selectedToken !== 0 ||

--- a/apps/token-manager/app/src/components/InfoBoxes.js
+++ b/apps/token-manager/app/src/components/InfoBoxes.js
@@ -62,7 +62,7 @@ function InfoBoxes({
                 address={tokenAddress}
                 name={tokenName}
                 symbol={tokenSymbol}
-                networkType={network.type}
+                networkType={network && network.type}
               />,
             ],
           ].map(([label, content], index) => (

--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -298,7 +298,7 @@ function Status({ vote }) {
       {executionTransaction && (
         <div>
           <TransactionBadge
-            networkType={network.type}
+            networkType={network && network.type}
             transaction={executionTransaction}
             css={`
               margin-top: ${1 * GU}px;


### PR DESCRIPTION
Fixes #1014.

It looks like we get unlucky sometimes, where `@aragon/api-react`'s hooks are not hydrated with data fast enough and their default state is used.

This change adds protections to accessing `network.type` from `useNetwork()`, to avoid causing the apps to error immediately.