### PR TITLE
Voting: update VoteText's address rendering

### DIFF
--- a/apps/voting/app/src/components/VoteText.js
+++ b/apps/voting/app/src/components/VoteText.js
@@ -34,14 +34,11 @@ const VoteText = React.memo(
               {i > 0 && <br />}
               {transformAddresses(line, (part, isAddress, index) =>
                 isAddress ? (
-                  <span title={part} key={index}>
-                    {' '}
-                    <LocalIdentityBadge
-                      badgeOnly={disabled}
-                      compact
-                      entity={part}
-                    />{' '}
-                  </span>
+                  <LocalIdentityBadge
+                    badgeOnly={disabled}
+                    compact
+                    entity={part}
+                  />
                 ) : (
                   <span key={index}>{part}</span>
                 )


### PR DESCRIPTION
Similar to https://github.com/aragon/aragon/pull/1426.

AFAIK there's no change being rendered; we updated the `AddressBadge`'s compact mode to include the spacing.