### PR TITLE
[cicd] adds auto release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Release
 
 on:
   pull_request:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,9 +23,10 @@ jobs:
         id: matrix
         env:
           PULL_LABELS: ${{ github.event.pull_request.labels }}
+        # loop through all labels and prepare matrix to run in the next job
         run: |
           LABELS=()
-          for LABEL in $(cat labels.json | jq '.[].name'); do 
+          for LABEL in $(echo $PULL_LABELS | jq '.[].name'); do 
             APP=$(cut -d":" -f1 <<< $LABEL | sed "s/\"//")
             LEVEL=$(cut -d":" -f2 <<< $LABEL | sed "s/\"//")
             if [ $LEVEL = 'minor' ] || [ $LEVEL = 'major' ] || [ $LEVEL = 'patch' ]; then 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -65,7 +65,7 @@ jobs:
     environment: ${{ matrix.network }}
     steps:
       - uses: actions/checkout@v2
-        ref: 'master'
+        ref: ${{ github.event.pull_request.base.sha }}
       - name: Install node
         uses: actions/setup-node@v1
         with:
@@ -95,20 +95,16 @@ jobs:
           PUBLISH_MESSAGE=$(npx buidler publish ${{ matrix.level }} --dry-run --network ${{ matrix.network }})
           echo "::set-output name=cid::$(echo $PUBLISH_MESSAGE | awk '{ split($0,a,"|"); split(a[8],b," "); print b[6] }')"
           echo "::set-output name=version::$(echo $PUBLISH_MESSAGE | awk '{ split($0,a,"|"); split(a[10],b," "); print b[4] }')"
-      - name: package app
-        id: packaging
+      - name: create tag
+        uses: actions/github-script@v3
         env:
