### PR TITLE
fixes broken page when trying to divide by zero for vested tokens

### DIFF
--- a/apps/token-manager/app/src/app-logic.js
+++ b/apps/token-manager/app/src/app-logic.js
@@ -74,7 +74,8 @@ export function useTotalVestedTokensInfo(vestings) {
 
   const vestingsTokensInfo = vestings.map(vesting =>
     getVestedTokensInfo(now, vesting.data)
-  )
+  ).filter((exists) => Boolean(exists) === true) // display only unrevoked vestings
+
   const totalLocked = vestingsTokensInfo.reduce((total, vestingTokenInfo) => {
     return total.add(vestingTokenInfo.lockedTokens)
   }, new BN(0))

--- a/apps/token-manager/app/src/vesting-utils.js
+++ b/apps/token-manager/app/src/vesting-utils.js
@@ -25,6 +25,12 @@ function getVestingUnlockedTokens(time, { amount, start, cliff, end }) {
 
 export function getVestedTokensInfo(now, vestingData) {
   const { amount, start, cliff, vesting: end } = vestingData
+
+  if (!amount && !start && !cliff && !end) {
+    // this vesting has been revoked
+    return false;
+  }
+  
   const amountBn = new BN(amount)
 
   // Shortcuts for before cliff and after vested cases.


### PR DESCRIPTION
When token amount is zero for vesting, the page would break because of a divide by zero error. This fix will avoid the divide by zero error so that the page displays correctly if tokens have been revoked.