### PR TITLE
Voting: quorum and support hint copy updates

### DIFF
--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -209,11 +209,11 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
               heading={
                 <React.Fragment>
                   Support %
-                  <Help hint="What’s the support?">
+                  <Help hint="What is Support?">
                     <strong>Support</strong> is the relative percentage of
                     tokens that are required to vote “Yes” for a proposal to be
-                    approved. For example, if “Support” is set to 51%, then more
-                    than 51% of the tokens used to vote on a proposal must be
+                    approved. For example, if “Support” is set to 50%, then more
+                    than 50% of the tokens used to vote on a proposal must vote
                     “Yes” for it to pass.
                   </Help>
                 </React.Fragment>
@@ -245,10 +245,10 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
               heading={
                 <React.Fragment>
                   Approval %
-                  <Help hint="What’s the vote duration?">
+                  <Help hint="What is the Vote Duration?">
                     <strong>Vote Duration</strong> is the length of time that
                     the vote will be open for participation. For example, if the
-                    Vote Duration is set to 24 hours, then token holders have 24
+                    Vote Duration is set to 24 hours, then tokenholders have 24
                     hours to participate in the vote.
                   </Help>
                 </React.Fragment>

--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -244,12 +244,13 @@ function VoteDetail({ vote, onBack, onVote, onExecute }) {
             <Box
               heading={
                 <React.Fragment>
-                  Approval %
-                  <Help hint="What is the Vote Duration?">
-                    <strong>Vote Duration</strong> is the length of time that
-                    the vote will be open for participation. For example, if the
-                    Vote Duration is set to 24 hours, then tokenholders have 24
-                    hours to participate in the vote.
+                  Minimum Approval %
+                  <Help hint="What is Minimum Approval?">
+                    <strong>Minimum Approval</strong> is the percentage of 
+                    the total token supply that is required to vote “Yes” on 
+                    a proposal before it can be approved. For example, if the 
+                    “Minimum Approval” is set to 20%, then more than 20% of the 
+                    outstanding token supply must vote “Yes” on a proposal for it to pass.
                   </Help>
                 </React.Fragment>
               }


### PR DESCRIPTION
- Users are more likely to set `50%` support for simply majority rule, rather than the previous `51%`, so I'm changing this to avoid confusion among users about how to implement a simple majority rule.
- "token holders" -> "tokenholders" (which is the terminology we use in the user guide at help.aragon.org)
- Fix Minimum Approval description