### PR TITLE
Finance: Add Thousands Separator Util from UI

### DIFF
--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -7,7 +7,7 @@
     "@aragon/api": "^2.0.0-beta.9",
     "@aragon/api-react": "^2.0.0-beta.9",
     "@aragon/templates-tokens": "^1.3.0",
-    "@aragon/ui": "^1.3.1",
+    "@aragon/ui": "^1.4.0",
     "@babel/polyfill": "^7.8.3",
     "bn.js": "^4.11.8",
     "core-js": "^2.6.5",

--- a/apps/finance/app/src/components/BalanceToken.js
+++ b/apps/finance/app/src/components/BalanceToken.js
@@ -1,11 +1,10 @@
 import React from 'react'
-import { GU, textStyle, useTheme } from '@aragon/ui'
+import { GU, formatNumber, textStyle, useTheme } from '@aragon/ui'
 import { useNetwork } from '@aragon/api-react'
 import { tokenIconUrl } from '../lib/icon-utils'
-import { formatTokenAmount } from '../lib/utils'
 
 const splitAmount = amount => {
-  const [integer, fractional] = formatTokenAmount(amount).split('.')
+  const [integer, fractional] = formatNumber(amount).split('.')
   return (
     <span>
       <span>{integer}</span>
@@ -74,7 +73,7 @@ const BalanceToken = ({
           `}
         >
           {convertedAmount >= 0
-            ? `$${formatTokenAmount(convertedAmount.toFixed(2))}`
+            ? `$${formatNumber(convertedAmount.toFixed(2))}`
             : '−'}
         </div>
       </div>


### PR DESCRIPTION
Adds the new Aragon UI util formatToken(). Fixes #1065.

Closing #1080, since that PR used a deleted forked repo.