### PR TITLE
Voting: use local date in warnings about tokens holded

### DIFF
--- a/apps/voting/app/src/components/VoteActions.js
+++ b/apps/voting/app/src/components/VoteActions.js
@@ -1,17 +1,19 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import styled from 'styled-components'
 import {
+  blockExplorerUrl,
   Button,
   GU,
   IconCheck,
   IconConnect,
   IconCross,
   Info,
+  Link,
   RADIUS,
   textStyle,
   useTheme,
 } from '@aragon/ui'
-import { useAppState, useConnectedAccount } from '@aragon/api-react'
+import { useAppState, useConnectedAccount, useNetwork } from '@aragon/api-react'
 import useExtendedVoteData from '../hooks/useExtendedVoteData'
 import { noop, formatDate } from '../utils'
 import { VOTE_NAY, VOTE_YEA } from '../vote-types'
@@ -223,7 +225,8 @@ const TokenReference = ({
     <strong>
       {userBalance} {tokenSymbol}
     </strong>{' '}
-    due to the snapshot taken at block <strong>{snapshotBlock}</strong> at{' '}
+    due to the snapshot taken at block{' '}
+    <BlockNumber blockNumber={snapshotBlock} /> at{' '}
     <strong>{formatDate(startDate)}</strong>.{' '}
     {userBalance !== userBalanceNow ? (
       <span>
@@ -238,6 +241,23 @@ const TokenReference = ({
     )}
   </Info>
 )
+
+function BlockNumber({ blockNumber }) {
+  const network = useNetwork()
+
+  return network ? (
+    <Link
+      href={blockExplorerUrl('block', blockNumber, {
+        networkType: network.type,
+      })}
+      title={blockNumber}
+    >
+      {blockNumber}
+    </Link>
+  ) : (
+    <span>{blockNumber}</span>
+  )
+}
 
 const VotingButton = styled(Button)`
   ${textStyle('body2')};

--- a/apps/voting/app/src/components/VoteActions.js
+++ b/apps/voting/app/src/components/VoteActions.js
@@ -255,7 +255,7 @@ function BlockNumber({ blockNumber }) {
       {blockNumber}
     </Link>
   ) : (
-    <span>{blockNumber}</span>
+    <strong>{blockNumber}</strong>
   )
 }
 

--- a/apps/voting/app/src/components/VoteActions.js
+++ b/apps/voting/app/src/components/VoteActions.js
@@ -225,7 +225,7 @@ const TokenReference = ({
     <strong>
       {userBalance} {tokenSymbol}
     </strong>{' '}
-    due to the snapshot taken at block{' '}
+    as that was your balance during the snapshot taken at block{' '}
     <BlockNumber blockNumber={snapshotBlock} /> at{' '}
     <strong>{formatDate(startDate)}</strong>.{' '}
     {userBalance !== userBalanceNow ? (

--- a/apps/voting/app/src/components/VoteActions.js
+++ b/apps/voting/app/src/components/VoteActions.js
@@ -250,7 +250,6 @@ function BlockNumber({ blockNumber }) {
       href={blockExplorerUrl('block', blockNumber, {
         networkType: network.type,
       })}
-      title={blockNumber}
     >
       {blockNumber}
     </Link>

--- a/apps/voting/app/src/components/VoteActions.js
+++ b/apps/voting/app/src/components/VoteActions.js
@@ -241,7 +241,7 @@ const TokenReference = ({
     )}
   </Info>
 )
-// Voting with <tokens>. This was your balance when the vote started (block <block>, mined at <date>).
+
 function BlockNumber({ blockNumber }) {
   const network = useNetwork()
 

--- a/apps/voting/app/src/components/VoteActions.js
+++ b/apps/voting/app/src/components/VoteActions.js
@@ -225,9 +225,9 @@ const TokenReference = ({
     <strong>
       {userBalance} {tokenSymbol}
     </strong>{' '}
-    as that was your balance during the snapshot taken at block{' '}
-    <BlockNumber blockNumber={snapshotBlock} /> at{' '}
-    <strong>{formatDate(startDate)}</strong>.{' '}
+    . This was your balance when the vote started (block{' '}
+    <BlockNumber blockNumber={snapshotBlock} />, mined at{' '}
+    <strong>{formatDate(startDate)}</strong>).{' '}
     {userBalance !== userBalanceNow ? (
       <span>
         Your current balance is{' '}
@@ -241,7 +241,7 @@ const TokenReference = ({
     )}
   </Info>
 )
-
+// Voting with <tokens>. This was your balance when the vote started (block <block>, mined at <date>).
 function BlockNumber({ blockNumber }) {
   const network = useNetwork()
 

--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -12,7 +12,8 @@ function useDecoratedVotes() {
   const installedApps = useInstalledApps()
 
   return useMemo(() => {
-    if (!votes) {
+    // Make sure we have loaded information about the current app and other installed apps before showing votes
+    if (!(votes && currentApp && installedApps)) {
       return [[], []]
     }
     const decoratedVotes = votes.map((vote, i) => {

--- a/apps/voting/app/src/utils.js
+++ b/apps/voting/app/src/utils.js
@@ -12,7 +12,7 @@ export function pluralize(count, singular, plural, re = PLURALIZE_RE) {
 export function noop() {}
 
 export function formatDate(date) {
-  return `${format(date, 'HH:mm')} UTC on ${format(date, 'do')} of ${format(
+  return `${format(date, 'HH:mm')} on ${format(date, 'do')} of ${format(
     date,
     'MMM. yyyy'
   )}`


### PR DESCRIPTION
This pr closes https://github.com/aragon/aragon/issues/1150.

Rather than aligning the dates to UTC, we've decided to keep the times local, as all the other filters (as well as apps, e.g. Finance) use local times.

<img width="840" alt="Screen Shot 2020-04-09 at 7 19 34 PM" src="https://user-images.githubusercontent.com/11763623/78945588-12a9f500-7a97-11ea-8f0a-650a32fb3437.png">
