### PR TITLE
Voting: fix dev server autoreload

### DIFF
--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -14,7 +14,7 @@ import useScrollTop from './hooks/useScrollTop'
 import NoVotes from './screens/NoVotes'
 import VoteDetail from './screens/VoteDetail'
 import Votes from './screens/Votes'
-import { AppLogicProvider, useAppLogic } from './app-logic'
+import { useAppLogic } from './app-logic'
 import { IdentityProvider } from './identity-manager'
 import { SettingsProvider } from './vote-settings-manager'
 
@@ -30,6 +30,7 @@ const App = React.memo(function App() {
   } = useAppLogic()
 
   const { appearance } = useGuiStyle()
+
   const { layoutName } = useLayout()
   const compactMode = layoutName === 'small'
   const handleBack = useCallback(() => selectVote(-1), [selectVote])
@@ -125,14 +126,10 @@ const App = React.memo(function App() {
   )
 })
 
-export default function Voting() {
-  return (
-    <AppLogicProvider>
-      <IdentityProvider>
-        <SettingsProvider>
-          <App />
-        </SettingsProvider>
-      </IdentityProvider>
-    </AppLogicProvider>
-  )
-}
+export default () => (
+  <IdentityProvider>
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
+  </IdentityProvider>
+)

--- a/apps/voting/app/src/app-logic.js
+++ b/apps/voting/app/src/app-logic.js
@@ -111,7 +111,3 @@ export function useAppLogic() {
     votes,
   }
 }
-
-export function AppLogicProvider({ children }) {
-  return <AragonApi reducer={appStateReducer}>{children}</AragonApi>
-}

--- a/apps/voting/app/src/identity-manager.js
+++ b/apps/voting/app/src/identity-manager.js
@@ -1,4 +1,10 @@
-import React, { useCallback } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { Subject } from 'rxjs'
 import { useApi } from '@aragon/api-react'
 
@@ -29,11 +35,11 @@ function useModifyLocalIdentity() {
 // The main identity hook, exposing `name`
 // and `handleModifyLocalIdentity` based on the provided address.
 export function useIdentity(address) {
-  const [name, setName] = React.useState(null)
+  const [name, setName] = useState(null)
   const resolveLocalIdentity = useResolveLocalIdentity()
   const modifyLocalIdentity = useModifyLocalIdentity()
 
-  const { updates$ } = React.useContext(IdentityContext)
+  const { updates$ } = useContext(IdentityContext)
 
   const handleNameChange = useCallback(metadata => {
     setName(metadata ? metadata.name : null)
@@ -45,7 +51,7 @@ export function useIdentity(address) {
     return modifyLocalIdentity(address).then(() => updates$.next(address))
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     resolveLocalIdentity(address).then(handleNameChange)
 
     const subscription = updates$.subscribe(updatedAddress => {

--- a/apps/voting/app/src/index.js
+++ b/apps/voting/app/src/index.js
@@ -1,5 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { AragonApi } from '@aragon/api-react'
+import appStateReducer from './app-state-reducer'
 import App from './App'
 
-ReactDOM.render(<App />, document.getElementById('root'))
+ReactDOM.render(
+  <AragonApi reducer={appStateReducer}>
+    <App />
+  </AragonApi>,
+  document.getElementById('root')
+)


### PR DESCRIPTION
<AragonApi /> has moved to index.js and is now the root component. It fixes an issue where the devserver autoreload would prevent the aragonAPI connection to restore properly. The issue seems to only appear when <AragonApi /> is not the root component. I will investigate separately on the side of aragonAPI for React.

It also aligns the Voting app with the other apps in that regard.