### PR TITLE
DisputableVoting: Rollback ACL v2 related changes

### DIFF
--- a/apps/voting-disputable/contracts/DisputableVoting.sol
+++ b/apps/voting-disputable/contracts/DisputableVoting.sol
@@ -699,12 +699,12 @@ contract DisputableVoting is IForwarderWithContext, DisputableAragonApp {
     * @return True if the given address can create votes
     */
     function _canForward(address _sender, bytes) internal view returns (bool) {
-        // TODO: Handle the case where a Disputable app doesn't have an Agreement set
+        IAgreement agreement = _getAgreement();
         // To make sure the sender address is reachable by ACL oracles, we need to pass it as an argument.
         // ACL oracles are set for ANY_ENTITY, therefore there is no default way to know the original sender
         // for an ACL oracle in case the CREATE_VOTES_ROLE permission was configured with one
         // Note that `canPerform()` implicitly does an initialization check itself
-        return canPerform(_sender, CREATE_VOTES_ROLE, arr(_sender));
+        return agreement != IAgreement(0) && canPerform(_sender, CREATE_VOTES_ROLE, arr(_sender));
     }
 
     /**

--- a/apps/voting-disputable/contracts/DisputableVoting.sol
+++ b/apps/voting-disputable/contracts/DisputableVoting.sol
@@ -700,8 +700,11 @@ contract DisputableVoting is IForwarderWithContext, DisputableAragonApp {
     */
     function _canForward(address _sender, bytes) internal view returns (bool) {
         // TODO: Handle the case where a Disputable app doesn't have an Agreement set
+        // To make sure the sender address is reachable by ACL oracles, we need to pass it as an argument.
+        // ACL oracles are set for ANY_ENTITY, therefore there is no default way to know the original sender
+        // for an ACL oracle in case the CREATE_VOTES_ROLE permission was configured with one
         // Note that `canPerform()` implicitly does an initialization check itself
-        return canPerform(_sender, CREATE_VOTES_ROLE, arr());
+        return canPerform(_sender, CREATE_VOTES_ROLE, arr(_sender));
     }
 
     /**

--- a/apps/voting-disputable/package.json
+++ b/apps/voting-disputable/package.json
@@ -25,7 +25,7 @@
     "apm:publish:patch": "aragon apm publish patch --files app/build/ --prepublish-script apm:prepublish"
   },
   "dependencies": {
-    "@aragon/os": "5.0.0-beta.6",
+    "@aragon/os": "5.0.0-beta.7",
     "@aragon/apps-agreement": "^0.1.0-beta.0"
   },
   "devDependencies": {

--- a/apps/voting-disputable/test/contracts/voting_create.js
+++ b/apps/voting-disputable/test/contracts/voting_create.js
@@ -1,11 +1,11 @@
 const deployer = require('../helpers/deployer')(web3, artifacts)
 const { ARAGON_OS_ERRORS, VOTING_ERRORS } = require('../helpers/errors')
-const { VOTER_STATE, createVote, voteScript, getVoteState } = require('../helpers/voting')
+const { createVote, voteScript, getVoteState } = require('../helpers/voting')
 
 const { ONE_DAY, bigExp, pct16, getEventArgument } = require('@aragon/contract-helpers-test')
 const { assertBn, assertRevert, assertEvent, assertAmountOfEvents } = require('@aragon/contract-helpers-test/src/asserts')
 
-contract('Voting', ([_, owner, holder1, holder2, holder20, holder29, holder51, nonHolder]) => {
+contract('Voting', ([_, owner, holder1, holder2, holder20, holder29, holder51, agreement]) => {
   let voting, token
 
   const CONTEXT = '0xabcdef'
@@ -64,6 +64,8 @@ contract('Voting', ([_, owner, holder1, holder2, holder20, holder29, holder51, n
           })
 
           it('can be forwarded', async () => {
+            await voting.setAgreement(agreement, { from: owner })
+
             const receipt = await voting.forward(script, CONTEXT, { from: holder51 })
 
             assertAmountOfEvents(receipt, 'StartVote')

--- a/apps/voting-disputable/test/contracts/voting_disputable.js
+++ b/apps/voting-disputable/test/contracts/voting_disputable.js
@@ -39,6 +39,9 @@ contract('Voting disputable', ([_, owner, representative, voter10, voter20, vote
   beforeEach('create voting app', async () => {
     voting = await votingDeployer.deployAndInitialize({ owner, agreement: true, requiredSupport: MIN_SUPPORT, minimumAcceptanceQuorum: MIN_QUORUM, voteDuration: VOTING_DURATION, quietEndingPeriod: QUIET_ENDING_PERIOD, quietEndingExtension: QUIET_ENDING_EXTENSION, overruleWindow: OVERRULE_WINDOW })
     await voting.mockSetTimestamp(await agreement.currentTimestamp())
+
+    const SET_AGREEMENT_ROLE = await voting.SET_AGREEMENT_ROLE()
+    await votingDeployer.acl.grantPermission(agreement.address, voting.address, SET_AGREEMENT_ROLE, { from: owner })
     await agreement.activate({ disputable: voting, collateralToken, actionCollateral: 0, challengeCollateral: 0, challengeDuration: ONE_DAY, from: owner })
   })
 

--- a/apps/voting-disputable/test/contracts/voting_disputable.js
+++ b/apps/voting-disputable/test/contracts/voting_disputable.js
@@ -39,9 +39,6 @@ contract('Voting disputable', ([_, owner, representative, voter10, voter20, vote
   beforeEach('create voting app', async () => {
     voting = await votingDeployer.deployAndInitialize({ owner, agreement: true, requiredSupport: MIN_SUPPORT, minimumAcceptanceQuorum: MIN_QUORUM, voteDuration: VOTING_DURATION, quietEndingPeriod: QUIET_ENDING_PERIOD, quietEndingExtension: QUIET_ENDING_EXTENSION, overruleWindow: OVERRULE_WINDOW })
     await voting.mockSetTimestamp(await agreement.currentTimestamp())
-
-    const SET_AGREEMENT_ROLE = await voting.SET_AGREEMENT_ROLE()
-    await votingDeployer.acl.createPermission(agreement.address, voting.address, SET_AGREEMENT_ROLE, owner, { from: owner })
     await agreement.activate({ disputable: voting, collateralToken, actionCollateral: 0, challengeCollateral: 0, challengeDuration: ONE_DAY, from: owner })
   })
 

--- a/apps/voting-disputable/test/contracts/voting_gas_costs.js
+++ b/apps/voting-disputable/test/contracts/voting_gas_costs.js
@@ -25,9 +25,6 @@ contract('Voting', ([_, owner, voter]) => {
   beforeEach('create voting app', async () => {
     voting = await votingDeployer.deployAndInitialize({ owner, agreement: true })
     await voting.mockSetTimestamp(await agreement.currentTimestamp())
-
-    const SET_AGREEMENT_ROLE = await voting.SET_AGREEMENT_ROLE()
-    await votingDeployer.acl.createPermission(agreement.address, voting.address, SET_AGREEMENT_ROLE, owner, { from: owner })
     await agreement.activate({ disputable: voting, collateralToken, actionCollateral: 0, challengeCollateral: 0, challengeDuration: ONE_DAY, from: owner })
   })
 

--- a/apps/voting-disputable/test/contracts/voting_gas_costs.js
+++ b/apps/voting-disputable/test/contracts/voting_gas_costs.js
@@ -25,6 +25,9 @@ contract('Voting', ([_, owner, voter]) => {
   beforeEach('create voting app', async () => {
     voting = await votingDeployer.deployAndInitialize({ owner, agreement: true })
     await voting.mockSetTimestamp(await agreement.currentTimestamp())
+
+    const SET_AGREEMENT_ROLE = await voting.SET_AGREEMENT_ROLE()
+    await votingDeployer.acl.grantPermission(agreement.address, voting.address, SET_AGREEMENT_ROLE, { from: owner })
     await agreement.activate({ disputable: voting, collateralToken, actionCollateral: 0, challengeCollateral: 0, challengeDuration: ONE_DAY, from: owner })
   })
 

--- a/apps/voting-disputable/test/helpers/deployer.js
+++ b/apps/voting-disputable/test/helpers/deployer.js
@@ -75,7 +75,7 @@ class VotingDeployer {
     const receipt = await this.dao.newAppInstance(appId, this.base.address, '0x', false, { from: owner })
     const voting = await this.base.constructor.at(await getInstalledApp(receipt, appId))
 
-    const restrictedPermissions = ['MODIFY_SUPPORT_ROLE', 'MODIFY_QUORUM_ROLE', 'MODIFY_OVERRULE_WINDOW_ROLE', 'MODIFY_EXECUTION_DELAY_ROLE', 'MODIFY_QUIET_ENDING_CONFIGURATION']
+    const restrictedPermissions = ['SET_AGREEMENT_ROLE', 'MODIFY_SUPPORT_ROLE', 'MODIFY_QUORUM_ROLE', 'MODIFY_OVERRULE_WINDOW_ROLE', 'MODIFY_EXECUTION_DELAY_ROLE', 'MODIFY_QUIET_ENDING_CONFIGURATION']
     await this._createPermissions(voting, restrictedPermissions, owner)
 
     const openPermissions = ['CREATE_VOTES_ROLE', 'CHALLENGE_ROLE']


### PR DESCRIPTION
This PR changes the way `canForward` was computed basically:
- Pass the original sender by parameter
- Check the agreement was set

This PR also updates the `disputable_voting_app` branch with the last changes from `master`, it is recommended to review only the last two commits.