### PR TITLE
Agent, Finance: update babel configuration

### DIFF
--- a/apps/agent/app/.babelrc
+++ b/apps/agent/app/.babelrc
@@ -4,12 +4,14 @@
       "@babel/preset-env",
       {
         "modules": false,
-        "useBuiltIns": false
+        "useBuiltIns": "entry",
+        "core-js": 3,
+        "shippedProposals": true,
       }
-    ]
+    ],
+    "@babel/preset-react"
   ],
   "plugins": [
     ["styled-components", { "displayName": true }],
-    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/apps/agent/app/package.json
+++ b/apps/agent/app/package.json
@@ -8,7 +8,7 @@
     "@aragon/api-react": "^2.0.0-beta.9",
     "@aragon/templates-tokens": "^1.2.0",
     "@aragon/ui": "^1.3.0",
-    "@babel/polyfill": "^7.0.0",
+    "@babel/polyfill": "^7.8.3",
     "date-fns": "2.0.0-alpha.22",
     "file-saver": "^2.0.2",
     "prop-types": "^15.7.2",
@@ -20,10 +20,9 @@
     "web3-utils": "^1.2.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/plugin-proposal-class-properties": "^7.0.0",
-    "@babel/preset-env": "^7.1.0",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/core": "^7.10.2",
+    "@babel/preset-env": "^7.10.2",
+    "@babel/preset-react": "^7.10.1",
     "babel-eslint": "^10.0.1",
     "babel-plugin-styled-components": "^1.7.1",
     "eslint": "^5.6.0",

--- a/apps/finance/app/.babelrc
+++ b/apps/finance/app/.babelrc
@@ -4,12 +4,14 @@
       "@babel/preset-env",
       {
         "modules": false,
-        "useBuiltIns": false
+        "useBuiltIns": "entry",
+        "core-js": 3,
+        "shippedProposals": true,
       }
-    ]
+    ],
+    "@babel/preset-react"
   ],
   "plugins": [
     ["styled-components", { "displayName": true }],
-    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -24,10 +24,9 @@
     "web3-utils": "^1.0.0-beta.30"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.4",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/preset-env": "^7.8.4",
-    "@babel/preset-react": "^7.8.3",
+    "@babel/core": "^7.10.2",
+    "@babel/preset-env": "^7.10.2",
+    "@babel/preset-react": "^7.10.1",
     "babel-eslint": "^10.0.1",
     "babel-plugin-styled-components": "^1.10.7",
     "eslint": "^5.6.0",


### PR DESCRIPTION
Similar to https://github.com/aragon/aragon/pull/1434, Agent/Finance's frontend builds were failing due to the new release causing babel plugin clashes.

Only a problem for these apps as the others have not upgraded to babel@7 yet 🙈.