### PR TITLE
Agent: support ERC-1155

### DIFF
--- a/apps/agent/contracts/Agent.sol
+++ b/apps/agent/contracts/Agent.sol
@@ -38,7 +38,7 @@ contract Agent is IERC165, IERC721Receiver, IERC1155Receiver, ERC1271Bytes, IFor
 
     bytes4 private constant ERC165_INTERFACE_ID = 0x01ffc9a7;
     bytes4 private constant ERC721_RECEIVED_INTERFACE_ID = 0x150b7a02; // bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))
-    bytes4 private constant ERC1155_RECEIVER_INTERFACE_ID= 0x4e2312e0; // IERC721Receiver.onERC1155Received.selector ^ IERC721Receiver.onERC1155BatchReceived.selector
+    bytes4 private constant ERC1155_RECEIVER_INTERFACE_ID = 0x4e2312e0; // IERC721Receiver.onERC1155Received.selector ^ IERC721Receiver.onERC1155BatchReceived.selector
     bytes4 private constant ERC1155_SINGLE_RECEIVED_INTERFACE_ID = 0xf23a6e61; // bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))
     bytes4 private constant ERC1155_BATCH_RECEIVED_INTERFACE_ID = 0xbc197c81; // bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))
 

--- a/apps/agent/contracts/Agent.sol
+++ b/apps/agent/contracts/Agent.sol
@@ -313,7 +313,7 @@ contract Agent is IERC165, IERC721Receiver, ERC1271Bytes, IForwarder, IsContract
     }
 
     function _protectedTokenIndex(address _token) internal view returns (uint256) {
-        for (uint i = 0; i < protectedTokens.length; i++) {
+        for (uint256 i = 0; i < protectedTokens.length; i++) {
             if (protectedTokens[i] == _token) {
               return i;
             }

--- a/apps/agent/contracts/Agent.sol
+++ b/apps/agent/contracts/Agent.sol
@@ -256,12 +256,13 @@ contract Agent is IERC165, IERC721Receiver, IERC1155Receiver, ERC1271Bytes, IFor
      * @param _interfaceId Interface bytes to check
      * @return True if this contract supports the interface
      */
-    function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
-        return
+    function supportsInterface(bytes4 _interfaceId) external view returns (bool) {
+        return hasInitialized() && (
             _interfaceId == ERC1271_INTERFACE_ID ||
             _interfaceId == ERC721_RECEIVED_INTERFACE_ID ||
             _interfaceId == ERC1155_RECEIVER_INTERFACE_ID ||
-            _interfaceId == ERC165_INTERFACE_ID;
+            _interfaceId == ERC165_INTERFACE_ID
+        );
     }
 
     /**

--- a/apps/agent/contracts/standards/IERC1155Receiver.sol
+++ b/apps/agent/contracts/standards/IERC1155Receiver.sol
@@ -1,0 +1,35 @@
+pragma solidity 0.4.24;
+
+
+// See https://eips.ethereum.org/EIPS/eip-1155
+interface IERC1155Receiver {
+    /**
+    * @notice Handle the receipt of a single ERC1155 token type.
+    * @dev An ERC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeTransferFrom` after the balance has been updated.
+    *      This function MUST return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` (i.e. 0xf23a6e61) if it accepts the transfer.
+    *      This function MUST revert if it rejects the transfer.
+    *      Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
+    * @param _operator The address which initiated the transfer (i.e. msg.sender)
+    * @param _from The address which previously owned the token
+    * @param _id The ID of the token being transferred
+    * @param _value The amount of tokens being transferred
+    * @param _data Additional data with no specified format
+    * @return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+    */
+    function onERC1155Received(address _operator, address _from, uint256 _id, uint256 _value, bytes _data) external returns (bytes4);
+
+    /**
+    * @notice Handle the receipt of multiple ERC1155 token types.
+    * @dev An ERC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeBatchTransferFrom` after the balances have been updated.
+    *      This function MUST return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` (i.e. 0xbc197c81) if it accepts the transfer(s).
+    *      This function MUST revert if it rejects the transfer(s).
+    *      Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
+    * @param _operator The address which initiated the batch transfer (i.e. msg.sender)
+    * @param _from The address which previously owned the token
+    * @param _ids An array containing ids of each token being transferred (order and length must match _values array)
+    * @param _values An array containing amounts of each token being transferred (order and length must match _ids array)
+    * @param _data Additional data with no specified format
+    * @return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+    */
+    function onERC1155BatchReceived(address _operator, address _from, uint256[] _ids, uint256[] _values, bytes _data) external returns (bytes4);
+}

--- a/apps/agent/contracts/standards/IERC1155Receiver.sol
+++ b/apps/agent/contracts/standards/IERC1155Receiver.sol
@@ -1,7 +1,11 @@
 pragma solidity 0.4.24;
 
 
-// See https://eips.ethereum.org/EIPS/eip-1155
+/**
+* @title ERC-1155 Multi Token Receiver
+* @dev See https://eips.ethereum.org/EIPS/eip-1155
+*      Note: The ERC-165 identifier for this interface is `0x4e2312e0`
+*/
 interface IERC1155Receiver {
     /**
     * @notice Handle the receipt of a single ERC1155 token type.

--- a/apps/agent/contracts/standards/IERC165.sol
+++ b/apps/agent/contracts/standards/IERC165.sol
@@ -1,6 +1,14 @@
 pragma solidity 0.4.24;
 
 
+// See https://eips.ethereum.org/EIPS/eip-165
 interface IERC165 {
-    function supportsInterface(bytes4 interfaceId) external pure returns (bool);
+    /**
+    * @notice Query if a contract implements an interface
+    * @param interfaceID The interface identifier, as specified in ERC-165
+    * @dev Interface identification is specified in ERC-165. This function
+    *      uses less than 30,000 gas.
+    * @return `true` if the contract implements `interfaceID` and `interfaceID` is not 0xffffffff, `false` otherwise
+    */
+    function supportsInterface(bytes4 interfaceID) external pure returns (bool);
 }

--- a/apps/agent/contracts/standards/IERC165.sol
+++ b/apps/agent/contracts/standards/IERC165.sol
@@ -10,5 +10,5 @@ interface IERC165 {
     *      uses less than 30,000 gas.
     * @return `true` if the contract implements `interfaceID` and `interfaceID` is not 0xffffffff, `false` otherwise
     */
-    function supportsInterface(bytes4 interfaceID) external pure returns (bool);
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }

--- a/apps/agent/contracts/standards/IERC165.sol
+++ b/apps/agent/contracts/standards/IERC165.sol
@@ -1,7 +1,10 @@
 pragma solidity 0.4.24;
 
 
-// See https://eips.ethereum.org/EIPS/eip-165
+/**
+* @title ERC-165 Standard Interface Detection
+* @dev See https://eips.ethereum.org/EIPS/eip-165
+*/
 interface IERC165 {
     /**
     * @notice Query if a contract implements an interface

--- a/apps/agent/contracts/standards/IERC721Receiver.sol
+++ b/apps/agent/contracts/standards/IERC721Receiver.sol
@@ -1,20 +1,20 @@
 pragma solidity 0.4.24;
 
 
+// See https://eips.ethereum.org/EIPS/eip-721
 interface IERC721Receiver {
     /**
-     * @notice Handle the receipt of an NFT
-     * @dev The ERC721 smart contract calls this function on the recipient
-     * after a {IERC721-safeTransferFrom}. This function MUST return the function selector,
-     * otherwise the caller will revert the transaction. The selector to be
-     * returned can be obtained as `this.onERC721Received.selector`. This
-     * function MAY throw to revert and reject the transfer.
-     * Note: the ERC721 contract address is always the message sender.
-     * @param operator The address which called `safeTransferFrom` function
-     * @param from The address which previously owned the token
-     * @param tokenId The NFT identifier which is being transferred
-     * @param data Additional data with no specified format
-     * @return bytes4 `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
-     */
-    function onERC721Received(address operator, address from, uint256 tokenId, bytes data) external returns (bytes4);
+    * @notice Handle the receipt of an NFT
+    * @dev The ERC721 smart contract calls this function on the recipient
+    *      after a `transfer`. This function MAY throw to revert and reject the
+    *      transfer. Return of other than the magic value MUST result in the
+    *      transaction being reverted.
+    *      Note: the contract address is always the message sender.
+    * @param _operator The address which called `safeTransferFrom` function
+    * @param _from The address which previously owned the token
+    * @param _tokenId The NFT identifier which is being transferred
+    * @param _data Additional data with no specified format
+    * @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))` unless throwing
+    */
+    function onERC721Received(address _operator, address _from, uint256 _tokenId, bytes _data) external returns(bytes4);
 }

--- a/apps/agent/contracts/standards/IERC721Receiver.sol
+++ b/apps/agent/contracts/standards/IERC721Receiver.sol
@@ -1,7 +1,11 @@
 pragma solidity 0.4.24;
 
 
-// See https://eips.ethereum.org/EIPS/eip-721
+/**
+* @title ERC-721 Non-Fungible Token Standard
+* @dev See https://eips.ethereum.org/EIPS/eip-721
+*      Note: The ERC-165 identifier for this interface is `0x80ac58cd`
+*/
 interface IERC721Receiver {
     /**
     * @notice Handle the receipt of an NFT

--- a/apps/agent/test/agent_shared.js
+++ b/apps/agent/test/agent_shared.js
@@ -215,6 +215,7 @@ module.exports = (
         it("doesn't support any other interface", async () => {
           assert.isFalse(await agent.supportsInterface('0x12345678'))
           assert.isFalse(await agent.supportsInterface('0x'))
+          assert.isFalse(await agent.supportsInterface('0xffffffff'))
         })
       })
 

--- a/apps/agent/test/agent_shared.js
+++ b/apps/agent/test/agent_shared.js
@@ -125,6 +125,10 @@ module.exports = (
         assert.isTrue(await agent.hasInitialized())
       })
 
+      it('does not support ERC165', async () => {
+        assert.isFalse(await agent.supportsInterface(ERC165_SUPPORT_INTERFACE_ID))
+      })
+
       it('does not support ERC721 receipt callback', async () => {
         const callbackReturn = await agent.onERC721Received.call(accounts[1], accounts[2], 0, NO_DATA)
         assert.notEqual(callbackReturn, ERC721_RECEIVED_INTERFACE_ID, 'expected to fail ERC721 receipt')


### PR DESCRIPTION
Adds support for [ERC-1155 tokens](https://eips.ethereum.org/EIPS/eip-1155) to the Agent.

Also found a couple other things I've updated with this change:

- When uninitialized, report false for ERC-165, ERC-721, and ERC-1155
- Update docstrings / code style for ERC interfaces to closely match their finalized states on eip.org