### PR TITLE
Tokens: fix the text overflow in the header

### DIFF
--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -131,7 +131,6 @@ class App extends React.PureComponent {
                     align-items: center;
                     flex: 1 1 auto;
                     width: 0;
-                    align-items: center;
                   `}
                 >
                   <h1

--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -129,6 +129,9 @@ class App extends React.PureComponent {
                   css={`
                     display: flex;
                     align-items: center;
+                    flex: 1 1 auto;
+                    width: 0;
+                    align-items: center;
                   `}
                 >
                   <h1
@@ -136,13 +139,19 @@ class App extends React.PureComponent {
                       ${textStyle(
                         layoutName === 'small' ? 'title3' : 'title2'
                       )};
-                      color: ${theme.content};
+                      flex: 0 1 auto;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
                       margin-right: ${1 * GU}px;
+                      color: ${theme.content};
                     `}
                   >
                     Tokens
                   </h1>
-                  {tokenSymbol && <Tag mode="identifier">{tokenSymbol}</Tag>}
+                  <div css="flex-shrink: 0">
+                    {tokenSymbol && <Tag mode="identifier">{tokenSymbol}</Tag>}
+                  </div>
                 </div>
               }
               secondary={


### PR DESCRIPTION
Not strictly necessary with the normal app title, but it is a structure we can reuse on other apps too.

Before:

<img src=https://user-images.githubusercontent.com/36158/68078204-90bfec80-fdd1-11e9-9368-bee88e7077a4.png width=50%>

After:

<img src=https://user-images.githubusercontent.com/36158/68078215-aaf9ca80-fdd1-11e9-99e6-646b19a60f02.png width=50%>
