### PR TITLE
Tokens: Move renderEntry hook calls into its own component & fix crash

### DIFF
--- a/apps/token-manager/app/src/screens/Holders.js
+++ b/apps/token-manager/app/src/screens/Holders.js
@@ -63,9 +63,6 @@ function Holders({
           fields={groupMode ? ['Owner'] : ['Holder', 'Balance']}
           entries={mappedEntries}
           renderEntry={([address, balance, vestings]) => {
-            const theme = useTheme()
-            const { totalLocked } = useTotalVestedTokensInfo(vestings)
-
             const isCurrentUser = addressesEqual(address, connectedAccount)
 
             const values = [
@@ -89,25 +86,11 @@ function Holders({
 
             if (!groupMode) {
               values.push(
-                <div
-                  css={`
-                    display: flex;
-                    align-items: center;
-                  `}
-                >
-                  {formatTokenAmount(balance, tokenDecimals)}
-                  {!totalLocked.isZero() && (
-                    <div
-                      css={`
-                        padding-left: ${1 * GU}px;
-                        ${textStyle('label1')};
-                        color: ${theme.surfaceContentSecondary};
-                      `}
-                    >
-                      ({formatTokenAmount(totalLocked, tokenDecimals)} locked)
-                    </div>
-                  )}
-                </div>
+                <TokenAmount
+                  balance={balance}
+                  tokenDecimals={tokenDecimals}
+                  vestings={vestings}
+                />
               )
             }
 
@@ -221,6 +204,33 @@ function EntryActions({
         </ContextMenuItem>
       ))}
     </ContextMenu>
+  )
+}
+
+function TokenAmount({ balance, tokenDecimals, vestings }) {
+  const theme = useTheme()
+  const { totalLocked } = useTotalVestedTokensInfo(vestings)
+
+  return (
+    <div
+      css={`
+        display: flex;
+        align-items: center;
+      `}
+    >
+      {formatTokenAmount(balance, tokenDecimals)}
+      {!totalLocked.isZero() && (
+        <div
+          css={`
+            padding-left: ${1 * GU}px;
+            ${textStyle('label1')};
+            color: ${theme.surfaceContentSecondary};
+          `}
+        >
+          ({formatTokenAmount(totalLocked, tokenDecimals)} locked)
+        </div>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
Moves renderEntry hook calls and & UI depending on these into its own component, to avoid breaking the rules of hooks. Fixes #1170 

Right now there's a bug that's breaking Token Manager apps with more than 10 holders (the pagination threshold) live on Mainnet; when switching to the last tab, a React error will appear, saying that a different amount of hooks were rendered, compared to the previous render. This breaks the rules of hooks, and subsequently, the app throws.

The reason this happens is actually documented on the [aragonUI docs](https://ui.aragon.org/data-view/) for the `DataView` component: the props marked with `render` should never hold hooks as they're called conditionally. The solution is to move the breaking parts of this function to a component.