### PR TITLE
Finance: disable tree-shaking

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "lint": "eslint ./src",
     "start": "npm run sync-assets && npm run watch:script & parcel serve index.html -p 3002 --out-dir build/",
-    "build": "npm run sync-assets && npm run build:script && parcel build index.html --no-cache --experimental-scope-hoisting --out-dir build/ --public-url \".\"",
+    "build": "npm run sync-assets && npm run build:script && parcel build index.html --no-cache --out-dir build/ --public-url \".\"",
     "build:script": "parcel build src/script.js --out-dir build/",
     "watch:script": "parcel watch src/script.js --out-dir build/ --no-hmr",
     "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && rsync -rtu ./public/ ./build",


### PR DESCRIPTION
@bpierre Reversing the build-time configuration change from https://github.com/aragon/aragon-apps/pull/1078.

Producing a build via `npm run build` in Finance is failing with a cryptic `Uncaught ReferenceError: module is not defined`.

Perhaps it's because we haven't published the tree-shaking enabled version of aragonUI yet?