### PR TITLE
Agent: fix screenshot location

### DIFF
--- a/apps/agent/manifest.json
+++ b/apps/agent/manifest.json
@@ -7,8 +7,8 @@
   "source_url": "https://github.com/aragon/aragon-apps/blob/master/apps/agent",
   "icons": [{"src": "/meta/icon.svg", "sizes": "56x56"}],
   "screenshots": [
-    {"src": "./app/public/meta/screenshot-1.png"},
-    {"src": "./app/public/meta/screenshot-2.png"}
+    {"src": "/meta/screenshot-1.png"},
+    {"src": "/meta/screenshot-2.png"}
   ],
   "script": "/script.js",
   "start_url": "/index.html"


### PR DESCRIPTION
@Evalir These locations are a bit weird, but since we publish apps with a slightly different directory structure, we assume the meta folder lives in the published folder's root directory.

E.g. if you do:

```
❯ ipfs ls QmbxRT5KXXP37ce3ixBRUxjXxaMjk2ff7fj923c48XkDBr
QmfBKBqv51pshk6jVbFeF3XtNcG1rd1tzyLLpSwTt9dqWR 20920   BCC.a29566e8.png
QmW9XjtMy7uDL5orxv8N7QnT41Z2s5hESuphmVVbuPqSKJ 15589   agent_badge.4e35e27e.svg
Qme1BVNBgvRBcdvNE7kXQKqkyjdtQQh8u8vi2epAFrJiQX -       aragon-ui/
QmWdkK7VPKao9rtLgHshbsVnDiqRfg1FZdBbJv296WrYJb 22082   artifact.json
QmXvT1hHwyw96dmT6CVd6YSb77PXaiuxaBixUuJp5CibkG 61430   code.sol
QmPZzqpEqTgw21gHZgAdujPwX7c1Wwg6js29wzpEj1DJMR 368     index.html
QmbZyMF7TJ7XQzwoLYQp2eCCrEsCeZjTXQ4gwZZrS6UYe8 543     manifest.json
QmUk4tiWznXKRHckDiD1VGgifZJPy7tviCMNfV9QWUMfEr -       meta/
QmfKCy4k8R9XYzX2JATXfTBBJ3Pdb6pbg8cmHWnRVLucW3 567398  script.js
QmYjKoctRVNohMP68oawxMh4zFWgqy8JF6dR86ZGshBNZh 1975285 script.js.map
QmdnyHcy8hrv6abdf2gosr8u9gFevV7BwtePWe7n93CF2J 1581462 src.ec516239.js
QmfKcV9hXg9vedT9Crp9akJKJbEXwwbP6PmjEmKhKCnRGF 4563037 src.ec516239.js.ma
```

(`QmbxRT5KXXP37ce3ixBRUxjXxaMjk2ff7fj923c48XkDBr` is the published app directory) You'll see that the `meta/` directory is in the root :)