### PR TITLE
Fix finance USD conversion mechanism

### DIFF
--- a/apps/finance/app/.babelrc
+++ b/apps/finance/app/.babelrc
@@ -5,13 +5,24 @@
       {
         "modules": false,
         "useBuiltIns": "entry",
-        "core-js": 3,
-        "shippedProposals": true,
+        "corejs": 3,
+        "shippedProposals": true
       }
     ],
     "@babel/preset-react"
   ],
-  "plugins": [
-    ["styled-components", { "displayName": true }],
-  ]
+  "plugins": [["styled-components", { "displayName": true }]],
+  "env": {
+    "test": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "modules": "commonjs",
+            "targets": { "node": "current" }
+          }
+        ]
+      ]
+    }
+  }
 }

--- a/apps/finance/app/package.json
+++ b/apps/finance/app/package.json
@@ -27,17 +27,20 @@
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
     "babel-eslint": "^10.0.1",
+    "babel-jest": "^26.1.0",
     "babel-plugin-styled-components": "^1.10.7",
     "eslint": "^5.6.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-config-standard-react": "^7.0.2",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jest": "^23.17.1",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-prettier": "^2.7.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "^4.0.0",
+    "jest": "^26.1.0",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-bundle-visualiser": "^1.2.0",
     "prettier": "^1.11.1"
@@ -49,7 +52,8 @@
     "build:script": "parcel build src/script.js --out-dir build/",
     "watch:script": "parcel watch src/script.js --out-dir build/ --no-hmr",
     "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && rsync -rtu ./public/ ./build",
-    "now-build": "npm run build"
+    "now-build": "npm run build",
+    "test": "jest"
   },
   "browserslist": [
     ">2%",

--- a/apps/finance/app/src/components/Balances.js
+++ b/apps/finance/app/src/components/Balances.js
@@ -2,7 +2,8 @@ import React, { useMemo } from 'react'
 import BN from 'bn.js'
 import { Box, GU, textStyle, useTheme, useLayout } from '@aragon/ui'
 import BalanceToken from './BalanceToken'
-import { getConvertedAmount, useConvertRates } from '../lib/conversion-utils'
+import { getConvertedAmount } from '../lib/conversion-utils'
+import { useConvertRates } from './useConvertRates'
 
 // Prepare the balances for the BalanceToken component
 function useBalanceItems(balances) {

--- a/apps/finance/app/src/components/Balances.js
+++ b/apps/finance/app/src/components/Balances.js
@@ -1,67 +1,8 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useMemo } from 'react'
 import BN from 'bn.js'
 import { Box, GU, textStyle, useTheme, useLayout } from '@aragon/ui'
 import BalanceToken from './BalanceToken'
-
-const CONVERT_API_RETRY_DELAY = 2 * 1000
-const CONVERT_API_RETRY_DELAY_MAX = 60 * 1000
-
-function convertRatesUrl(symbolsQuery) {
-  return `https://min-api.cryptocompare.com/data/price?fsym=USD&tsyms=${symbolsQuery}`
-}
-
-function useConvertRates(symbols) {
-  const [rates, setRates] = useState({})
-  const retryDelay = useRef(CONVERT_API_RETRY_DELAY)
-
-  const symbolsQuery = symbols.join(',')
-
-  useEffect(() => {
-    let cancelled = false
-    let retryTimer = null
-
-    const update = async () => {
-      if (!symbolsQuery) {
-        setRates({})
-        return
-      }
-
-      try {
-        const response = await fetch(convertRatesUrl(symbolsQuery))
-        const rates = await response.json()
-        if (!cancelled) {
-          setRates(rates)
-          retryDelay.current = CONVERT_API_RETRY_DELAY
-        }
-      } catch (err) {
-        // The !cancelled check is needed in case:
-        //  1. The fetch() request is ongoing.
-        //  2. The component gets unmounted.
-        //  3. An error gets thrown.
-        //
-        //  Assuming the fetch() request keeps throwing, it would create new
-        //  requests even though the useEffect() got cancelled.
-        if (!cancelled) {
-          // Add more delay after every failed attempt
-          retryDelay.current = Math.min(
-            CONVERT_API_RETRY_DELAY_MAX,
-            retryDelay.current * 1.2
-          )
-          retryTimer = setTimeout(update, retryDelay.current)
-        }
-      }
-    }
-    update()
-
-    return () => {
-      cancelled = true
-      clearTimeout(retryTimer)
-      retryDelay.current = CONVERT_API_RETRY_DELAY
-    }
-  }, [symbolsQuery])
-
-  return rates
-}
+import { getConvertedAmount, useConvertRates } from '../lib/conversion-utils'
 
 // Prepare the balances for the BalanceToken component
 function useBalanceItems(balances) {
@@ -72,18 +13,22 @@ function useBalanceItems(balances) {
   const convertRates = useConvertRates(verifiedSymbols)
 
   const balanceItems = useMemo(() => {
-    return balances.map(({ address, amount, decimals, symbol, verified }) => ({
-      address,
-      amount,
-      convertedAmount: convertRates[symbol]
-        ? amount.divn(convertRates[symbol])
-        : new BN(-1),
-      decimals,
-      symbol,
-      verified,
-    }))
-  }, [balances, convertRates])
-
+    return balances.map(
+      ({ address, amount, decimals, symbol, verified }) => {
+        return {
+          address,
+          amount,
+          convertedAmount: convertRates[symbol]
+            ? getConvertedAmount(amount, convertRates[symbol], decimals)
+            : new BN('-1'),
+          decimals,
+          symbol,
+          verified,
+        }
+      },
+      [balances, convertRates]
+    )
+  })
   return balanceItems
 }
 

