### PR TITLE
DisputableVoting: avoid publishing Client-based frontend to aragonPM

### DIFF
--- a/apps/voting-disputable/README.md
+++ b/apps/voting-disputable/README.md
@@ -1,1 +1,11 @@
 # Disputable Voting
+
+#### 🛠️ Project stage: development
+
+The DisputableVoting app is still in development phase and aspects of the mechanism are still being designed and implemented.
+
+A frontend for the Aragon client has been started in [`app/`](app/) but is not yet production-ready.
+
+#### ⚠️ Security review status: pre-audit
+
+The code in this sub-repo is under heavy development and hasn't undergone a professional security review yet, therefore we cannot recommend using any of the code at the moment.

--- a/apps/voting-disputable/manifest.json
+++ b/apps/voting-disputable/manifest.json
@@ -5,7 +5,7 @@
   "changelog_url": "https://github.com/aragon/aragon-apps/releases",
   "details_url": "/meta/details.md",
   "source_url": "https://github.com/aragon/aragon-apps/blob/master/apps/voting-disputable",
-  "icons": [{ "src": "/meta/icon.svg", "sizes": "56x56" }],
-  "script": "/script.js",
-  "start_url": "/index.html"
+  "icons": [
+    { "src": "/meta/icon.svg", "sizes": "56x56" }
+  ]
 }

--- a/apps/voting-disputable/package.json
+++ b/apps/voting-disputable/package.json
@@ -19,11 +19,7 @@
     "test": "buidler test",
     "test:gas": "REPORT_GAS=true buidler test --network localhost",
     "coverage": "buidler coverage --network coverage",
-    "abi:extract": "buidler-extract --output abi/ --keys abi",
-    "apm:prepublish": "npm run compile",
-    "apm:publish:major": "aragon apm publish major --files app/build/ --prepublish-script apm:prepublish",
-    "apm:publish:minor": "aragon apm publish minor --files app/build/ --prepublish-script apm:prepublish",
-    "apm:publish:patch": "aragon apm publish patch --files app/build/ --prepublish-script apm:prepublish"
+    "abi:extract": "buidler-extract --output abi/ --keys abi"
   },
   "dependencies": {
     "@aragon/apps-agreement": "^0.1.0-beta.0",


### PR DESCRIPTION
Adds some notes about the frontend's development and removes the old publish scripts for now.