### PR TITLE
Voting: fix UTC still being present in VoteDetail

### DIFF
--- a/apps/voting/app/src/screens/VoteDetail.js
+++ b/apps/voting/app/src/screens/VoteDetail.js
@@ -30,7 +30,7 @@ import { getQuorumProgress } from '../vote-utils'
 import { VOTE_NAY, VOTE_YEA } from '../vote-types'
 import { addressesEqual } from '../web3-utils'
 
-const formatDate = date => `${format(date, 'do MMM yy, HH:mm')} UTC`
+const formatDate = date => `${format(date, 'do MMM yy, HH:mm')}`
 
 const DEFAULT_DESCRIPTION =
   'No additional description has been provided for this proposal.'


### PR DESCRIPTION
Oops, I thought https://github.com/aragon/aragon-apps/pull/1114 had covered this case, but it looks like this uses a different format!