### PR TITLE
Finance: fix withdrawal panel not detecting tokens

### DIFF
--- a/apps/finance/app/src/app-state-reducer.js
+++ b/apps/finance/app/src/app-state-reducer.js
@@ -35,13 +35,18 @@ function appStateReducer(state) {
   return {
     ...state,
 
-    tokens: balancesBn.map(({ address, decimals, name, symbol, verified }) => ({
-      address,
-      decimals: decimals.toNumber(),
-      name,
-      symbol,
-      verified,
-    })),
+    tokens: balancesBn.map(
+      ({ address, amount, decimals, name, symbol, verified }) => ({
+        address,
+        // TODO: we should remove `amount` from this interface in the future, but right now it
+        // is the easiest way to tell components that this org holds this token
+        amount,
+        decimals: decimals.toNumber(),
+        name,
+        symbol,
+        verified,
+      })
+    ),
 
     // Filter out empty balances
     balances: balancesBn.filter(balance => !balance.amount.isZero()),

--- a/apps/finance/app/src/components/NewTransfer/Withdrawal.js
+++ b/apps/finance/app/src/components/NewTransfer/Withdrawal.js
@@ -49,7 +49,7 @@ class Withdrawal extends React.Component {
     }
   }
   nonZeroTokens() {
-    return this.props.tokens.filter(({ amount }) => amount > 0)
+    return this.props.tokens.filter(({ amount }) => !amount.isZero())
   }
   handleAmountUpdate = event => {
     this.setState({


### PR DESCRIPTION
Oops, we actually need that `amount` state in the `tokens` array!

Finance still has a lot of older React class components, but in the future, we should migrate to functional components so we can use hooks and `api-react` to fetch app state so we don't have to pass this down :).