### PR TITLE
Voting: fix race condition with currentApp address being null

### DIFF
--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -12,6 +12,7 @@ function useDecoratedVotes() {
   const installedApps = useInstalledApps()
 
   return useMemo(() => {
+    // Make sure we have loaded information about the current app and other installed apps before showing votes
     if (!(votes && currentApp && installedApps)) {
       return [[], []]
     }
@@ -68,7 +69,6 @@ function useDecoratedVotes() {
     })
 
     // Reduce the list of installed apps to just those that have been targetted by apps
-    console.log('installed apps ', installedApps)
     const executionTargets = installedApps
       .filter(app =>
         votes.some(vote =>

--- a/apps/voting/app/src/hooks/useVotes.js
+++ b/apps/voting/app/src/hooks/useVotes.js
@@ -12,7 +12,7 @@ function useDecoratedVotes() {
   const installedApps = useInstalledApps()
 
   return useMemo(() => {
-    if (!votes) {
+    if (!(votes && currentApp && installedApps)) {
       return [[], []]
     }
     const decoratedVotes = votes.map((vote, i) => {
@@ -68,6 +68,7 @@ function useDecoratedVotes() {
     })
 
     // Reduce the list of installed apps to just those that have been targetted by apps
+    console.log('installed apps ', installedApps)
     const executionTargets = installedApps
       .filter(app =>
         votes.some(vote =>


### PR DESCRIPTION
We were getting an error in the `LocalIdentityProvider` inside the wrapper because we had a race condition where the `currentApp` or `installedApps` were not resolved by the time we were rendering initial votes (and sending a null address into the local identity badges in)