--- a/apps/finance/app/src/components/useConvertRates.js
+++ b/apps/finance/app/src/components/useConvertRates.js
@@ -1,0 +1,61 @@
+import { useEffect, useState, useRef } from 'react'
+
+const CONVERT_API_RETRY_DELAY = 2 * 1000
+const CONVERT_API_RETRY_DELAY_MAX = 60 * 1000
+
+function convertRatesUrl(symbolsQuery) {
+  return `https://min-api.cryptocompare.com/data/price?fsym=USD&tsyms=${symbolsQuery}`
+}
+
+export function useConvertRates(symbols) {
+  const [rates, setRates] = useState({})
+  const retryDelay = useRef(CONVERT_API_RETRY_DELAY)
+
+  const symbolsQuery = symbols.join(',')
+
+  useEffect(() => {
+    let cancelled = false
+    let retryTimer = null
+
+    const update = async () => {
+      if (!symbolsQuery) {
+        setRates({})
+        return
+      }
+
+      try {
+        const response = await fetch(convertRatesUrl(symbolsQuery))
+        const rates = await response.json()
+        if (!cancelled) {
+          setRates(rates)
+          retryDelay.current = CONVERT_API_RETRY_DELAY
+        }
+      } catch (err) {
+        // The !cancelled check is needed in case:
+        //  1. The fetch() request is ongoing.
+        //  2. The component gets unmounted.
+        //  3. An error gets thrown.
+        //
+        //  Assuming the fetch() request keeps throwing, it would create new
+        //  requests even though the useEffect() got cancelled.
+        if (!cancelled) {
+          // Add more delay after every failed attempt
+          retryDelay.current = Math.min(
+            CONVERT_API_RETRY_DELAY_MAX,
+            retryDelay.current * 1.2
+          )
+          retryTimer = setTimeout(update, retryDelay.current)
+        }
+      }
+    }
+    update()
+
+    return () => {
+      cancelled = true
+      clearTimeout(retryTimer)
+      retryDelay.current = CONVERT_API_RETRY_DELAY
+    }
+  }, [symbolsQuery])
+
+  return rates
+}

