### PR TITLE
[cicd] adds workflow to build, deploy and release on a tag

### DIFF
--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -1,0 +1,98 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - '*.*.*-*-*'
+
+jobs:
+  checkTag:
+    runs-on: ubuntu-latest
+    output:
+      valid: ${{ steps.check.outputs.valid }}
+      app: ${{ steps.check.outputs.app }}
+      network: ${{ steps.check.outputs.network }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: check tag name
+        id: check
+        run:
+          VERSION=$(echo "${{ github.event.release.tag }}" | cut -d '-' -f 1)
+          APP=$(echo "${{ github.event.release.tag }}" | cut -d '-' -f 2)
+          NETWORK=$(echo "${{ github.event.release.tag }}" | cut -d '-' -f 3)
+
+          if [ "$APP" != "" ] && [ "$NETWORK" != "" ] && [ "$VERSION" != "" ]; then
+            echo "::set-output name=valid::true"
+            echo "::set-output name=app::$APP"
+            echo "::set-output name=network::$NETWORK"
+            echo "::set-output name=version::$VERSION"
+          else
+            echo "::set-output name=valid::false"
+          fi
+  deploy:
+      runs-on: ubuntu-latest
+      needs: [checkTag]
+      environment: ${{ needs.checkTag.outputs.environment }} 
+      steps:
+        - uses: actions/checkout@v2
+        - name: Install node
+          uses: actions/setup-node@v1
+          with:
+            node_version: 12
+        - name: setup ipfs
+          uses: ibnesayeed/setup-ipfs@master
+          with:
+            run_daemon: true
+        - name: Configure aragon cli 
+          run: |
+            echo ${{ secrets.ARAGON_CLI_JSON }} >> ~/.aragon/${{ needs.checkTag.outputs.network }}_key.json
+        - name: Install npm packages
+          run: yarn
+        - name: build, publish and package
+          id: build
+          run: | 
+            cd apps/${{ needs.checkTag.outputs.app }}
+            yarn --ignore-engines --dev
+            cd app 
+            yarn 
+            cd .. 
+            yarn build 
+            yarn compile
+        - name: publish
+          id: publish
+          run:  |
+            PUBLISH_MESSAGE=$(npx buidler publish ${{ needs.checkTag.outputs.version }} --network ${{ needs.checkTag.outputs.network }})
+            echo "::set-output name=cid::$(echo $PUBLISH_MESSAGE | awk '{ split($0,a,"|"); split(a[8],b," "); print b[6] }')"
+        - name: package app
+          id: packaging
+          env:
+            CID: ${{ steps.publish.outputs.cid }}
+            PACKAGE_NAME: ${{ needs.checkTag.outputs.app }}.aragonpm.eth@${{{ needs.checkTag.outputs.version }}}
+          run: |
+            cd $(mktemp -d)
+            ipfs get $CID
+            tar -czvf $PACKAGE_NAME.tar.gz $CID/
+            echo "::set-output name=tar::$(echo $PWD/$PACKAGE_NAME.tar.gz)"
+        - uses: "marvinpinto/action-automatic-releases@latest"
+          with:
+            repo_token: "${{ secrets.GITHUB_TOKEN }}"
+            automatic_release_tag: "${{ github.event.release.tag }}"
+            prerelease: false
+            title: "${{ github.event.release.tag }}"
+            files: |
+              ${{ steps.packaging.outputs.tar }}
+        - name: Checkout Deployments
+          uses: actions/checkout@v2
+          with:
+            repository: 'aragon/deployments'
+            ref: 'master'
+            token: ${{ secrets.ARABOT_PAT }}
+            path: deployments
+        - name: Commit and push
+          run: |
+            cp  ${{ steps.packaging.outputs.tar }} deployments/environments/${{ needs.checkTag.outputs.network }}/${{ needs.checkTag.outputs.app }}.aragonpm.eth/
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add .
+            git commit -m "Updates ${{ needs.checkTag.outputs.app }} on ${{ needs.checkTag.outputs.network }} to ${{ needs.checkTag.outputs.version }}"
+            git push


### PR DESCRIPTION
# Changes
Adds new workflow to publish an app based on the tag name.
It automatically creates a new Release on Github, pushes the new version to APM and adds the bundle to aragon/deployments

## Tag format
The tag format is fixed and works hand in hand with the release workflow.
Format: `VERSION-APP-NETWORK` e.g.: `2.5.15-voting-matic`