### PR TITLE
Voting: fix voting copy to fit one line & add tooltip

### DIFF
--- a/apps/voting/app/.prettierrc
+++ b/apps/voting/app/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false
+}

--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -204,7 +204,7 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
             <Box heading="Status">
               <Status vote={vote} />
             </Box>
-            <Box heading="Relative support %">
+            <Box heading="Support %">
               <div
                 css={`
                   ${textStyle('body2')};
@@ -216,7 +216,7 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
                     color: ${theme.surfaceContentSecondary};
                   `}
                 >
-                  (>{round(supportRequired * 100, 2)}% support needed)
+                  (>{round(supportRequired * 100, 2)}% needed)
                 </span>
               </div>
               <SummaryBar
@@ -227,7 +227,7 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
                 `}
               />
             </Box>
-            <Box heading="Minimum approval %">
+            <Box heading="Approval %">
               <div
                 css={`
                   ${textStyle('body2')};
@@ -239,7 +239,7 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
                     color: ${theme.surfaceContentSecondary};
                   `}
                 >
-                  (>{round(minAcceptQuorum * 100, 2)}% approval needed)
+                  (>{round(minAcceptQuorum * 100, 2)}% needed)
                 </span>
               </div>
               <SummaryBar

--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -4,6 +4,7 @@ import {
   Bar,
   Box,
   GU,
+  Help,
   IconCheck,
   IconTime,
   Split,
@@ -204,7 +205,20 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
             <Box heading="Status">
               <Status vote={vote} />
             </Box>
-            <Box heading="Support %">
+            <Box
+              heading={
+                <React.Fragment>
+                  Support %
+                  <Help hint="What’s the support?">
+                    <strong>Support</strong> is the relative percentage of
+                    tokens that are required to vote “Yes” for a proposal to be
+                    approved. For example, if “Support” is set to 51%, then more
+                    than 51% of the tokens used to vote on a proposal must be
+                    “Yes” for it to pass.
+                  </Help>
+                </React.Fragment>
+              }
+            >
               <div
                 css={`
                   ${textStyle('body2')};
@@ -227,7 +241,19 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
                 `}
               />
             </Box>
-            <Box heading="Approval %">
+            <Box
+              heading={
+                <React.Fragment>
+                  Approval %
+                  <Help hint="What’s the vote duration?">
+                    <strong>Vote Duration</strong> is the length of time that
+                    the vote will be open for participation. For example, if the
+                    Vote Duration is set to 24 hours, then token holders have 24
+                    hours to participate in the vote.
+                  </Help>
+                </React.Fragment>
+              }
+            >
               <div
                 css={`
                   ${textStyle('body2')};


### PR DESCRIPTION
Building over the discussion at #1110 .

Here's how it looks with the copy changes:

<img width="1680" alt="Screen Shot 2020-04-08 at 11 56 19 PM" src="https://user-images.githubusercontent.com/26014927/78856474-e178e880-79f4-11ea-9d34-714a37ed6e33.png">

<img width="1680" alt="Screen Shot 2020-04-08 at 11 59 22 PM" src="https://user-images.githubusercontent.com/26014927/78856531-09684c00-79f5-11ea-8c0f-ae4e6c549116.png">
