### PR TITLE
Finance: app improvements

### DIFF
--- a/apps/finance/app/src/components/NewTransfer/Withdrawal.js
+++ b/apps/finance/app/src/components/NewTransfer/Withdrawal.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useLayoutEffect, useState } from 'react'
 import styled from 'styled-components'
 import {
   Button,
@@ -22,38 +22,29 @@ const DECIMALS_TOO_MANY_ERROR = Symbol('DECIMALS_TOO_MANY_ERROR')
 
 const NULL_SELECTED_TOKEN = -1
 
-const initialState = {
-  amount: {
-    error: NO_ERROR,
-    value: '',
-  },
-  recipient: {
-    error: NO_ERROR,
-    value: '',
-  },
-  reference: '',
-  selectedToken: NULL_SELECTED_TOKEN,
-}
-
 class Withdrawal extends React.Component {
   static defaultProps = {
     tokens: [],
     onWithdraw: () => {},
   }
   state = {
-    ...initialState,
+    amount: {
+      error: NO_ERROR,
+      value: '',
+    },
+    recipient: {
+      error: NO_ERROR,
+      value: '',
+    },
+    reference: '',
+    selectedToken: NULL_SELECTED_TOKEN,
   }
   _recipientInput = React.createRef()
-  componentDidMount() {
-    // setTimeout is needed as a small hack to wait until the input is
-    // on-screen before we call focus
-    this._recipientInput.current &&
-      setTimeout(() => this._recipientInput.current.focus(), 0)
-  }
-  componentWillReceiveProps({ opened }) {
-    if (!opened && this.props.opened) {
-      // Panel closing; reset state
-      this.setState({ ...initialState })
+  componentDidUpdate(prevProps) {
+    const { readyToFocus } = this.props
+    const input = this._recipientInput.current
+    if (readyToFocus && !prevProps.readyToFocus && input) {
+      input.focus()
     }
   }
   nonZeroTokens() {
@@ -247,4 +238,10 @@ const ValidationError = ({ message }) => {
   )
 }
 
-export default Withdrawal
+export default props => {
+  const [readyToFocus, setReadyToFocus] = useState(false)
+  useLayoutEffect(() => {
+    setReadyToFocus(true)
+  }, [])
+  return <Withdrawal readyToFocus={readyToFocus} {...props} />
+}

--- a/apps/finance/app/src/components/ToggleContent.js
+++ b/apps/finance/app/src/components/ToggleContent.js
@@ -1,59 +1,60 @@
-import React from 'react'
-import styled from 'styled-components'
-import { springs, GU } from '@aragon/ui'
+import React, { useState } from 'react'
+import { ButtonBase, GU, IconUp, RADIUS, springs, useTheme } from '@aragon/ui'
 import { Transition, animated } from 'react-spring'
-import arrow from './assets/arrow.svg'
 
-class ToggleContent extends React.Component {
-  state = { opened: false }
-  handleClick = () => {
-    this.setState(({ opened }) => ({ opened: !opened }))
-  }
-  render() {
-    const { opened } = this.state
-    const { label, children } = this.props
-    return (
-      <div>
-        <Label onClick={this.handleClick}>
-          {label} <Arrow opened={opened} />
-        </Label>
+const AnimatedDiv = animated.div
 
-        <Transition
-          items={opened}
-          config={springs.swift}
-          from={{ height: 0, opacity: 0 }}
-          enter={{ height: 'auto', opacity: 1 }}
-          leave={{ height: 0, opacity: 0 }}
-          native
-        >
-          {show =>
-            show && (props => <Content style={props}>{children}</Content>)
+function ToggleContent({ label, children }) {
+  const theme = useTheme()
+  const [opened, setOpened] = useState()
+  return (
+    <React.Fragment>
+      <ButtonBase
+        onClick={() => setOpened(opened => !opened)}
+        focusRingRadius={RADIUS}
+        focusRingSpacing={0.5 * GU}
+        css={`
+          display: flex;
+          align-items: center;
+          width: calc(100%);
+          &:active {
+            color: ${theme.surfaceContentSecondary};
           }
-        </Transition>
-      </div>
-    )
-  }
+        `}
+      >
+        {label}{' '}
+        <IconUp
+          size="small"
+          css={`
+            position: relative;
+            top: -1px;
+            margin-left: ${1 * GU}px;
+            transform-origin: 50% 50%;
+            transform: rotate(${opened ? 180 : 0}deg);
+            transition: transform 200ms ease-in-out;
+          `}
+        />
+      </ButtonBase>
+
+      <Transition
+        items={opened}
+        config={springs.swift}
+        from={{ height: 0, opacity: 0 }}
+        enter={{ height: 'auto', opacity: 1 }}
+        leave={{ height: 0, opacity: 0 }}
+        native
+      >
+        {show =>
+          show &&
+          (props => (
+            <AnimatedDiv style={props} css="overflow: hidden">
+              {children}
+            </AnimatedDiv>
+          ))
+        }
+      </Transition>
+    </React.Fragment>
+  )
 }
-
-const Label = styled.button.attrs({ type: 'button' })`
-  cursor: pointer;
-  font-weight: 600;
-  background: none;
-  border: 0;
-  outline: 0;
-  padding: 0;
-  img {
-    margin-left: ${1 * GU}px;
-  }
-`
-const Content = styled(animated.div)`
-  overflow: hidden;
-`
-
-const Arrow = styled.img.attrs({ src: arrow, alt: '' })`
-  transform-origin: 50% 50%;
-  transform: rotate(${p => (p.opened ? 180 : 0)}deg);
-  transition: transform 200ms ease-in-out;
-`
 
 export default ToggleContent

--- a/apps/finance/app/src/components/assets/arrow.svg
+++ b/apps/finance/app/src/components/assets/arrow.svg
@@ -1,1 +1,0 @@
-<svg width="10" height="10" xmlns="http://www.w3.org/2000/svg"><path fill="#B3B3B3" d="M1 6h8L5 2z" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
## Panel

The new SidePanel now unmounts its content when closed, so there is no need to reset the state internally anymore.

Also use useLayoutEffect() rather than setTimeout() to focus the text field.

## ToggleContent

- Use IconUp rather than a custom image.
- Use ButtonBase rather than a button.
- Move to a function component.
- Add a pressed state.
- Use the css prop.

