### PR TITLE
Finance: add useDownloadData hook

### DIFF
--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -14,7 +14,6 @@ import {
   textStyle,
   useLayout,
   useTheme,
-  useToast,
 } from '@aragon/ui'
 import {
   useAragonApi,
@@ -35,7 +34,6 @@ const Transfers = React.memo(({ tokens, transactions }) => {
   const connectedAccount = useConnectedAccount()
   const { layoutName } = useLayout()
   const theme = useTheme()
-  const toast = useToast()
 
   const {
     emptyResultsViaFilters,
@@ -66,7 +64,6 @@ const Transfers = React.memo(({ tokens, transactions }) => {
   const { handleDownload } = useDownloadData({
     filteredTransfers,
     selectedDateRange,
-    toast,
     tokenDetails,
   })
 

--- a/apps/finance/app/src/components/useDownloadData.js
+++ b/apps/finance/app/src/components/useDownloadData.js
@@ -2,6 +2,7 @@ import { useContext, useCallback } from 'react'
 import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { useCurrentApp } from '@aragon/api-react'
+import { useToast } from '@aragon/ui'
 import { IdentityContext } from './IdentityManager/IdentityManager'
 import { toChecksumAddress } from '../lib/web3-utils'
 import { formatTokenAmount } from '../lib/utils'
@@ -66,11 +67,11 @@ const getDownloadData = async (transfers, tokenDetails, resolveAddress) => {
 function useDownloadData({
   filteredTransfers,
   selectedDateRange,
-  toast,
   tokenDetails,
 }) {
   const { resolve: resolveAddress } = useContext(IdentityContext)
   const currentApp = useCurrentApp()
+  const toast = useToast()
 
   const handleDownload = useCallback(async () => {
     const { appAddress: financeAddress } = currentApp

--- a/apps/finance/app/src/components/useDownloadData.js
+++ b/apps/finance/app/src/components/useDownloadData.js
@@ -1,0 +1,94 @@
+import { useContext, useCallback } from 'react'
+import { format } from 'date-fns'
+import { saveAs } from 'file-saver'
+import { useCurrentApp } from '@aragon/api-react'
+import { IdentityContext } from './IdentityManager/IdentityManager'
+import { toChecksumAddress } from '../lib/web3-utils'
+import { formatTokenAmount } from '../lib/utils'
+import { formatDate, YYMMDD_LONG_FORMAT } from '../lib/date-utils'
+
+// Transforms a two dimensional array into a CSV data structure
+// Surround every field with double quotes + escape double quotes inside.
+function csv(data) {
+  return data
+    .map(cells => cells.map(cell => `"${cell.replace(/"/g, '""')}"`).join(','))
+    .join('\n')
+}
+
+const getDownloadFilename = (appAddress, { start, end }) => {
+  const today = format(Date.now(), YYMMDD_LONG_FORMAT)
+  let filename = `finance_${appAddress}_${today}.csv`
+  if (start && end) {
+    const formattedStart = format(start, YYMMDD_LONG_FORMAT)
+    const formattedEnd = format(end, YYMMDD_LONG_FORMAT)
+    filename = `finance_${appAddress}_${formattedStart}_to_${formattedEnd}.csv`
+  }
+  return filename
+}
+
+const getDownloadData = async (transfers, tokenDetails, resolveAddress) => {
+  const processedTransfers = await Promise.all(
+    transfers.map(
+      async ({
+        date,
+        numData: { amount },
+        reference,
+        isIncoming,
+        entity,
+        token,
+      }) => {
+        const { symbol, decimals } = tokenDetails[toChecksumAddress(token)]
+        const formattedAmount = formatTokenAmount(
+          amount,
+          isIncoming,
+          decimals,
+          true,
+          { rounding: 5 }
+        )
+        const { name = '' } = (await resolveAddress(entity)) || {}
+        return [
+          formatDate(date),
+          name,
+          entity,
+          reference,
+          `${formattedAmount} ${symbol}`,
+        ]
+      }
+    )
+  )
+
+  return csv([
+    ['Date', 'Name', 'Source/Recipient', 'Reference', 'Amount'],
+    ...processedTransfers,
+  ])
+}
+
+function useDownloadData({
+  filteredTransfers,
+  selectedDateRange,
+  toast,
+  tokenDetails,
+}) {
+  const { resolve: resolveAddress } = useContext(IdentityContext)
+  const currentApp = useCurrentApp()
+
+  const handleDownload = useCallback(async () => {
+    const { appAddress: financeAddress } = currentApp
+    const downloadData = await getDownloadData(
+      filteredTransfers,
+      tokenDetails,
+      resolveAddress
+    )
+    const fileName = getDownloadFilename(financeAddress, selectedDateRange)
+
+    saveAs(
+      new Blob([downloadData], { type: 'text/csv;charset=utf-8' }),
+      fileName
+    )
+    toast('Transfers data exported')
+  }, [filteredTransfers, selectedDateRange, toast, tokenDetails])
+
+  return { handleDownload }
+}
+
+export default useDownloadData

--- a/apps/finance/app/src/components/useDownloadData.js
+++ b/apps/finance/app/src/components/useDownloadData.js
@@ -1,10 +1,9 @@
 import { useContext, useCallback } from 'react'
-import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { useCurrentApp } from '@aragon/api-react'
 import { useToast } from '@aragon/ui'
 import { IdentityContext } from './IdentityManager/IdentityManager'
-import { formatDate, YYMMDD_LONG_FORMAT } from '../lib/date-utils'
+import { formatDate } from '../lib/date-utils'
 import { formatTokenAmount } from '../lib/utils'
 import { toChecksumAddress } from '../lib/web3-utils'
 
@@ -17,11 +16,11 @@ function csv(data) {
 }
 
 const getDownloadFilename = (appAddress, { start, end }) => {
-  const today = format(Date.now(), YYMMDD_LONG_FORMAT)
+  const today = formatDate(Date.now())
   let filename = `finance_${appAddress}_${today}.csv`
   if (start && end) {
-    const formattedStart = format(start, YYMMDD_LONG_FORMAT)
-    const formattedEnd = format(end, YYMMDD_LONG_FORMAT)
+    const formattedStart = formatDate(start)
+    const formattedEnd = formatDate(end)
     filename = `finance_${appAddress}_${formattedStart}_to_${formattedEnd}.csv`
   }
   return filename

--- a/apps/finance/app/src/components/useDownloadData.js
+++ b/apps/finance/app/src/components/useDownloadData.js
@@ -4,9 +4,9 @@ import { saveAs } from 'file-saver'
 import { useCurrentApp } from '@aragon/api-react'
 import { useToast } from '@aragon/ui'
 import { IdentityContext } from './IdentityManager/IdentityManager'
-import { toChecksumAddress } from '../lib/web3-utils'
-import { formatTokenAmount } from '../lib/utils'
 import { formatDate, YYMMDD_LONG_FORMAT } from '../lib/date-utils'
+import { formatTokenAmount } from '../lib/utils'
+import { toChecksumAddress } from '../lib/web3-utils'
 
 // Transforms a two dimensional array into a CSV data structure
 // Surround every field with double quotes + escape double quotes inside.

--- a/apps/finance/app/src/lib/date-utils.js
+++ b/apps/finance/app/src/lib/date-utils.js
@@ -1,7 +1,6 @@
 import { format } from 'date-fns'
 
-export const MMDDYY_FUNC_FORMAT = 'MM/dd/yy'
-export const YYMMDD_LONG_FORMAT = 'yyyy-MM-dd'
+const YYMMDD_LONG_FORMAT = 'yyyy-MM-dd'
 
 export function formatDate(date, dateFormat = YYMMDD_LONG_FORMAT) {
   return format(date, dateFormat)

--- a/apps/finance/app/src/lib/date-utils.js
+++ b/apps/finance/app/src/lib/date-utils.js
@@ -3,6 +3,6 @@ import { format } from 'date-fns'
 export const MMDDYY_FUNC_FORMAT = 'MM/dd/yy'
 export const YYMMDD_LONG_FORMAT = 'yyyy-MM-dd'
 
-export function formatDate(date) {
-  return format(date, MMDDYY_FUNC_FORMAT)
+export function formatDate(date, dateFormat = MMDDYY_FUNC_FORMAT) {
+  return format(date, dateFormat)
 }

--- a/apps/finance/app/src/lib/date-utils.js
+++ b/apps/finance/app/src/lib/date-utils.js
@@ -1,0 +1,8 @@
+import { format } from 'date-fns'
+
+export const MMDDYY_FUNC_FORMAT = 'MM/dd/yy'
+export const YYMMDD_LONG_FORMAT = 'yyyy-MM-dd'
+
+export function formatDate(date) {
+  return format(date, MMDDYY_FUNC_FORMAT)
+}

--- a/apps/finance/app/src/lib/date-utils.js
+++ b/apps/finance/app/src/lib/date-utils.js
@@ -3,6 +3,6 @@ import { format } from 'date-fns'
 export const MMDDYY_FUNC_FORMAT = 'MM/dd/yy'
 export const YYMMDD_LONG_FORMAT = 'yyyy-MM-dd'
 
-export function formatDate(date, dateFormat = MMDDYY_FUNC_FORMAT) {
+export function formatDate(date, dateFormat = YYMMDD_LONG_FORMAT) {
   return format(date, dateFormat)
 }


### PR DESCRIPTION
Builds on #1102 (should be merged first) , closes #1087 .

Adds an useDownloadData hook that builds the CSV on demand, properly formatting it to fit the finance usage. Ported over from the Agent implementation.