### PR TITLE
Voting: make amount of tokens always display 3 decimals

### DIFF
--- a/apps/voting/app/src/components/SummaryRows.js
+++ b/apps/voting/app/src/components/SummaryRows.js
@@ -18,14 +18,14 @@ function SummaryRows({ yea, nay, symbol, connectedAccountVote }) {
         color={theme.positive}
         label="Yes"
         pct={yea.pct}
-        token={{ amount: yea.amount, symbol }}
+        token={{ amount: yea.amount.toFixed(3), symbol }}
         youVoted={connectedAccountVote === VOTE_YEA}
       />
       <SummaryRow
         color={theme.negative}
         label="No"
         pct={nay.pct}
-        token={{ amount: nay.amount, symbol }}
+        token={{ amount: nay.amount.toFixed(3), symbol }}
         youVoted={connectedAccountVote === VOTE_NAY}
       />
     </div>


### PR DESCRIPTION
Spring cleaning 🌸, closing [#589](https://github.com/aragon/aragon/issues/589).

> _Heavy metal intensifies_

Makes the number of tokens shown in the vote detail always have 3 decimals; this amount was chosen due to anj.aragon.org always displaying this amount of decimals, in an effort to make it more consistent across all products (we may want some discussion over this, as other apps are using 2 decimals). The decimal change was not made at the top (script) level to avoid any precision issues elsewhere. Some screenshots:

Before:
<img width="823" alt="Screen Shot 2020-04-06 at 5 15 07 PM" src="https://user-images.githubusercontent.com/26014927/78605803-3583a180-782a-11ea-8c80-31eeda9b4fab.png">

After:
<img width="724" alt="Screen Shot 2020-04-06 at 5 14 24 PM" src="https://user-images.githubusercontent.com/26014927/78605812-387e9200-782a-11ea-91f6-c9f3f88dd213.png">
