### PR TITLE
Agreement: Improve can close check for disputables

### DIFF
--- a/apps/agreement/contracts/test/mocks/disputable/DisputableAppMock.sol
+++ b/apps/agreement/contracts/test/mocks/disputable/DisputableAppMock.sol
@@ -39,7 +39,7 @@ contract DisputableAppMock is DisputableAragonApp, TimeHelpersMock {
     uint256 private entriesLength;
     mapping (uint256 => Entry) private entries;
     bool private callbacksRevert;
-    
+
     /**
     * @dev Initialize app
     */
@@ -62,6 +62,13 @@ contract DisputableAppMock is DisputableAragonApp, TimeHelpersMock {
     */
     function mockSetCallbacksRevert(bool _callbacksRevert) external {
         callbacksRevert = _callbacksRevert;
+    }
+
+    /**
+    * @dev Helper function to close actions
+    */
+    function closeAction(uint256 _id) external {
+        _closeAgreementAction(entries[_id].actionId);
     }
 
     /**

--- a/apps/agreement/test/helpers/wrappers/disputable.js
+++ b/apps/agreement/test/helpers/wrappers/disputable.js
@@ -102,6 +102,10 @@ class DisputableWrapper extends AgreementWrapper {
     return this.forward({ script: actionContext, from: submitter })
   }
 
+  async close(id, fromDisputable = false) {
+    return fromDisputable ? this.disputable.closeAction(id) : super.close(id)
+  }
+
   async challenge(options = {}) {
     if (options.stake === undefined) options.stake = this.challengeCollateral
     if (options.stake) await this.approve({ amount: options.stake, from: options.challenger })


### PR DESCRIPTION
Related to https://github.com/aragon/aragonOS/pull/594

This PRs improve the `close` function of the Agreement app to avoid calling `canClose` if the sender is the disputable app