### PR TITLE
Tokens: Fix token SyncIndicator position

### DIFF
--- a/apps/token-manager/app/src/App.js
+++ b/apps/token-manager/app/src/App.js
@@ -113,7 +113,7 @@ class App extends React.PureComponent {
         onResolve={this.handleResolveLocalIdentity}
         onShowLocalIdentityModal={this.handleShowLocalIdentityModal}
       >
-        <SyncIndicator visible={isSyncing} />
+        <SyncIndicator visible={isSyncing} shift={50} />
 
         {!isSyncing && appStateReady && holders.length === 0 && (
           <EmptyState onAssignHolder={this.handleLaunchAssignTokensNoHolder} />

--- a/apps/voting/app/src/App.js
+++ b/apps/voting/app/src/App.js
@@ -72,7 +72,7 @@ const App = React.memo(function App() {
         )}
         {votes.length > 0 && (
           <React.Fragment>
-            <SyncIndicator visible={isSyncing} />
+            <SyncIndicator visible={isSyncing} shift={50} />
             <Header
               primary="Voting"
               secondary={


### PR DESCRIPTION
Seems we hadn't updated the Token Manager app for allocating the correct spacing in between the sync indicator and the helpscout icon.

Before:
![Screen Shot 2020-07-16 at 5 29 47 PM](https://user-images.githubusercontent.com/26014927/87724764-01554080-c78a-11ea-8734-8fce71593d92.png)


After:
![Screen Shot 2020-07-16 at 5 29 40 PM](https://user-images.githubusercontent.com/26014927/87724773-04e8c780-c78a-11ea-9cb3-c77d134f7f33.png)

