### PR TITLE
Finance: fix transfers layout (text overflow)

### DIFF
--- a/apps/agent/app/src/components/Transactions.js
+++ b/apps/agent/app/src/components/Transactions.js
@@ -191,7 +191,6 @@ const Transactions = React.memo(function Transactions({
             css={`
               ${textStyle('body2')};
               color: ${theme.surfaceContent};
-              padding-right: ${2 * GU}px;
               white-space: nowrap;
             `}
           >
@@ -239,7 +238,7 @@ const Transactions = React.memo(function Transactions({
             css={`
               ${textStyle('body2')};
               color: ${theme.surfaceContent};
-              padding: ${1 * GU}px ${0.5 * GU}px;
+              padding: ${1 * GU}px 0;
               overflow-wrap: break-word;
               word-break: break-word;
               hyphens: auto;

--- a/apps/agent/app/src/components/Transactions.js
+++ b/apps/agent/app/src/components/Transactions.js
@@ -191,6 +191,8 @@ const Transactions = React.memo(function Transactions({
             css={`
               ${textStyle('body2')};
               color: ${theme.surfaceContent};
+              padding-right: ${2 * GU}px;
+              white-space: nowrap;
             `}
           >
             {formattedDate}
@@ -237,6 +239,10 @@ const Transactions = React.memo(function Transactions({
             css={`
               ${textStyle('body2')};
               color: ${theme.surfaceContent};
+              padding: ${1 * GU}px ${0.5 * GU}px;
+              overflow-wrap: break-word;
+              word-break: break-word;
+              hyphens: auto;
             `}
           >
             {reference}

--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -218,7 +218,14 @@ const Transfers = React.memo(({ tokens, transactions }) => {
         )
 
         return [
-          <time dateTime={formattedDate} title={formattedDate}>
+          <time
+            dateTime={formattedDate}
+            title={formattedDate}
+            css={`
+              padding-right: ${2 * GU}px;
+              white-space: nowrap;
+            `}
+          >
             {formatDate(date)}
           </time>,
           <div

--- a/apps/finance/app/src/components/Transfers.js
+++ b/apps/finance/app/src/components/Transfers.js
@@ -239,7 +239,10 @@ const Transfers = React.memo(({ tokens, transactions }) => {
           </div>,
           <div
             css={`
-              padding: 0 ${0.5 * GU}px;
+              padding: ${1 * GU}px ${0.5 * GU}px;
+              overflow-wrap: break-word;
+              word-break: break-word;
+              hyphens: auto;
             `}
           >
             {reference}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36158/92942625-a10d1300-f449-11ea-9466-0bc4cc2cf2c4.png)

@sohkai could you please check in Safari just to be sure? (I can only do Gecko / Blink)

Fixes https://github.com/aragon/aragon/issues/1212.