--- a/apps/finance/app/src/lib/conversion-utils.js
+++ b/apps/finance/app/src/lib/conversion-utils.js
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react'
+import BN from 'bn.js'
+
+const CONVERT_API_RETRY_DELAY = 2 * 1000
+const CONVERT_API_RETRY_DELAY_MAX = 60 * 1000
+
+const USD_DECIMALS = new BN('2')
+
+function convertRatesUrl(symbolsQuery) {
+  return `https://min-api.cryptocompare.com/data/price?fsym=USD&tsyms=${symbolsQuery}`
+}
+
+function formatConvertRate(convertRate, decimals) {
+  const [whole = '', dec = ''] = convertRate.split('.')
+  const parsedWhole = whole.replace(/^0*/, '')
+  const parsedDec = dec.replace(/0*$/, '')
+  // parsedWhole could be empty,
+  // so in this case, we wanna remove leading zeros.
+  const fullyParsedDec = parsedWhole ? parsedDec : parsedDec.replace(/^0*/, '')
+
+  // Even if we remove leading zeroes from the decimal
+  // part, we want to count as if we "shifted" them
+  const decimalsToShift = decimals.sub(new BN(parsedDec.length.toString()))
+  // Apart from always considering the USD decimals (2),
+  // if there's the strange case that the above is negative,
+  // we take it as a carry as we know we already shifted to far,
+  // and will compensate by shifting the token amount by this much
+  const carryAmount =
+    decimalsToShift.toNumber() < 0
+      ? decimalsToShift.add(USD_DECIMALS)
+      : USD_DECIMALS
+  // The remaining total amount to shift through bn.js to avoid overflow.
+  const amountToShift = new BN('10').pow(
+    decimalsToShift.toNumber() > 0 ? decimalsToShift : new BN('0')
+  )
+
+  // Finish shifting the whole number through BN.js to avoid overflow,
+  return [
+    new BN(`${parsedWhole}${fullyParsedDec}`).mul(amountToShift),
+    carryAmount,
+  ]
+}
+
+export function getConvertedAmount(amount, convertRate, decimals) {
+  const [formattedConvertRate, carryAmount] = formatConvertRate(
+    convertRate.toString(),
+    decimals
+  )
+
+  // Get the actual precision we need to re-add when calculations are over
+  const precisionTarget = new BN('10').pow(decimals.sub(USD_DECIMALS))
+  const convertedAmount = amount
+    // Shift the amount to take into account the USD decimals
+    // + any leftover
+    .mul(new BN('10').pow(carryAmount))
+    // Actually convert to an USD rate
+    .div(formattedConvertRate)
+    // Return it to its original precision
+    // Note that we don't have to subtract the "extra carry"
+    // as it's undone during the division
+    .mul(precisionTarget)
+
+  return convertedAmount
+}
+
+export function useConvertRates(symbols) {
+  const [rates, setRates] = useState({})
+  const retryDelay = useRef(CONVERT_API_RETRY_DELAY)
+
+  const symbolsQuery = symbols.join(',')
+
+  useEffect(() => {
+    let cancelled = false
+    let retryTimer = null
+
+    const update = async () => {
+      if (!symbolsQuery) {
+        setRates({})
+        return
+      }
+
+      try {
+        const response = await fetch(convertRatesUrl(symbolsQuery))
+        const rates = await response.json()
+        if (!cancelled) {
+          setRates(rates)
+          retryDelay.current = CONVERT_API_RETRY_DELAY
+        }
+      } catch (err) {
+        // The !cancelled check is needed in case:
+        //  1. The fetch() request is ongoing.
+        //  2. The component gets unmounted.
+        //  3. An error gets thrown.
+        //
+        //  Assuming the fetch() request keeps throwing, it would create new
+        //  requests even though the useEffect() got cancelled.
+        if (!cancelled) {
+          // Add more delay after every failed attempt
+          retryDelay.current = Math.min(
+            CONVERT_API_RETRY_DELAY_MAX,
+            retryDelay.current * 1.2
+          )
+          retryTimer = setTimeout(update, retryDelay.current)
+        }
+      }
+    }
+    update()
+
+    return () => {
+      cancelled = true
+      clearTimeout(retryTimer)
+      retryDelay.current = CONVERT_API_RETRY_DELAY
+    }
+  }, [symbolsQuery])
+
+  return rates
+}