-          CID: ${{ steps.publish.outputs.cid }}
-          PACKAGE_NAME: ${{ matrix.app }}-${{ matrix.network }}-${{ steps.publish.outputs.version }}
-        run: |
-          cd $(mktemp -d)
-          ipfs get $CID
-          tar -czvf $PACKAGE_NAME.tar.gz $CID/
-          echo "::set-output name=tar::$(echo $PWD/$PACKAGE_NAME.tar.gz)"
-      - uses: "marvinpinto/action-automatic-releases@latest"
+          TAG_NAME: "${{ steps.publish.outputs.version }}-${{ matrix.app }}-${{ matrix.network }}"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ steps.publish.outputs.version }}-${{ matrix.app }}-${{ matrix.network }}"
-          prerelease: false
-          title: "${{ steps.publish.outputs.version }}-${{ matrix.app }}-${{ matrix.network }}"
-          files: ${{ steps.packaging.outputs.tar }}
+          github-token: ${{ github.token }}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${process.env.TAG_NAME}`,
+              sha: context.sha
+            })

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 env:
-  POSSIBLE_NETWORKS: "mainnet rinkeby mumbai polygon"
+  POSSIBLE_NETWORKS: "mainnet rinkeby mumbai matic"
 
 jobs:
   checkLabels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,105 @@
+name: Deploy
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  NETWORKS: "mainnet rinkeby mumbai polygon"
+
+jobs:
+  checkLabels:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged && github.event.pull_request.labels.*.name && github.base_ref == 'master'
+    steps:
+      - run: echo Check labels is not empty and pull is merged
+  buildMatrix:
+    needs: [checkLabels]
+    runs-on: ubuntu-latest
+    output:
+      labels: ${{ steps.matrix.outputs.labels }}
+    steps:
+      - name: Build Matrix
+        id: matrix
+        env:
+          PULL_LABELS: ${{ github.event.pull_request.labels }}
+        run: |
+          LABELS=()
+          for LABEL in $(cat labels.json | jq '.[].name'); do 
+            APP=$(cut -d":" -f1 <<< $LABEL | sed "s/\"//")
+            LEVEL=$(cut -d":" -f2 <<< $LABEL | sed "s/\"//")
+            if [ $LEVEL = 'minor' ] || [ $LEVEL = 'major' ] || [ $LEVEL = 'patch' ]; then 
+              for NETWORK in $NETWORKS; do
+                LABELS[${#LABELS[@]}]="{\"app\": \"$APP\", \"level\": \"$LEVEL\", \"network\": \"$NETWORK\"}"
+              done
+            fi
+          done
+          JSON="["
+          for i in "${LABELS[@]}"; do
+            JSON+="$i,"
+          done
+          JSON="${JSON::-1}]"
+          echo "::set-output name=labels::{\"include\":$JSON}"
+
+  release:
+    needs: [buildMatrix]
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    matrix: ${{ fromJson(needs.buildMatrix.outputs.labels }}
+    environment: ${{ matrix.network }}
+    steps:
+      - uses: actions/checkout@v2
+        ref: 'master'
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node_version: 12
+      - name: setup ipfs
+        uses: ibnesayeed/setup-ipfs@master
+        with:
+          run_daemon: true
+      - name: Configure aragon cli 
+        run: |
+          echo ${{ secrets.ARAGON_CLI_JSON }} >> ~/.aragon/${{ matrix.network }}_key.json
+      - name: Install cli dependencies
+        run: apt-get update && apt-get install -y git python make g++ rsync
+      # changes npm user to root to avoid permission issues with install
+      - name: set npm user
+        run: npm config set user root
+      - name: Install aragon cli
+        run: npm install -g @aragon/cli
+      - name: Install npm packages
+        run: yarn
+      - name: build, publish and package
+        id: build
+        run: | 
+          cd apps/${{ matrix.app }}
+          yarn --ignore-engines --dev
+          cd app 
+          yarn 
+          cd .. 
+          yarn build 
+          yarn compile
+      - name: publish
+        id: publish
+        run:  |
+          PUBLISH_MESSAGE=$(npx buidler publish ${{ matrix.level }} --dry-run --network ${{ matrix.network }})
+          echo "::set-output name=cid::$(echo $PUBLISH_MESSAGE | awk '{ split($0,a,"|"); split(a[8],b," "); print b[6] }')"
+          echo "::set-output name=version::$(echo $PUBLISH_MESSAGE | awk '{ split($0,a,"|"); split(a[10],b," "); print b[4] }')"
+      - name: package app
+        id: packaging
+        env:
+          CID: ${{ steps.publish.outputs.cid }}
+          PACKAGE_NAME: ${{ matrix.app }}-${{ matrix.network }}-${{ steps.publish.outputs.version }}
+        run: |
+          cd $(mktemp -d)
+          ipfs get $CID
+          tar -czvf $PACKAGE_NAME.tar.gz $CID/
+          echo "::set-output name=tar::$(echo $PWD/$PACKAGE_NAME.tar.gz)"
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ matrix.app }}-${{ matrix.network }}-${{ steps.publish.outputs.version }}"
+          prerelease: false
+          title: "${{ matrix.app }}-${{ matrix.network }}-${{ steps.publish.outputs.version }}"
+          files: ${{ steps.packaging.outputs.tar }}

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 env:
-  NETWORKS: "mainnet rinkeby mumbai polygon"
+  POSSIBLE_NETWORKS: "mainnet rinkeby mumbai polygon"
 
 jobs:
   checkLabels:
@@ -18,11 +18,26 @@ jobs:
     runs-on: ubuntu-latest
     output:
       labels: ${{ steps.matrix.outputs.labels }}
+      networks: ${{ steps.networks.outputs.networks }}
     steps:
+      - name: Get Networks
+        id: networks
+        env:
+          PULL_LABELS: ${{ github.event.pull_request.labels }}
+        run: |
+          NETWORKS=""
+          for LABEL in $(echo $PULL_LABELS | jq '.[].name'); do
+            CLEANED=$(echo $LABEL | sed "s/\"//g")
+            if [[ $POSSIBLE_NETWORKS =~ (^|[[:space:]])$CLEANED($|[[:space:]]) ]]; then
+              NETWORKS+=" $CLEANED"
+            fi
+          done
+          echo "::set-output name=networks::$(jq -n --arg v "${NETWORKS:1}" '$v | split(" ")')"
       - name: Build Matrix
         id: matrix
         env:
           PULL_LABELS: ${{ github.event.pull_request.labels }}
+          NETWORKS: ${{ steps.networks.outputs.networks }}
         # loop through all labels and prepare matrix to run in the next job
         run: |
           LABELS=()
@@ -62,13 +77,6 @@ jobs:
       - name: Configure aragon cli 
         run: |
           echo ${{ secrets.ARAGON_CLI_JSON }} >> ~/.aragon/${{ matrix.network }}_key.json
-      - name: Install cli dependencies
-        run: apt-get update && apt-get install -y git python make g++ rsync
-      # changes npm user to root to avoid permission issues with install
-      - name: set npm user
-        run: npm config set user root
-      - name: Install aragon cli
-        run: npm install -g @aragon/cli
       - name: Install npm packages
         run: yarn
       - name: build, publish and package
@@ -100,7 +108,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ matrix.app }}-${{ matrix.network }}-${{ steps.publish.outputs.version }}"
+          automatic_release_tag: "${{ steps.publish.outputs.version }}-${{ matrix.app }}-${{ matrix.network }}"
           prerelease: false
-          title: "${{ matrix.app }}-${{ matrix.network }}-${{ steps.publish.outputs.version }}"
+          title: "${{ steps.publish.outputs.version }}-${{ matrix.app }}-${{ matrix.network }}"
           files: ${{ steps.packaging.outputs.tar }}


### PR DESCRIPTION
## Changes
The new workflow automatically creates new Github Releases in this repo for the apps mentioned in the labels of the merged pull request.
The workflow only runs if the pull request is merged to the `master` branch and only adds new releases for the apps mentioned in the labels.
It also automatically bumps the version number of the app by the level also configured in the tags.
It **does not** publish the release to the apm registry. It only runs the dry run method to get the ipfs hash and the apm version number.
New Github Releases will be created per chain (mainnet, rinkeby, mumbai, polygon) and app.

## Example
A pull request with the labels `voting:patch` and `token-manager:major` gets merged to the master branch.
Then the workflow will create 4 new Github Releases for voting with the new version numbers bumped by patch and 4 new Github Releases for the token-manager app with new version numbers bumped by major.

## To Be Done
- Workflow to check that not more then one label per app is added to a pull request
- ~~Automatic release to APM based on tags~~ (https://github.com/aragon/aragon-apps/pull/1322)
- Automatic push of new IPFS content from https://github.com/aragon/deployments

## Misc
The labels `voting:patch`, `mumbai` and `rinkeby` are added to test the workflow