--- a/apps/finance/app/src/lib/conversion-utils.js
+++ b/apps/finance/app/src/lib/conversion-utils.js
@@ -1,117 +1,16 @@
-import { useEffect, useRef, useState } from 'react'
 import BN from 'bn.js'
 
-const CONVERT_API_RETRY_DELAY = 2 * 1000
-const CONVERT_API_RETRY_DELAY_MAX = 60 * 1000
-
-const USD_DECIMALS = new BN('2')
-
-function convertRatesUrl(symbolsQuery) {
-  return `https://min-api.cryptocompare.com/data/price?fsym=USD&tsyms=${symbolsQuery}`
-}
-
-function formatConvertRate(convertRate, decimals) {
-  const [whole = '', dec = ''] = convertRate.split('.')
-  const parsedWhole = whole.replace(/^0*/, '')
+export function getConvertedAmount(amount, convertRate) {
+  const [whole = '', dec = ''] = convertRate.toString().split('.')
+  // Remove any trailing zeros from the decimal part
   const parsedDec = dec.replace(/0*$/, '')
-  // parsedWhole could be empty,
-  // so in this case, we wanna remove leading zeros.
-  const fullyParsedDec = parsedWhole ? parsedDec : parsedDec.replace(/^0*/, '')
+  // Construct the final rate, and remove any leading zeros
+  const rate = `${whole}${parsedDec}`.replace(/^0*/, '')
 
-  // Even if we remove leading zeroes from the decimal
-  // part, we want to count as if we "shifted" them
-  const decimalsToShift = decimals.sub(new BN(parsedDec.length.toString()))
-  // Apart from always considering the USD decimals (2),
-  // if there's the strange case that the above is negative,
-  // we take it as a carry as we know we already shifted to far,
-  // and will compensate by shifting the token amount by this much
-  const carryAmount =
-    decimalsToShift.toNumber() < 0
-      ? decimalsToShift.add(USD_DECIMALS)
-      : USD_DECIMALS
-  // The remaining total amount to shift through bn.js to avoid overflow.
-  const amountToShift = new BN('10').pow(
-    decimalsToShift.toNumber() > 0 ? decimalsToShift : new BN('0')
-  )
+  // Number of decimals to shift the amount of the token passed in,
+  // resulting from converting the rate to a number without any decimal
+  // places
+  const carryAmount = new BN(parsedDec.length.toString())
 
-  // Finish shifting the whole number through BN.js to avoid overflow,
-  return [
-    new BN(`${parsedWhole}${fullyParsedDec}`).mul(amountToShift),
-    carryAmount,
-  ]
-}
-
-export function getConvertedAmount(amount, convertRate, decimals) {
-  const [formattedConvertRate, carryAmount] = formatConvertRate(
-    convertRate.toString(),
-    decimals
-  )
-
-  // Get the actual precision we need to re-add when calculations are over
-  const precisionTarget = new BN('10').pow(decimals.sub(USD_DECIMALS))
-  const convertedAmount = amount
-    // Shift the amount to take into account the USD decimals
-    // + any leftover
-    .mul(new BN('10').pow(carryAmount))
-    // Actually convert to an USD rate
-    .div(formattedConvertRate)
-    // Return it to its original precision
-    // Note that we don't have to subtract the "extra carry"
-    // as it's undone during the division
-    .mul(precisionTarget)
-
-  return convertedAmount
-}
-
-export function useConvertRates(symbols) {
-  const [rates, setRates] = useState({})
-  const retryDelay = useRef(CONVERT_API_RETRY_DELAY)
-
-  const symbolsQuery = symbols.join(',')
-
-  useEffect(() => {
-    let cancelled = false
-    let retryTimer = null
-
-    const update = async () => {
-      if (!symbolsQuery) {
-        setRates({})
-        return
-      }
-
-      try {
-        const response = await fetch(convertRatesUrl(symbolsQuery))
-        const rates = await response.json()
-        if (!cancelled) {
-          setRates(rates)
-          retryDelay.current = CONVERT_API_RETRY_DELAY
-        }
-      } catch (err) {
-        // The !cancelled check is needed in case:
-        //  1. The fetch() request is ongoing.
-        //  2. The component gets unmounted.
-        //  3. An error gets thrown.
-        //
-        //  Assuming the fetch() request keeps throwing, it would create new
-        //  requests even though the useEffect() got cancelled.
-        if (!cancelled) {
-          // Add more delay after every failed attempt
-          retryDelay.current = Math.min(
-            CONVERT_API_RETRY_DELAY_MAX,
-            retryDelay.current * 1.2
-          )
-          retryTimer = setTimeout(update, retryDelay.current)
-        }
-      }
-    }
-    update()
-
-    return () => {
-      cancelled = true
-      clearTimeout(retryTimer)
-      retryDelay.current = CONVERT_API_RETRY_DELAY
-    }
-  }, [symbolsQuery])
-
-  return rates
+  return amount.mul(new BN('10').pow(carryAmount)).div(new BN(rate))
 }

--- a/apps/finance/app/src/lib/conversion-utils.test.js
+++ b/apps/finance/app/src/lib/conversion-utils.test.js
@@ -1,0 +1,29 @@
+import BN from 'bn.js'
+import { getConvertedAmount } from './conversion-utils'
+
+const ONE_ETH = new BN('10').pow(new BN('18'))
+
+describe('getConvertedAmount tests', () => {
+  test('Converts amounts correctly', () => {
+    expect(getConvertedAmount(new BN('1'), 1).toString()).toEqual('1')
+    expect(getConvertedAmount(new BN(ONE_ETH), 1).toString()).toEqual(
+      ONE_ETH.toString()
+    )
+    expect(getConvertedAmount(new BN('1'), 0.5).toString()).toEqual('2')
+    expect(getConvertedAmount(new BN('1'), 0.25).toString()).toEqual('4')
+    expect(getConvertedAmount(new BN('1'), 0.125).toString()).toEqual('8')
+
+    expect(getConvertedAmount(new BN('100'), 50).toString()).toEqual('2')
+    // This is the exact case that broke the previous implementation,
+    // which is AAVE's amount of WBTC + the exchange rate at a certain
+    // hour on 2020-06-24
+    expect(
+      getConvertedAmount(new BN('1145054'), 0.00009248).toString()
+    ).toEqual('12381639273')
+  })
+
+  test('Throws on invalid inputs', () => {
+    expect(() => getConvertedAmount(new BN('1'), 0)).toThrow()
+    expect(() => getConvertedAmount('1000', 0)).toThrow()
+  })
+})


### PR DESCRIPTION
Fixes a problem that arose with the move to using [bn.js everywhere](https://github.com/aragon/aragon-apps/commit/b90ebc47c722dcfa16b74b2fc7a9ec12193adb8f#diff-e842cf2b89a742592b21eeebff9f7086R79), where the conversion from Token Amount to USD was being done incorrectly, as bn.js itself can't handle decimals, and they were being passed onto the function. This adds a few things:

- A function to "shift" numbers a certain amount of decimals safely and counting the amount of places it was shifted (`toDecimal` and `fromDecimal` exist, but required a bit of hacking to make them work for this, so I implemented another version)
- A function to transform the passed token taking into account its decimals and the exchange rate correctly, using just bn.js and not relying on pure Javascript numbers.
- Moves all conversion related things to `conversion-utils.js` to remove bloat from the `Balances.js` file.

Few screenshots from the AAVE Org (where the problem arose due to WBTC breaking the previous implementation):
![Screen Shot 2020-06-23 at 9 59 32 PM](https://user-images.githubusercontent.com/26014927/85488857-082ed000-b59d-11ea-820c-a15646fe5b36.png)
![Screen Shot 2020-06-23 at 9 59 43 PM](https://user-images.githubusercontent.com/26014927/85488862-0b29c080-b59d-11ea-872b-d76055128580.png)
